### PR TITLE
fix: docker-compose, makefile and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ FROM node:lts-alpine as app
 ## Copy built node modules and binaries without including the toolchain
 RUN addgroup app && adduser -S -G app app
 RUN mkdir /app
-RUN chown app:app /app
-USER app
 COPY --from=builder /deps/node_modules /app/node_modules
 ENV PATH /app/node_modules/.bin:$PATH
+RUN chown -R app:app /app
+USER app
 WORKDIR /app/src/
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,9 @@ RUN yarn
 FROM node:lts-alpine as app
 
 ## Copy built node modules and binaries without including the toolchain
-RUN addgroup app && adduser -S -G app app
 RUN mkdir /app
 COPY --from=builder /deps/node_modules /app/node_modules
 ENV PATH /app/node_modules/.bin:$PATH
-RUN chown -R app:app /app
-USER app
+USER node
 WORKDIR /app/src/
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN yarn
 FROM node:lts-alpine as app
 
 ## Copy built node modules and binaries without including the toolchain
+RUN addgroup app && adduser -S -G app app
+RUN mkdir /app
+RUN chown app:app /app
+USER app
 COPY --from=builder /deps/node_modules /app/node_modules
 ENV PATH /app/node_modules/.bin:$PATH
 WORKDIR /app/src/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-build-image: 
-	docker build -t paybutton-server -f ./.docker/Dockerfile .
+dev:
+	docker-compose up --build -d
 
-dev: 
-	make build-image
-	docker run -p 3000:3000 -v $(PWD):/app/src/ paybutton-server npm run dev
+stop-dev:
+	docker-compose down

--- a/README.md
+++ b/README.md
@@ -4,7 +4,24 @@ https://paybutton.org
 
 ## Developing
 - [Install and configure Docker](https://docs.docker.com/get-docker/)
-- Run the following make command to build the docker image and run the server locally:
+- [Install docker-compose](https://docs.docker.com/compose/install/)
+- Fill up .env or .env.local file with all social provider credentials. You can get testing credentials from [here](https://supertokens.com/docs/thirdpartyemailpassword/quick-setup/backend#2-initialise-supertokens).
+Your .env or .env.local file should look like this:
+````
+APPLE_CLIENT_ID=<insert credentials here>
+APPLE_KEY_ID=<insert credentials here>
+APPLE_PRIVATE_KEY=<insert credentials here>
+APPLE_TEAM_ID=<insert credentials here>
+FACEBOOK_CLIENT_ID=<insert credentials here>
+FACEBOOK_CLIENT_SECRET=<insert credentials here>
+GITHUB_CLIENT_ID=<insert credentials here>
+GITHUB_CLIENT_SECRET=<insert credentials here>
+GOOGLE_CLIENT_SECRET=<insert credentials here>
+SUPERTOKENS_API_KEY=<insert credentials here>
+SUPERTOKENS_CONNECTION_URI=<insert credentials here>
+```
+- **If you run docker as root user, run the following commands with `sudo`** 
+- Run the following make command to build/pull the relevant docker images and run the server locally:
     ```
     make dev
     ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,4 @@ services:
       - "3000:3000"
     volumes:
       - .:/app/src
-    links: 
-      - db
     command: npm run dev
-  db:
-    image: mysql/mysql-server:latest
-    restart: always
-    volumes:
-      - mysql_data:/var/lib/mysql
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: paybutton
-volumes:
-   mysql_data:


### PR DESCRIPTION
Description: 
- Removes MySQL image and volumes from docker-compose **for now**: it doesn't spin up containers in some contexts , **a separate PR will be made with new and tested configuration using mariadb image.**
-  Update README with information regarding credentials (otherwise, currently, the app wont start)
-  Update Makefile with proper docker-compose commands

Test Plan: 
- add credentials to .env or .env.local file
- run `make dev`
- app should be visible on http://localhost:3000