### PR TITLE
fix: run app with available social login credentials

### DIFF
--- a/config/backendConfig.ts
+++ b/config/backendConfig.ts
@@ -45,7 +45,7 @@ export let backendConfig = () : TypeInput => {
     framework: 'express',
     supertokens: {
       apiKey: process.env.SUPERTOKENS_API_KEY,
-      connectionURI: process.env.SUPERTOKENS_CONNECTION_URI,
+      connectionURI: process.env.SUPERTOKENS_CONNECTION_URI || 'https://try.supertokens.com',
     },
     appInfo,
     recipeList: [

--- a/config/backendConfig.ts
+++ b/config/backendConfig.ts
@@ -2,6 +2,44 @@ import ThirdPartyEmailPasswordNode from 'supertokens-node/recipe/thirdpartyemail
 import SessionNode from 'supertokens-node/recipe/session'
 import { appInfo } from './appInfo'
 import { TypeInput } from 'supertokens-node/types'
+
+const getSocialLoginProviders = () => {
+  const availableSocialProviders = {
+   'github': process.env.GITHUB_CLIENT_ID ? () => 
+          ThirdPartyEmailPasswordNode.Github({
+            clientId: process.env.GITHUB_CLIENT_ID,
+            clientSecret: process.env.GITHUB_CLIENT_SECRET
+          }) : false,
+   'google': process.env.GOOGLE_CLIENT_ID ? () =>
+          ThirdPartyEmailPasswordNode.Google({
+            clientId: process.env.GOOGLE_CLIENT_ID,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+          }) : false,
+   'facebook': process.env.FACEBOOK_CLIENT_ID ? () => 
+          ThirdPartyEmailPasswordNode.Facebook({
+            clientId: process.env.FACEBOOK_CLIENT_ID,
+            clientSecret: process.env.FACEBOOK_CLIENT_SECRET
+          }) : false,
+   'apple': process.env.APPLE_CLIENT_ID ? () => 
+          ThirdPartyEmailPasswordNode.Apple({
+            clientId: process.env.APPLE_CLIENT_ID,
+            clientSecret: {
+                keyId: process.env.APPLE_KEY_ID,
+                privateKey: process.env.APPLE_PRIVATE_KEY,
+                teamId: process.env.APPLE_TEAM_ID
+            },
+          }) : false,
+  }
+
+  const socialProviderNodes = Object.keys(availableSocialProviders).map(providerKey => {
+    const getSocialProviderNode = availableSocialProviders[providerKey]
+    if (getSocialProviderNode) {
+      return getSocialProviderNode()
+    }
+  })
+
+  return socialProviderNodes.filter(provider => provider !== undefined)
+}
 export let backendConfig = () : TypeInput => {
   return {
     framework: 'express',
@@ -12,28 +50,7 @@ export let backendConfig = () : TypeInput => {
     appInfo,
     recipeList: [
       ThirdPartyEmailPasswordNode.init({
-        providers: [
-          ThirdPartyEmailPasswordNode.Github({
-            clientId: process.env.GITHUB_CLIENT_ID,
-            clientSecret: process.env.GITHUB_CLIENT_SECRET
-          }),
-          ThirdPartyEmailPasswordNode.Google({
-            clientId: process.env.GOOGLE_CLIENT_ID,
-            clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-          }),
-          ThirdPartyEmailPasswordNode.Facebook({
-            clientId: process.env.FACEBOOK_CLIENT_ID,
-            clientSecret: process.env.FACEBOOK_CLIENT_SECRET
-          }),
-          ThirdPartyEmailPasswordNode.Apple({
-            clientId: process.env.APPLE_CLIENT_ID,
-            clientSecret: {
-                keyId: process.env.APPLE_KEY_ID,
-                privateKey: process.env.APPLE_PRIVATE_KEY,
-                teamId: process.env.APPLE_TEAM_ID
-            },
-          }),
-        ],
+        providers: getSocialLoginProviders()
       }),
       SessionNode.init(),
     ],

--- a/config/frontendConfig.tsx
+++ b/config/frontendConfig.tsx
@@ -3,6 +3,20 @@ import SessionReact from 'supertokens-auth-react/recipe/session'
 import { appInfo } from './appInfo'
 
 export let frontendConfig = () => {
+  const getAvailableSocialProviders = () => {
+    const socialProviderNodes = {
+      'github': process.env.GITHUB_CLIENT_ID && ThirdPartyEmailPasswordReact.Github.init(),
+      'google': process.env.GOOGLE_CLIENT_ID && ThirdPartyEmailPasswordReact.Google.init(),
+      'facebook': process.env.FACEBOOK_CLIENT_ID && ThirdPartyEmailPasswordReact.Facebook.init(),
+      'apple': process.env.APPLE_CLIENT_ID && ThirdPartyEmailPasswordReact.Apple.init(),
+    }
+    const availableSocialProvidersNodes = Object.keys(socialProviderNodes).map(providerKey => {
+      if (socialProviderNodes[providerKey] !== undefined)
+        return socialProviderNodes[providerKey]
+    })
+    return availableSocialProvidersNodes.filter(provider => provider !== undefined)
+  }
+   
   return {
     appInfo,
     recipeList: [
@@ -11,12 +25,7 @@ export let frontendConfig = () => {
           mode: 'REQUIRED',
         },
         signInAndUpFeature: {
-          providers: [
-            ThirdPartyEmailPasswordReact.Github.init(),
-            ThirdPartyEmailPasswordReact.Google.init(),
-            ThirdPartyEmailPasswordReact.Facebook.init(),
-            ThirdPartyEmailPasswordReact.Apple.init(),
-          ],
+          providers: getAvailableSocialProviders()
         },
       }),
       SessionReact.init(),


### PR DESCRIPTION
Description:
- Fix issue where, without all social login credentials, app would crash
- Now app will add only available social logins, if none, only email/password will show up on sign in/sign up page.

Test Plan: 
`make dev` and then run without social login credentials, add some social login credentials and run `make dev` again. 
app should be available at http://localhost:3000 with only available credentials, or only email/password. 
