### PR TITLE
chore: add check logs commands to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,9 @@ dev:
 
 stop-dev:
 	docker-compose down
+
+check-logs-dev:
+	docker logs -f paybutton-server_paybutton_1
+
+check-logs-db:
+	docker logs -f paybutton-server_db_1


### PR DESCRIPTION
Description: adds `make check-logs-dev` and `make check-logs-db` to run commands to follow logs from paybutton-server container and db container.

Test Plan: run `make dev`, then each of the commands described above and see if logs are shown properly.