### PR TITLE
fix: subdomain parsing

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,7 +20,7 @@ const {
       APP_URL: (() => {
         if (isDev) return 'http://localhost:3000'
         if (isProd) {
-          return branch === 'master' ? `https://${base_url}` : `https://${branch.replace('/', '-')}.${base_url}`
+          return branch === 'master' ? `https://${base_url}` : `https://${branch.replaceAll('/', '-')}.${base_url}`
         }
         return 'APP_URL:not (isDev,isProd && !isStaging,isProd && isStaging)'
       })(),


### PR DESCRIPTION
fix: subdomain parsing

Description: Switching from replace to replaceAll to replace all occurences
in cases of "feat/add-button/1" -- one or more slashes

Test Plan: check if feat-add-button-1.paybutton.io or branches similar to this
are working fine in their domain