### PR TITLE
feat: Add PayButton [Part 3] (API)

### DIFF
--- a/components/PayButton/PayButtonsList.tsx
+++ b/components/PayButton/PayButtonsList.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { ButtonResource } from 'types/index'
+
+type IProps = { payButtons: ButtonResource[] }
+export default ({payButtons}:IProps) => 
+<ul>
+{payButtons.map(payButton => (
+    <li key={payButton.id}>
+      <section>
+        <h3>{payButton.id}</h3>
+        <ul>
+          {payButton.addresses.map(address => (<li key={address}>{address}</li>))}
+        </ul>
+      </section>
+    </li>
+))}
+</ul>

--- a/components/PayButton/index.tsx
+++ b/components/PayButton/index.tsx
@@ -1,0 +1,5 @@
+import PayButtonsList from "./PayButtonsList";
+
+export {
+    PayButtonsList
+}

--- a/pages/api/button/[id].ts
+++ b/pages/api/button/[id].ts
@@ -1,0 +1,21 @@
+import { NextApiResponse, NextApiRequest } from "next/types"
+import { ButtonResource } from "types"
+
+const fetchResource = (userId: string): ButtonResource[] => {
+    const temp_addresses = ['ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc', 'bitcoincash:qrw5fzqlxzf639m8s7fq7wn33as7nfw9wg9zphxlxe']
+    return [{
+        id: btoa(userId + Math.random()).slice(10,20),
+        userId,
+        addresses: temp_addresses
+    }]
+}
+
+export default (
+    req: NextApiRequest,
+    res: NextApiResponse
+) => {
+    const userId = req.query.id as string
+    const response = fetchResource(userId);
+    if (response) res.status(200).json(response);
+    if (!response) res.status(404).json({ error: 'Not found' });
+}

--- a/pages/api/button/index.ts
+++ b/pages/api/button/index.ts
@@ -1,0 +1,28 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { ButtonResource } from 'types'
+
+const generateIdFromUserId = userId => Math.random().toString(16).slice(2)
+
+const createResource = (userId: string, addresses: string[]):ButtonResource => {
+    return {
+        id: generateIdFromUserId(userId),
+        userId: userId,
+        addresses: addresses
+    }
+}
+
+export default (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const body = JSON.parse(req.body)
+    const { userId, addresses } = body
+    const response = createResource(userId, addresses);
+    console.log(response)
+    if (!response) {
+      throw new Error('Could not create resource')
+    }
+
+    res.status(200).json(response)
+  } catch (err: any) {
+    res.status(500).json({ statusCode: 500, message: err.message })
+  }
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,5 @@
+export type ButtonResource = {
+        id: string,
+        userId: string,
+        addresses: string[],
+}


### PR DESCRIPTION
Description: This module provides a simple API for creating and getting PayButtons.

Test Plan: After clicking Add PayButton on the signed-in index page, it will show on console the response.
Also, after adding a PayButton, a simple list of added buttons with corresponding addresses will be shown on the signed-in page.

Depends on: feat/add-button/2