### PR TITLE
fix: remove USER node and chown -R on prisma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,6 @@
-FROM node:lts-alpine as builder
-
-## Install build toolchain
+FROM node:lts-alpine
 RUN apk add --no-cache python3 make g++
-
-# Install node deps and compile native add-ons
-WORKDIR /deps/
-COPY package.json /deps/
-COPY yarn.lock /deps/
-RUN yarn
-
-FROM node:lts-alpine as app
-
-## Copy built node modules and binaries without including the toolchain
 USER node
-COPY --chown=node --from=builder /deps/node_modules /home/node/src/node_modules
-ENV PATH /home/node/src/node_modules/.bin:$PATH
 WORKDIR /home/node/src/
+ENV PATH /home/node/src/node_modules/.bin:$PATH
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM node:lts-alpine as builder
 RUN apk add --no-cache python3 make g++
 
 # Install node deps and compile native add-ons
+USER node
 WORKDIR /deps/
 COPY package.json /deps/
 COPY yarn.lock /deps/
@@ -13,7 +14,6 @@ FROM node:lts-alpine as app
 
 ## Copy built node modules and binaries without including the toolchain
 RUN mkdir /app
-USER node
 COPY --from=builder /deps/node_modules /app/node_modules
 ENV PATH /app/node_modules/.bin:$PATH
 WORKDIR /app/src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM node:lts-alpine as builder
 RUN apk add --no-cache python3 make g++
 
 # Install node deps and compile native add-ons
-USER node
 WORKDIR /deps/
 COPY package.json /deps/
 COPY yarn.lock /deps/
@@ -13,8 +12,8 @@ RUN yarn
 FROM node:lts-alpine as app
 
 ## Copy built node modules and binaries without including the toolchain
-RUN mkdir /app
-COPY --from=builder /deps/node_modules /app/node_modules
-ENV PATH /app/node_modules/.bin:$PATH
-WORKDIR /app/src/
+USER node
+COPY --from=builder /deps/node_modules /home/node/node_modules
+ENV PATH /home/node/node_modules/.bin:$PATH
+WORKDIR /home/node/src/
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM node:lts-alpine as app
 
 ## Copy built node modules and binaries without including the toolchain
 RUN mkdir /app
+USER node
 COPY --from=builder /deps/node_modules /app/node_modules
 ENV PATH /app/node_modules/.bin:$PATH
 WORKDIR /app/src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,5 @@ FROM node:lts-alpine as app
 RUN mkdir /app
 COPY --from=builder /deps/node_modules /app/node_modules
 ENV PATH /app/node_modules/.bin:$PATH
-RUN chown -R node:node /app/node_modules/prisma
-USER node
 WORKDIR /app/src/
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM node:lts-alpine as app
 
 ## Copy built node modules and binaries without including the toolchain
 USER node
-COPY --chown=node --from=builder /deps/node_modules /home/node/node_modules
-ENV PATH /home/node/node_modules/.bin:$PATH
+COPY --chown=node --from=builder /deps/node_modules /home/node/src/node_modules
+ENV PATH /home/node/src/node_modules/.bin:$PATH
 WORKDIR /home/node/src/
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM node:lts-alpine as app
 
 ## Copy built node modules and binaries without including the toolchain
 USER node
-COPY --from=builder /deps/node_modules /home/node/node_modules
+COPY --chown=node --from=builder /deps/node_modules /home/node/node_modules
 ENV PATH /home/node/node_modules/.bin:$PATH
 WORKDIR /home/node/src/
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - "3000:3000"
     volumes:
       - .:/app/src
-      - /app/src/prisma/migrations
     command: sh -c "yarn prisma migrate dev && yarn prisma db seed && yarn dev"
   db:
     container_name: paybutton-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - .:/app/src
+      - .:/home/node/src
     command: sh -c "yarn prisma migrate dev && yarn prisma db seed && yarn dev"
   db:
     container_name: paybutton-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "3000:3000"
     volumes:
       - .:/home/node/src
-    command: sh -c "yarn prisma migrate dev && yarn prisma db seed && yarn dev"
+    command: sh -c "yarn && yarn prisma migrate dev && yarn prisma db seed && yarn dev"
   db:
     container_name: paybutton-db
     image: mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "3000:3000"
     volumes:
       - .:/app/src
+      - /app/src/prisma/migrations
     command: sh -c "yarn prisma migrate dev && yarn prisma db seed && yarn dev"
   db:
     container_name: paybutton-db


### PR DESCRIPTION
Description: fix for #121 **and other permissions issues**. It removes the multi-stage build since it was giving us too many permission issues to deal with, and workarounds on it, wasting time.

Test Plan: `git clean -fdx`, `docker rm -f $(docker ps -aq)`, `make dev`, then `make check-logs-dev` should show the server booting up. Prisma seeding issues will be fixed on #129.