### PR TITLE
ci: add named containers and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,10 @@ stop-dev:
 	docker-compose down
 
 check-logs-dev:
-	docker logs -f paybutton-server_paybutton_1
+	docker logs -f paybutton-dev
 
 check-logs-db:
-	docker logs -f paybutton-server_db_1
+	docker logs -f paybutton-db
 
 check-logs-users:
-	docker logs -f paybutton-server_users-service_1
-
+	docker logs -f paybutton-users-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   paybutton:
+    container_name: paybutton-dev
     restart: always
     depends_on: 
       - db
@@ -12,6 +13,7 @@ services:
       - .:/app/src
     command: sh -c "yarn db:migrate && yarn dev"
   db:
+    container_name: paybutton-db
     image: mariadb
     restart: always
     environment:
@@ -23,6 +25,7 @@ services:
     ports:
       - 3306:3306
   users-service:
+    container_name: paybutton-users-service
     depends_on:
       - db
     image: registry.supertokens.io/supertokens/supertokens-mysql


### PR DESCRIPTION
Description: Add named containers, updating Makefile accordingly. This fixes an issue where some operating systems would create a container with a different name (e.g. paybutton_server instead of paybutton-server) and would fail to run `make check-logs[...]` due to this mismatch.

Test Plan: `make dev`, then `make check-logs-dev`, `make check-logs-db`, `make check-logs-users`, see if logs are being printed accordingly.