### PR TITLE
Feature: Add paybutton `name`, `uuid` and `buttonData` fields — Create parsers

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -11,6 +11,9 @@ export const RESPONSE_MESSAGES = {
   NOT_FOUND_404: { statusCode: 404, message: 'Not found.' },
   INVALID_INPUT_400: { statusCode: 400, message: 'Invalid input.' },
   USER_ID_NOT_PROVIDED_400: { statusCode: 400, message: "'userId' not provided." },
+  NAME_NOT_PROVIDED_400: { statusCode: 400, message: "'name' not provided." },
+  NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Button name already exists for this user.' },
   ADDRESSES_NOT_PROVIDED_400: { statusCode: 400, message: "'addresses' not provided." },
-  INVALID_CHAIN_SLUG_400: { statusCode: 400, message: 'Invalid chain slug.' }
+  INVALID_CHAIN_SLUG_400: { statusCode: 400, message: 'Invalid chain slug.' },
+  INVALID_BUTTON_DATA_400: { statusCode: 400, message: "'buttonData' is not valid JSON." }
 }

--- a/services/paybuttonsService.ts
+++ b/services/paybuttonsService.ts
@@ -3,6 +3,13 @@ import { Paybutton, Prisma } from '@prisma/client'
 import prisma from 'prisma/clientInstance'
 import { RESPONSE_MESSAGES } from 'constants/index'
 
