### PR TITLE
feat: add mariadb (mysql drop-in replacement) to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,23 @@
 version: "3.9"
 services:
   paybutton:
+    restart: always
+    depends_on: 
+      - db
     build: .
     ports:
       - "3000:3000"
     volumes:
       - .:/app/src
     command: npm run dev
+  db:
+    image: mariadb
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: paybutton
+      MYSQL_USER: paybutton
+      MYSQL_PASSWORD: paybutton
+    command: --default-authentication-plugin=mysql_native_password
+    ports:
+      - 3306:3306


### PR DESCRIPTION
Description: Adds mariadb (mysql drop-in replacement) to docker-compose file

Test Plan: run `make dev` and then `docker ps` to see if `db` container is up and running