### PR TITLE
Fix prisma creating multiple migrations.

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,7 +26,7 @@ model PaybuttonAddress {
 model Paybutton {
   id             Int                  @id @default(autoincrement())
   name           String               @db.VarChar(255)
-  uuid           String               @default(dbgenerated("uuid()"))
+  uuid           String               @default(dbgenerated("(uuid())"))
   buttonData     String               @db.LongText
   providerUserId String?              @db.VarChar(255)
   createdAt      DateTime             @default(now())


### PR DESCRIPTION
Description:
Prisma was weirdly creating migrations that did nothing. It was detecting that something had changed with the `Paybutton.uuid` field, then creating a migration to make the DB match the scheme. But the migration did nothing besides redefining `Paybutton.uuid` to exactly what it already was, so if you would try to run migrations again, it would do exactly the same thing over and over.

Test plan:
Run `yarn docker m` , it shouldn't prompt to create a new migration