### PR TITLE
Chore/add users service (supertokens local instance)

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-GRPC_NODE_URL=bchd.greyh.at:8335
+SUPERTOKENS_CONNECTION_URI=http://users_service:3567

--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-SUPERTOKENS_CONNECTION_URI=http://users_service:3567

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ check-logs-db:
 	docker logs -f paybutton-server_db_1
 
 check-logs-users:
-	docker logs -f paybutton-server_users_service_1
+	docker logs -f paybutton-server_users-service_1

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ check-logs-dev:
 
 check-logs-db:
 	docker logs -f paybutton-server_db_1
+
+check-logs-users:
+	docker logs -f paybutton-server_users_service_1

--- a/config/backendConfig.ts
+++ b/config/backendConfig.ts
@@ -45,7 +45,7 @@ export let backendConfig = () : TypeInput => {
     framework: 'express',
     supertokens: {
       apiKey: process.env.SUPERTOKENS_API_KEY,
-      connectionURI: process.env.SUPERTOKENS_CONNECTION_URI || 'https://try.supertokens.com',
+      connectionURI: process.env.SUPERTOKENS_CONNECTION_URI || 'http://users-service:3567',
     },
     appInfo,
     recipeList: [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     restart: always
     depends_on: 
       - db
+      - users_service
     build: .
     ports:
       - "3000:3000"
@@ -21,3 +22,16 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     ports:
       - 3306:3306
+  users_service:
+    depends_on:
+      - db
+    image: registry.supertokens.io/supertokens/supertokens-mysql
+    restart: always
+    ports:
+      - 3567:3567
+    environment:
+      MYSQL_DATABASE_NAME: paybutton
+      MYSQL_USER: paybutton
+      MYSQL_PASSWORD: paybutton
+      MYSQL_HOST: db
+      MYSQL_PORT: 3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     restart: always
     depends_on: 
       - db
-      - users_service
+      - users-service
     build: .
     ports:
       - "3000:3000"
@@ -22,7 +22,7 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     ports:
       - 3306:3306
-  users_service:
+  users-service:
     depends_on:
       - db
     image: registry.supertokens.io/supertokens/supertokens-mysql


### PR DESCRIPTION
Description: adds supertokens (users service) local instance
Test Plan: 
- Remove existing SUPERTOKENS_API_KEY and SUPERTOKENS_CONNECTION_URI from your .env.local or .env file
- Run `make dev` **(`make stop-dev` first if containers already running)**  and then: 
  - Open up http://localhost:3567/hello on you browser, there should be a 'Hello' text on the page.
  - Sign up with email and password, and run `make check-logs-users`, there should be something similar to this:
      <img width="605" alt="image" src="https://user-images.githubusercontent.com/4197222/167234536-ce8ed182-49cc-4213-ac6f-7f13f9da19d4.png">

  