### PR TITLE
Feature: Add paybutton name, uuid and buttonData fields — Change paybuttonsService

### DIFF
--- a/services/paybuttonsService.ts
+++ b/services/paybuttonsService.ts
@@ -10,9 +10,9 @@ export interface CreatePaybuttonInput {
   prefixedAddressList: string[]
 }
 
-export async function createPaybutton (userId: string, prefixedAddressList: string[]): Promise<Paybutton> {
+export async function createPaybutton (values: CreatePaybuttonInput): Promise<Paybutton> {
   const paybuttonAddressesToCreate: Prisma.PaybuttonAddressUncheckedCreateWithoutPaybuttonInput[] = await Promise.all(
-    prefixedAddressList.map(
+    values.prefixedAddressList.map(
       async (addressWithPrefix) => {
         const [prefix, address] = addressWithPrefix.split(':').map(
           (substring) => substring.toLowerCase()
@@ -27,7 +27,9 @@ export async function createPaybutton (userId: string, prefixedAddressList: stri
   )
   return await prisma.paybutton.create({
     data: {
-      providerUserId: userId,
+      providerUserId: values.userId,
+      name: values.name,
+      buttonData: values.buttonData,
       addresses: {
         create: paybuttonAddressesToCreate
       }

--- a/tests/mockedModels.ts
+++ b/tests/mockedModels.ts
@@ -1,6 +1,9 @@
 export const mockedPaybutton = {
   id: 4,
   providerUserId: 'mocked-uid',
+  name: 'mocked-name',
+  buttonData: 'mockedData',
+  uuid: '730bfa24-eb57-11ec-b722-0242ac150002',
   createdAt: new Date('2022-05-27T15:18:42.000Z'),
   updatedAt: new Date('2022-05-27T15:18:42.000Z'),
   addresses: [
@@ -27,6 +30,9 @@ export const mockedPaybuttonList = [
   {
     id: 1,
     providerUserId: 'mocked-uid',
+    name: 'mocked-name-1',
+    buttonData: 'mockedData',
+    uuid: '730bfa24-eb57-11ec-b722-0242ac150002',
     createdAt: new Date('2022-05-27T15:18:42.000Z'),
     updatedAt: new Date('2022-05-27T15:18:42.000Z'),
     addresses: [
@@ -51,6 +57,9 @@ export const mockedPaybuttonList = [
   {
     id: 2,
     providerUserId: 'mocked-uid',
+    name: 'mocked-name-2',
+    buttonData: 'mockedData',
+    uuid: '133fb8aa-eb57-11ec-b722-0242ac150002',
     createdAt: new Date('2022-05-27T15:18:42.000Z'),
     updatedAt: new Date('2022-05-27T15:18:42.000Z'),
     addresses: [

--- a/tests/unittests/paybuttonsService.test.ts
+++ b/tests/unittests/paybuttonsService.test.ts
@@ -28,7 +28,13 @@ describe('Create services', () => {
 
     prismaMock.chain.findUnique.mockResolvedValue(mockedChain)
     prisma.chain.findUnique = prismaMock.chain.findUnique
-    const result = await paybuttonsService.createPaybutton('mocked-uid', ['mockedchain:mockaddress'])
+    const createPaybuttonInput = {
+      userId: 'mocked-uid',
+      name: 'mocked-name',
+      prefixedAddressList: ['mockedchain:mockaddress'],
+      buttonData: ''
+    }
+    const result = await paybuttonsService.createPaybutton(createPaybuttonInput)
     expect(result).toEqual(mockedPaybutton)
   })
 })


### PR DESCRIPTION
Description:
Part of #33: Makes the necessary changes related to the new added fields to  `paybuttonsService.ts` and its tests.

Depends on:

- [x] #113 
- [x] #114 

Test plan:
The API & tests will be addressed in another PR, so those tests will fail. `yarn docker t tests/unittests/paybuttonsService.test.ts` should succeed.