### PR TITLE
Feature: Add paybutton name, uuid and buttonData fields — Create scheme & migrations

### DIFF
--- a/prisma/migrations/20220609133700_add_name_hash_data_fields/migration.sql
+++ b/prisma/migrations/20220609133700_add_name_hash_data_fields/migration.sql
@@ -1,0 +1,10 @@
+ALTER TABLE `Paybutton`
+ADD COLUMN `name` VARCHAR(255) NOT NULL AFTER `id`;
+
+ALTER TABLE `Paybutton`
+ADD COLUMN `uuid` VARCHAR(191) NOT NULL DEFAULT UUID() AFTER `name`;
+
+ALTER TABLE `Paybutton`
+ADD COLUMN `buttonData` JSON NOT NULL AFTER `uuid`;
+
+ALTER TABLE `Paybutton` ADD CONSTRAINT `Paybutton_name_providerUserId_unique_constraint` UNIQUE (`name`, `providerUserId`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,39 +1,46 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["native", "linux-musl"]
 }
 
 datasource db {
-  provider = "mysql"
-  url      = env("DATABASE_URL")
+  provider          = "mysql"
+  url               = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
 model PaybuttonAddress {
-  id          Int        @id @default(autoincrement())
-  address     String     @db.VarChar(255)
-  createdAt   DateTime   @default(now())
-  updatedAt   DateTime   @updatedAt
+  id          Int       @id @default(autoincrement())
+  address     String    @db.VarChar(255)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
   chainId     Int
   paybuttonId Int
   chain       Chain     @relation(fields: [chainId], references: [id], onUpdate: Restrict)
-  paybutton  Paybutton @relation(fields: [paybuttonId], references: [id], onDelete: Cascade, onUpdate: Restrict)
+  paybutton   Paybutton @relation(fields: [paybuttonId], references: [id], onDelete: Cascade, onUpdate: Restrict)
+
+  @@index([chainId], map: "PaybuttonAddress_chainId_fkey")
+  @@index([paybuttonId], map: "PaybuttonAddress_paybuttonId_fkey")
 }
 
 model Paybutton {
-  id                  Int                   @id @default(autoincrement())
-  providerUserId      String?               @db.VarChar(255)
-  createdAt           DateTime              @default(now())
-  updatedAt           DateTime              @updatedAt
-  addresses           PaybuttonAddress[]
+  id             Int                  @id @default(autoincrement())
+  name           String               @db.VarChar(255)
+  uuid           String               @default(dbgenerated("uuid()"))
+  buttonData     String               @db.LongText
+  providerUserId String?              @db.VarChar(255)
+  createdAt      DateTime             @default(now())
+  updatedAt      DateTime             @updatedAt
+  addresses      PaybuttonAddress[]
+
+  @@unique([name, providerUserId], map: "Paybutton_name_providerUserId_unique_constraint")
 }
 
 model Chain {
-  id                  Int                   @id @default(autoincrement())
-  slug                String                @unique @db.VarChar(255)
-  title               String                @db.VarChar(255)
-  createdAt           DateTime              @default(now())
-  updatedAt           DateTime              @updatedAt
-  paybuttonAddresses  PaybuttonAddress[]
-
+  id                 Int                @id @default(autoincrement())
+  slug               String             @unique @db.VarChar(255)
+  title              String             @db.VarChar(255)
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @updatedAt
+  paybuttonAddresses PaybuttonAddress[]
 }


### PR DESCRIPTION
**Description:**
Part of #33: Creates the migration & updates the prisma scheme, adding the new fields.

- The `uuid` field is `VARCHAR` and not `UUID` because [prisma does not support UUID](https://www.prisma.io/docs/concepts/database-connectors/mysql#native-type-mappings) for MySQL yet.
- The `buttonData` field is set to NOT NULL so that null values are saved as `'{}', and thus even empty values can be parsed as JSON.

**Test plan:**
This, on its own, breaks all previous code related to the PayButton API & DB services, as well as their tests. The changes to that code will be added in subsequent PRs that point to this one as their dependency.

However, it's possible to test the migrations and the scheme by running:
```
yarn docker migratereset
yarn docker prismagenerate
```