### PR TITLE
feat: Support alternative BCHD installation (as an option)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+GRPC_NODE_URL=bchd.greyh.at:8335

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 https://paybutton.org
 
+````
+You can change gRPC node by modifying GRPC_NODE_URL variable in the .env file.
+````
+
 ## Want to join the team?
 
 Send us an email and we'll get in touch: contact@paybutton.org

--- a/server/utils/bchd.ts
+++ b/server/utils/bchd.ts
@@ -6,7 +6,7 @@ import {
   GetAddressTransactionsResponse,
   GetAddressUnspentOutputsResponse,
 } from 'grpc-bchrpc-node';
-const grpc = new GrpcClient({ url: "bchd.greyh.at:8335" });
+const grpc = new GrpcClient({ url: process.env.GRPC_NODE_URL });
 
 export interface OutputsList {
   outpoint: object;


### PR DESCRIPTION
Add a simple way to be able to change bchd grpc node url: just set the GRPC_NODE_URL variable in a .env file.