### PR TITLE
chore: add github action to enforce commit style

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,14 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: webiny/action-conventional-commits@v1.0.3


### PR DESCRIPTION
Add a github action to run on every Pull Request to ensure the commit messages follow the [Conventional Commits Spec](https://www.conventionalcommits.org/en/v1.0.0/)