+export interface CreatePaybuttonInput {
+  userId: string
+  name: string
+  buttonData: string
+  prefixedAddressList: string[]
+}
+
 export async function createPaybutton (userId: string, prefixedAddressList: string[]): Promise<Paybutton> {
   const paybuttonAddressesToCreate: Prisma.PaybuttonAddressUncheckedCreateWithoutPaybuttonInput[] = await Promise.all(
     prefixedAddressList.map(

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -1,113 +1,186 @@
 import * as v from 'utils/validators'
 import { RESPONSE_MESSAGES } from 'constants/index'
+import { Prisma } from '@prisma/client'
 
-// region: test `parseAddresses`
-test('Accept example addresses', () => {
-  const addressListString = 'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
-  expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+describe('parseAddresses', () => {
+  it('Accept example addresses', () => {
+    const addressListString = 'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
+    expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+  })
+
+  it('Accept addresses for testnets', () => {
+    const addressListString = 'bchreg:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbchtest:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
+    expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+  })
+
+  it('Accept example addresses uppercase', () => {
+    const addressListString = 'ecash:QPZ274AAJ98XXNNKUS8HZV367ZA28J900C7TV5V8PC\nbitcoincash:QZ0DQJF6W6DP0LCS8CC68S720Q9DV5ZV8CS8FC0LT4'
+    expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+  })
+
+  it('Accept example address one uppercase other lowercase', () => {
+    const addressListString = 'ecash:QPZ274AAJ98XXNNKUS8HZV367ZA28J900C7TV5V8PC\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
+    expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+  })
+
+  it('Accept chain uppercase', () => {
+    const addressListString = 'ECASH:QPZ274AAJ98XXNNKUS8HZV367ZA28J900C7TV5V8PC\nBiTcoinCash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
+    expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+  })
+
+  it('Reject address with disallowed characters', () => {
+    expect(() => {
+      v.parseAddresses((
+        'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
+        'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs1fc0lt4' // this has '1' in it
+      ))
+    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    expect(() => {
+      v.parseAddresses((
+        'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
+        'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8csbfc0lt4' // this has 'b' in it
+      ))
+    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    expect(() => {
+      v.parseAddresses((
+        'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
+        'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8csifc0lt4' // this has 'i' in it
+      ))
+    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    expect(() => {
+      v.parseAddresses((
+        'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
+        'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8csofc0lt4' // this has 'o' in it
+      ))
+    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+  })
+
+  it('Reject mixed case address', () => {
+    expect(() => {
+      v.parseAddresses((
+        'bitcoincash:qpz274aaJ98XXNNKUS8HZV367ZA28J900C7tv5v8pc'
+      ))
+    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+  })
+
+  it('Reject legacy address', () => {
+    expect(() => {
+      v.parseAddresses((
+        'ecash:1Nkmzb49MCUJThkpNWaVX9xCPmZvMKeu7Q'
+      ))
+    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+  })
+
+  it('Reject address without chain', () => {
+    expect(() => {
+      v.parseAddresses((
+        'qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc'
+      ))
+    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+  })
+
+  it('Reject non-supported chain', () => {
+    expect(() => {
+      v.parseAddresses((
+        'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
+        'bitcoin:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc' // this is not
+      ))
+    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+  })
+
+  it('Reject non-supported address format', () => {
+    expect(() => {
+      v.parseAddresses((
+        'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
+        'bitcoincash:bc1qvwhdfujkyulp8jxuql7h55zzxlsap6zg9f5wmj' // this is not
+      ))
+    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+  })
+
+  it('Reject valid addresses of repeated chain', () => {
+    expect(() => {
+      v.parseAddresses((
+        'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' +
+        'ecash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
+      ))
+    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+  })
+
+  it('Reject empty string', () => {
+    expect(() => {
+      v.parseAddresses('')
+    }).toThrow(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
+  })
 })
 
-test('Accept addresses for testnets', () => {
-  const addressListString = 'bchreg:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbchtest:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
-  expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+describe('parseError', () => {
+  it('Prisma unique name constraint violation turns into custom error', () => {
+    const error = new Prisma.PrismaClientKnownRequestError(
+      'Error message: Paybutton_name_providerUserId_unique_constraint',
+      'P2002',
+      'foo'
+    )
+    expect(v.parseError(error)).toStrictEqual(new Error(RESPONSE_MESSAGES.NAME_ALREADY_EXISTS_400.message))
+  })
 })
 
-test('Accept example addresses uppercase', () => {
-  const addressListString = 'ecash:QPZ274AAJ98XXNNKUS8HZV367ZA28J900C7TV5V8PC\nbitcoincash:QZ0DQJF6W6DP0LCS8CC68S720Q9DV5ZV8CS8FC0LT4'
-  expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+describe('parseButtonData', () => {
+  it('Empty values give empty JSON string', () => {
+    expect(v.parseButtonData(undefined)).toBe('{}')
+    expect(v.parseButtonData('')).toBe('{}')
+    expect(v.parseButtonData('{}')).toBe('{}')
+  })
+  it('Invalid JSON string throws error', () => {
+    expect(() => {
+      v.parseButtonData('bla')
+    }).toThrow(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message)
+    expect(() => {
+      v.parseButtonData('{bla:2}')
+    }).toThrow(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message)
+    expect(() => {
+      v.parseButtonData('{"bla": 2')
+    }).toThrow(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message)
+  })
+  it('Valid JSON string returns itself minimized', () => {
+    const expectedJSONString = '{"bla":3,"foo":"bar"}'
+    expect(v.parseButtonData(expectedJSONString)).toBe(expectedJSONString)
+    expect(v.parseButtonData('{"bla": 3, "foo": "bar"}')).toBe(expectedJSONString)
+    expect(v.parseButtonData('{"bla":\n3,      "foo"\n: "bar"  } ')).toBe(expectedJSONString)
+  })
 })
 
-test('Accept example address one uppercase other lowercase', () => {
-  const addressListString = 'ecash:QPZ274AAJ98XXNNKUS8HZV367ZA28J900C7TV5V8PC\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
-  expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+describe('parsePaybuttonPOSTRequest', () => {
+  const data: v.POSTParameters = {
+    userId: undefined,
+    name: 'somename',
+    buttonData: undefined,
+    addresses: 'ecash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
+  }
+  it('Missing userId throws errors', () => {
+    expect(() => {
+      v.parsePaybuttonPOSTRequest(data)
+    }).toThrow(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
+    expect(() => {
+      data.userId = ''
+      v.parsePaybuttonPOSTRequest(data)
+    }).toThrow(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
+  })
+  it('Missing name throws errors', () => {
+    expect(() => {
+      data.userId = 'some user'
+      data.name = undefined
+      v.parsePaybuttonPOSTRequest(data)
+    }).toThrow(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
+    expect(() => {
+      data.name = ''
+      v.parsePaybuttonPOSTRequest(data)
+    }).toThrow(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
+  })
+  it('Missing address throws errors', () => {
+    expect(() => {
+      data.name = 'some name'
+      data.addresses = ''
+      v.parsePaybuttonPOSTRequest(data)
+    }).toThrow(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
+  })
 })
-
-test('Accept chain uppercase', () => {
-  const addressListString = 'ECASH:QPZ274AAJ98XXNNKUS8HZV367ZA28J900C7TV5V8PC\nBiTcoinCash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
-  expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
-})
-
-test('Reject address with disallowed characters', () => {
-  expect(() => {
-    v.parseAddresses((
-      'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
-      'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs1fc0lt4' // this has '1' in it
-    ))
-  }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-  expect(() => {
-    v.parseAddresses((
-      'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
-      'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8csbfc0lt4' // this has 'b' in it
-    ))
-  }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-  expect(() => {
-    v.parseAddresses((
-      'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
-      'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8csifc0lt4' // this has 'i' in it
-    ))
-  }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-  expect(() => {
-    v.parseAddresses((
-      'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
-      'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8csofc0lt4' // this has 'o' in it
-    ))
-  }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-})
-
-test('Reject mixed case address', () => {
-  expect(() => {
-    v.parseAddresses((
-      'bitcoincash:qpz274aaJ98XXNNKUS8HZV367ZA28J900C7tv5v8pc'
-    ))
-  }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-})
-
-test('Reject legacy address', () => {
-  expect(() => {
-    v.parseAddresses((
-      'ecash:1Nkmzb49MCUJThkpNWaVX9xCPmZvMKeu7Q'
-    ))
-  }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-})
-
-test('Reject address without chain', () => {
-  expect(() => {
-    v.parseAddresses((
-      'qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc'
-    ))
-  }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-})
-
-test('Reject non-supported chain', () => {
-  expect(() => {
-    v.parseAddresses((
-      'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
-      'bitcoin:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc' // this is not
-    ))
-  }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-})
-
-test('Reject non-supported address format', () => {
-  expect(() => {
-    v.parseAddresses((
-      'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
-      'bitcoincash:bc1qvwhdfujkyulp8jxuql7h55zzxlsap6zg9f5wmj' // this is not
-    ))
-  }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-})
-
-test('Reject valid addresses of repeated chain', () => {
-  expect(() => {
-    v.parseAddresses((
-      'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' +
-      'ecash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
-    ))
-  }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-})
-
-test('Reject empty string', () => {
-  expect(() => {
-    v.parseAddresses('')
-  }).toThrow(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
-})
-// end region

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,29 +1,85 @@
-import { SUPPORTED_CHAINS, SUPPORTED_ADDRESS_PATTERN } from 'constants/index'
-import { RESPONSE_MESSAGES } from 'constants/index'
+import { SUPPORTED_CHAINS, SUPPORTED_ADDRESS_PATTERN, RESPONSE_MESSAGES } from 'constants/index'
+import { Prisma } from '@prisma/client'
+import { CreatePaybuttonInput } from 'services/paybuttonsService'
 
-export const parseAddresses = function (prefixedAddressString: string): string[] {
+/* The functions here defined should validate the data structure / syntax of an input by throwing
+ * an error in case something is different from the expected. The prefix for each function name
+ * here defined shall be:
+ * - 'parse', if the function validates the input and also uses it to create some other output;
+ * - 'validate', if the function only validates the input
+ */
+
+export const parseAddresses = function (prefixedAddressString: string | undefined): string[] {
   /**
    * Disallow addresses without a 'chain:' prefix
    * Disallow addresses with an unknown prefix
    * Disallow  addresses is in an invalid format
    * Disallow  addresses with repeated prefixes (chains)
    **/
-  if (!prefixedAddressString) throw new Error(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message);
+  if (prefixedAddressString === '' || prefixedAddressString === undefined) {
+    throw new Error(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
+  }
   const prefixedAddressList = prefixedAddressString.trim().split('\n')
-  let seenPrefixes = new Set()
+  const seenPrefixes = new Set()
   for (let i = 0; i < prefixedAddressList.length; i++) {
-    const addressWithPrefix = prefixedAddressList[i];
-    let [prefix, address] =  addressWithPrefix.split(':')
+    const addressWithPrefix = prefixedAddressList[i]
+    let [prefix, address] = addressWithPrefix.split(':')
     prefix = prefix.toLowerCase()
-    if(
-      !addressWithPrefix.includes(':')
-      || !SUPPORTED_CHAINS.includes(prefix)
-      || !address.match(SUPPORTED_ADDRESS_PATTERN)
-      || seenPrefixes.has(prefix)
+    if (
+      !addressWithPrefix.includes(':') ||
+      !SUPPORTED_CHAINS.includes(prefix) ||
+      (address.match(SUPPORTED_ADDRESS_PATTERN) == null) ||
+      seenPrefixes.has(prefix)
     ) {
       throw new Error(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
     }
     seenPrefixes.add(prefix)
   }
   return prefixedAddressList
+}
+
+export const parseButtonData = function (buttonDataString: string | undefined): string {
+  let parsedButtonData: string
+  if (buttonDataString === '' || buttonDataString === undefined) {
+    parsedButtonData = '{}'
+  } else {
+    try {
+      const jsonObject = JSON.parse(buttonDataString)
+      parsedButtonData = JSON.stringify(jsonObject, null, 0) // remove linebreaks, tabs & spaces.
+    } catch (e: any) {
+      throw new Error(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message)
+    }
+  }
+  return parsedButtonData
+}
+
+export const parseError = function (error: Error): Error {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    if (error.code === 'P2002') {
+      if (error.message.includes('Paybutton_name_providerUserId_unique_constraint')) {
+        return new Error(RESPONSE_MESSAGES.NAME_ALREADY_EXISTS_400.message)
+      }
+    }
+  }
+  return error
+}
+
+export interface POSTParameters {
+  userId?: string
+  name?: string
+  buttonData?: string
+  addresses?: string
+}
+
+export const parsePaybuttonPOSTRequest = function (params: POSTParameters): CreatePaybuttonInput {
+  if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
+  if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
+  const parsedAddresses = parseAddresses(params.addresses)
+  const parsedButtonData = parseButtonData(params.buttonData)
+  return {
+    userId: params.userId,
+    name: params.name,
+    buttonData: parsedButtonData,
+    prefixedAddressList: parsedAddresses
+  }
 }


### PR DESCRIPTION
Description:
Part of #33: Creates functions to parse the new fields, plus their unittests. In this PR, the fields still don't exist. Thus, the validators created are are still not being used.

Test plan:
All tests should pass.