### PR TITLE
feat: add initial seeds for paybuttons and paybuttons_addresses

### DIFF
--- a/db/seeders/20220409034149-paybuttons.js
+++ b/db/seeders/20220409034149-paybuttons.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.bulkInsert("paybuttons", [
+      {
+        user_id: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        user_id: 2,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        user_id: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+    ]);
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.bulkDelete("paybuttons", null, {});
+  }
+};

--- a/db/seeders/20220409034835-paybuttons_addresses.js
+++ b/db/seeders/20220409034835-paybuttons_addresses.js
@@ -1,0 +1,42 @@
+'use strict';
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.bulkInsert("paybuttons_addresses", [
+      {
+        paybutton_id: 1,
+        address: "ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc"
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        address: "ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc"
+        paybutton_id: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        address: "ecash:qry66pg4qvmthf90se33wm20mhx8pqgcdy5k5re8qh"
+        paybutton_id: 2,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        address: "ecash:qzjw63hvptddl293zm9yyht5jxhgmgcykuw8jduy6u"
+        paybutton_id: 2,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        address: "ecash:qzjw63hvptddl293zm9yyht5jxhgmgcykuw8jduy6u"
+        paybutton_id: 3,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+    ]);
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.bulkDelete("paybuttons_addresses", null, {});
+  }
+};


### PR DESCRIPTION
Description: Initial sequelize seeds for paybutton and paybuttons_addresses, will populate these two tables with sample data for future testing/initial usage.

Test Plan: `make init-db` should run successfully.

Depends on #49 