### PR TITLE
fix: users-service container name in make check-logs-users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,9 @@ check-logs-db:
 	docker logs -f paybutton-db
 
 check-logs-users:
-	docker logs -f paybutton-server_users-service_1
+	docker logs -f paybutton-users-service
 
 lint-master:
 	$(git_diff_to_master)
 	npx --yes ts-standard --stdin --stdin-filename DIFF
+


### PR DESCRIPTION
Description: fix missing proper name for users-service (supertokens) container on `make check-logs-users`.

Test Plan: `make dev`  && `make check-logs-users`, should show logs for the users-service container.