### PR TITLE
Save paybutton & addresses on the  database

### DIFF
--- a/components/AddPayButtonForm.tsx
+++ b/components/AddPayButtonForm.tsx
@@ -13,7 +13,7 @@ import axios from "axios";
 const schema = {
     fields: [
         {
-            component: "text-field",
+            component: "textarea",
             name: "addresses",
             label: "Addresses",
             helperText: "XEC and/or BCH wallet addresses",

--- a/components/AddPayButtonForm.tsx
+++ b/components/AddPayButtonForm.tsx
@@ -7,24 +7,32 @@ import {
   componentMapper,
 } from "@data-driven-forms/mui-component-mapper";
 import FormTemplate from "@data-driven-forms/mui-component-mapper/form-template";
+import { websiteDomain } from 'config/appInfo'
+import axios from "axios";
 
 const schema = {
-  fields: [
-    {
-      component: "text-field",
-      name: "text-field",
-      label: "Address",
-      helperText: "XEC or BCH wallet address ",
-    },
-  ],
+    fields: [
+        {
+            component: "text-field",
+            name: "addresses",
+            label: "Addresses",
+            helperText: "XEC and/or BCH wallet addresses",
+        },
+    ],
 };
+
+const onSubmit = async (formData) => {
+    const res = await axios.post(`${websiteDomain}/api/paybutton`,
+        { addresses: formData.addresses }
+    )
+}
 
 const Form = () => (
   <FormRenderer
     schema={schema}
     componentMapper={componentMapper}
     FormTemplate={FormTemplate}
-    onSubmit={console.log}
+    onSubmit={onSubmit}
   />
 );
 

--- a/db/models/paybuttons.js
+++ b/db/models/paybuttons.js
@@ -10,7 +10,7 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      paybuttons.hasMany(models.paybuttons_addresses, { as: 'addresses' })
+      paybuttons.addresses = paybuttons.hasMany(models.paybuttons_addresses, { as: 'addresses' })
     }
   }
   paybuttons.init({

--- a/db/models/paybuttons_addresses.js
+++ b/db/models/paybuttons_addresses.js
@@ -10,7 +10,7 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-        paybuttons_addresses.belongsTo(models.paybuttons, { as: 'paybutton' })
+        paybuttons_addresses.paybuttons = paybuttons_addresses.belongsTo(models.paybuttons, { as: 'paybutton' })
     }
   }
   paybuttons_addresses.init({

--- a/db/models/paybuttons_addresses.js
+++ b/db/models/paybuttons_addresses.js
@@ -10,7 +10,7 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+        paybuttons_addresses.belongsTo(models.paybuttons, { as: 'paybutton' })
     }
   }
   paybuttons_addresses.init({


### PR DESCRIPTION
Filling form and clicking the **Submit** button now commits the newly created paybutton and its addresses to the database.

![saving-pb-to-db-2022-05-11_13 11 46](https://user-images.githubusercontent.com/21281174/167899019-37e08e18-fe8e-4eb6-8e31-a51d53de5e5d.gif)

There is no validation being performed on these addresses (if the string before the colon is a valid chain, if the text field is not empty, etc); I'll do that in the next PR.
I am also mocking the user because I couldn't get their ID right now, so I'll also solve that in a different PR.