### PR TITLE
feat: add Apple and Facebook authentication

### DIFF
--- a/config/backendConfig.ts
+++ b/config/backendConfig.ts
@@ -20,6 +20,18 @@ export let backendConfig = () : TypeInput => {
             clientId: process.env.GOOGLE_CLIENT_ID,
             clientSecret: process.env.GOOGLE_CLIENT_SECRET,
           }),
+          ThirdPartyEmailPasswordNode.Facebook({
+            clientId: process.env.FACEBOOK_CLIENT_ID,
+            clientSecret: process.env.FACEBOOK_CLIENT_SECRET
+          }),
+          ThirdPartyEmailPasswordNode.Apple({
+            clientId: process.env.APPLE_CLIENT_ID,
+            clientSecret: {
+                keyId: process.env.APPLE_KEY_ID,
+                privateKey: process.env.APPLE_PRIVATE_KEY,
+                teamId: process.env.APPLE_TEAM_ID
+            },
+          }),
         ],
       }),
       SessionNode.init(),

--- a/config/frontendConfig.tsx
+++ b/config/frontendConfig.tsx
@@ -14,6 +14,8 @@ export let frontendConfig = () => {
           providers: [
             ThirdPartyEmailPasswordReact.Github.init(),
             ThirdPartyEmailPasswordReact.Google.init(),
+            ThirdPartyEmailPasswordReact.Facebook.init(),
+            ThirdPartyEmailPasswordReact.Apple.init(),
           ],
         },
       }),

--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,12 @@ const {
       GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
       GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
       GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+      FACEBOOK_CLIENT_ID: process.env.FACEBOOK_CLIENT_ID,
+      FACEBOOK_CLIENT_SECRET: process.env.FACEBOOK_CLIENT_SECRET,
+      APPLE_CLIENT_ID: process.env.APPLE_CLIENT_ID,
+      APPLE_KEY_ID: process.env.APPLE_KEY_ID,
+      APPLE_PRIVATE_KEY: process.env.APPLE_PRIVATE_KEY,
+      APPLE_TEAM_ID: process.env.APPLE_TEAM_ID,
     }
   
     // next.config.js object


### PR DESCRIPTION
WARNING: Facebook it's a demo app, so only added testers may login.
Apple uses supertokens.io demo account, remember to change to one of ours in the future.