### PR TITLE
chore: add codeowners file to add reviewers automatically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@alcipir @Klakurka @Gattaca1


### PR DESCRIPTION
Adding @Klakurka and @Gattaca1 (and me) as reviewers automatically on GitHub