### PR TITLE
[Issue 141] feat: optional domain for api/app and base path configuration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,7 @@
 DATABASE_URL="mysql://paybutton:paybutton@db:3306/paybutton"
 SHADOW_DATABASE_URL="mysql://paybutton:paybutton@db:3306/prisma-shadow-db"
+APP_NAME="PayButton"
+API_BASE_PATH=/api
+API_DOMAIN=http://localhost:3000
+WEBSITE_DOMAIN=http://localhost:3000
+WEBSITE_BASE_PATH=

--- a/config/appInfo.ts
+++ b/config/appInfo.ts
@@ -1,15 +1,9 @@
-const port: number = (process.env.APP_PORT !== 0 as number || 3000)
-
-const apiBasePath = '/api/auth/'
-
-export const websiteDomain: string =
-    (process.env.APP_URL as boolean && process.env.APP_URL as string) ||
-    (process.env.NEXT_PUBLIC_APP_URL as boolean && process.env.NEXT_PUBLIC_APP_URL as string) ||
-  `http://localhost:${port}`
-
+const websiteBasePath: string = (process.env.WEBSITE_BASE_PATH as boolean) && (process.env.WEBSITE_BASE_PATH as string)
+const apiBasePath: string = (process.env.API_BASE_PATH as boolean) && (process.env.API_BASE_PATH as string)
 export const appInfo = {
-  appName: 'PayButton.io',
-  websiteDomain,
-  apiDomain: websiteDomain,
-  apiBasePath
+  appName: process.env.APP_NAME,
+  apiBasePath: `${apiBasePath}/auth`,
+  apiDomain: process.env.API_DOMAIN,
+  websiteBasePath: `${websiteBasePath}/auth`,
+  websiteDomain: process.env.WEBSITE_DOMAIN
 }

--- a/next.config.js
+++ b/next.config.js
@@ -51,8 +51,16 @@ const {
       async rewrites() {
         return [
           {
-            source: '/api/:path*',
-            destination: `${env.API_DOMAIN}${env.API_BASE_PATH}/:path*`,
+            source: '/address/transactions/:address',
+            destination: `${env.API_BASE_PATH}/transactions/:address`,
+          },
+          {
+            source: '/:path*',
+            destination: '/:path*',
+          },
+          {
+            source: '/:path*',
+            destination: `${env.API_BASE_PATH}/:path*`,
           },
         ]
       },

--- a/next.config.js
+++ b/next.config.js
@@ -52,7 +52,7 @@ const {
         return [
           {
             source: '/api/:path*',
-            destination: `${env.API_BASE_PATH}/:path*`,
+            destination: `${env.API_DOMAIN}${env.API_BASE_PATH}/:path*`,
           },
         ]
       },

--- a/next.config.js
+++ b/next.config.js
@@ -36,12 +36,25 @@ const {
       APPLE_TEAM_ID: process.env.APPLE_TEAM_ID,
       SUPERTOKENS_API_KEY: process.env.SUPERTOKENS_API_KEY,
       SUPERTOKENS_CONNECTION_URI: process.env.SUPERTOKENS_CONNECTION_URI,
-      GRPC_NODE_URL: process.env.GRPC_NODE_URL
+      GRPC_NODE_URL: process.env.GRPC_NODE_URL,
+      WEBSITE_DOMAIN: process.env.WEBSITE_DOMAIN,
+      WEBSITE_BASE_PATH: process.env.WEBSITE_BASE_PATH,
+      API_DOMAIN: process.env.API_DOMAIN,
+      API_BASE_PATH: process.env.API_BASE_PATH,
+      APP_NAME: process.env.APP_NAME
     }
   
-    // next.config.js object
     return {
       env,
-      outputFileTracing: true
+      outputFileTracing: true,
+      basePath: process.env.WEBSITE_BASE_PATH,
+      async rewrites() {
+        return [
+          {
+            source: '/api/:path*',
+            destination: `${env.API_BASE_PATH}/:path*`,
+          },
+        ]
+      },
     }
   }

--- a/pages/api/transactions/[address].ts
+++ b/pages/api/transactions/[address].ts
@@ -1,10 +1,12 @@
 import { NextApiResponse, NextApiRequest } from 'next'
 import { getAddress } from 'services/bchdService'
 import { RESPONSE_MESSAGES } from 'constants/index'
+import Cors from "micro-cors";
 
 const { ADDRESS_NOT_PROVIDED_400 } = RESPONSE_MESSAGES
+const cors = Cors();
 
-export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+export default cors(async (req, res) => {
   if (req.method === 'GET') {
     const address = req.query.address as string
     try {
@@ -23,4 +25,4 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
       }
     }
   }
-}
+})

--- a/pages/api/transactions/[address].ts
+++ b/pages/api/transactions/[address].ts
@@ -1,12 +1,31 @@
 import { NextApiResponse, NextApiRequest } from 'next'
 import { getAddress } from 'services/bchdService'
 import { RESPONSE_MESSAGES } from 'constants/index'
-import Cors from "micro-cors";
+import Cors from 'cors'
 
 const { ADDRESS_NOT_PROVIDED_400 } = RESPONSE_MESSAGES
-const cors = Cors();
+const cors = Cors({
+  methods: ['GET', 'HEAD'],
+})
 
-export default cors(async (req, res) => {
+function runMiddleware(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  fn: Function
+) {
+  return new Promise((resolve, reject) => {
+    fn(req, res, (result: any) => {
+      if (result instanceof Error) {
+        return reject(result)
+      }
+
+      return resolve(result)
+    })
+  })
+}
+
+export default async (req, res) => {
+    await runMiddleware(req, res, cors)
   if (req.method === 'GET') {
     const address = req.query.address as string
     try {
@@ -25,4 +44,4 @@ export default cors(async (req, res) => {
       }
     }
   }
-})
+}

--- a/pages/api/transactions/[address].ts
+++ b/pages/api/transactions/[address].ts
@@ -24,7 +24,7 @@ function runMiddleware(
   })
 }
 
-export default async (req, res) => {
+export default async (req: NextApiRequest, res: NextApiResponse) => {
     await runMiddleware(req, res, cors)
   if (req.method === 'GET') {
     const address = req.query.address as string


### PR DESCRIPTION
Description: Related to #141 (and will help #79), also enables changing api base path if needed (as in api.paybutton.org without subfolders for example).

Proper local environment variables available on `.env.development`

Test Plan: `make dev` should work as usual, adding different environment values on `.env` should break the website/change accordingly (e.g. if you are running on a local server or just changing `hosts` file to map to another domain. Or different subfolders.)

