### PR TITLE
[Issue 145] refactor: validate addresses with `xecaddrjs`

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,10 +1,3 @@
-export const SUPPORTED_CHAINS = [
-  'ecash',
-  'bitcoincash',
-  'bchtest',
-  'bchreg'
-]
-
 export const SUPPORTED_ADDRESS_PATTERN = /((q|p)[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{41}|(Q|P)[QPZRY9X8GF2TVDW0S3JN54KHCE6MUA7L]{41})/
 
 export const RESPONSE_MESSAGES = {
@@ -18,5 +11,6 @@ export const RESPONSE_MESSAGES = {
   TRANSACTION_ID_NOT_PROVIDED_400: { statusCode: 400, message: "'transactionId' not provided." },
   INVALID_CHAIN_SLUG_400: { statusCode: 400, message: 'Invalid chain slug.' },
   INVALID_BUTTON_DATA_400: { statusCode: 400, message: "'buttonData' is not valid JSON." },
-  ADDRESS_NOT_PROVIDED_400: { statusCode: 400, message: "'address' not provided." }
+  ADDRESS_NOT_PROVIDED_400: { statusCode: 400, message: "'address' not provided." },
+  INVALID_ADDRESS_400: { statusCode: 400, message: 'Invalid address.' }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "simpledotcss": "^2.1.0",
     "socket.io": "^4.4.1",
     "supertokens-auth-react": "^0.19.0",
-    "supertokens-node": "^9.0.0"
+    "supertokens-node": "^9.0.0",
+    "xecaddrjs": "^0.0.1"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/pages/api/paybutton/index.ts
+++ b/pages/api/paybutton/index.ts
@@ -13,8 +13,8 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
     } catch (err: any) {
       const parsedErr = parseError(err)
       switch (parsedErr.message) {
-        case RESPONSE_MESSAGES.INVALID_INPUT_400.message:
-          res.status(400).json(RESPONSE_MESSAGES.INVALID_INPUT_400)
+        case RESPONSE_MESSAGES.INVALID_ADDRESS_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.INVALID_ADDRESS_400)
           break
         case RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message:
           res.status(400).json(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400)

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -4,14 +4,15 @@ import paybuttonEndpoint from 'pages/api/paybutton/index'
 import paybuttonIdEndpoint from 'pages/api/paybutton/[id]'
 import transactionsEndpoint from 'pages/api/transactions/[address]'
 import transactionDetailsEndpoint from 'pages/api/transaction/[transactionId]'
-
 import {
+  exampleAddresses,
   testEndpoint,
   clearPaybuttons,
   createPaybuttonForUser,
   countPaybuttons,
   countPaybuttonAddresses
 } from 'tests/utils'
+
 import { RESPONSE_MESSAGES } from 'constants/index'
 
 afterAll(async () => {
@@ -29,7 +30,7 @@ describe('POST /api/paybutton/', () => {
     },
     body: {
       userId: 'test-u-id',
-      addresses: 'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4',
+      addresses: `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`,
       name: 'test-paybutton',
       buttonData: '{"somefield":"somevalue"}'
     }
@@ -46,10 +47,10 @@ describe('POST /api/paybutton/', () => {
     expect(responseData.addresses).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          address: 'qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc'
+          address: exampleAddresses.ecash
         }),
         expect.objectContaining({
-          address: 'qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
+          address: exampleAddresses.bitcoincash
         })
       ])
     )
@@ -61,7 +62,7 @@ describe('POST /api/paybutton/', () => {
     baseRequestOptions.body = {
       userId: 'test-u-id',
       name: 'test-paybutton-no-button-data',
-      addresses: 'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc'
+      addresses: `ectest:${exampleAddresses.ectest}`
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)
     const responseData = res._getJSONData()
@@ -72,7 +73,7 @@ describe('POST /api/paybutton/', () => {
     expect(responseData.addresses).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          address: 'qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc'
+          address: exampleAddresses.ectest
         })
       ])
     )
@@ -82,7 +83,7 @@ describe('POST /api/paybutton/', () => {
     baseRequestOptions.body = {
       userId: '',
       name: 'test-paybutton',
-      addresses: 'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
+      addresses: `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)
     expect(res.statusCode).toBe(400)
@@ -94,7 +95,7 @@ describe('POST /api/paybutton/', () => {
     baseRequestOptions.body = {
       userId: 'test-u-id',
       name: '',
-      addresses: 'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
+      addresses: `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)
     expect(res.statusCode).toBe(400)
@@ -106,7 +107,7 @@ describe('POST /api/paybutton/', () => {
     baseRequestOptions.body = {
       userId: 'test-u-id',
       name: 'test-paybutton',
-      addresses: 'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
+      addresses: `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)
     expect(res.statusCode).toBe(400)
@@ -135,14 +136,14 @@ describe('POST /api/paybutton/', () => {
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)
     expect(res.statusCode).toBe(400)
     const responseData = res._getJSONData()
-    expect(responseData.message).toBe(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    expect(responseData.message).toBe(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
   })
 
   it('Fail with invalid buttonData', async () => {
     baseRequestOptions.body = {
       userId: 'test-u-id',
       name: 'test-paybutton',
-      addresses: 'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4',
+      addresses: `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`,
       buttonData: '{invalidjson'
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -30,7 +30,7 @@ describe('POST /api/paybutton/', () => {
     },
     body: {
       userId: 'test-u-id',
-      addresses: `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`,
+      addresses: `${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`,
       name: 'test-paybutton',
       buttonData: '{"somefield":"somevalue"}'
     }
@@ -47,10 +47,10 @@ describe('POST /api/paybutton/', () => {
     expect(responseData.addresses).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          address: exampleAddresses.ecash
+          address: `ecash:${exampleAddresses.ecash}`
         }),
         expect.objectContaining({
-          address: exampleAddresses.bitcoincash
+          address: `bitcoincash:${exampleAddresses.bitcoincash}`
         })
       ])
     )
@@ -73,7 +73,7 @@ describe('POST /api/paybutton/', () => {
     expect(responseData.addresses).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          address: exampleAddresses.ectest
+          address: `ectest:${exampleAddresses.ectest}`
         })
       ])
     )

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -1,115 +1,112 @@
 import * as v from 'utils/validators'
 import { RESPONSE_MESSAGES } from 'constants/index'
 import { Prisma } from '@prisma/client'
+import { exampleAddresses } from 'tests/utils'
 
-describe('parseAddresses', () => {
-  it('Accept example addresses', () => {
-    const addressListString = 'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
-    expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+describe('parseAddress', () => {
+  it('Accept example addresses without prefix', () => {
+    for (const [key, value] of Object.entries(exampleAddresses)) {
+      expect(v.parseAddress(value)).toStrictEqual(key + ':' + value)
+    }
+  })
+  it('Accept example addresses with prefix', () => {
+    for (const [key, value] of Object.entries(exampleAddresses)) {
+      expect(v.parseAddress(key + ':' + value)).toStrictEqual(key + ':' + value)
+    }
   })
 
-  it('Accept addresses for testnets', () => {
-    const addressListString = 'bchreg:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\nbchtest:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
-    expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+  it('Accept example address uppercase', () => {
+    expect(
+      v.parseAddress(exampleAddresses.ecash.toUpperCase())
+    ).toStrictEqual('ecash:' + exampleAddresses.ecash)
   })
 
-  it('Accept example addresses uppercase', () => {
-    const addressListString = 'ecash:QPZ274AAJ98XXNNKUS8HZV367ZA28J900C7TV5V8PC\nbitcoincash:QZ0DQJF6W6DP0LCS8CC68S720Q9DV5ZV8CS8FC0LT4'
-    expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
-  })
-
-  it('Accept example address one uppercase other lowercase', () => {
-    const addressListString = 'ecash:QPZ274AAJ98XXNNKUS8HZV367ZA28J900C7TV5V8PC\nbitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
-    expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
-  })
-
-  it('Accept chain uppercase', () => {
-    const addressListString = 'ECASH:QPZ274AAJ98XXNNKUS8HZV367ZA28J900C7TV5V8PC\nBiTcoinCash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
-    expect(v.parseAddresses(addressListString)).toStrictEqual(addressListString.split('\n'))
+  it('Accept example address with uppercase characters in chain', () => {
+    expect(
+      v.parseAddress('eCaSh:' + exampleAddresses.ecash)
+    ).toStrictEqual('ecash:' + exampleAddresses.ecash)
+    expect(
+      v.parseAddress('BITCOINCASH:' + exampleAddresses.bitcoincash)
+    ).toStrictEqual('bitcoincash:' + exampleAddresses.bitcoincash)
   })
 
   it('Reject address with disallowed characters', () => {
     expect(() => {
-      v.parseAddresses((
+      v.parseAddress((
         'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
         'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs1fc0lt4' // this has '1' in it
       ))
-    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
     expect(() => {
-      v.parseAddresses((
+      v.parseAddress((
         'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
         'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8csbfc0lt4' // this has 'b' in it
       ))
-    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
     expect(() => {
-      v.parseAddresses((
+      v.parseAddress((
         'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
         'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8csifc0lt4' // this has 'i' in it
       ))
-    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
     expect(() => {
-      v.parseAddresses((
+      v.parseAddress((
         'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
         'bitcoincash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8csofc0lt4' // this has 'o' in it
       ))
-    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
+  })
+
+  it('Reject address with wrong chain prefix', () => {
+    expect(() => {
+      v.parseAddress('bitcoincash:' + exampleAddresses.ecash)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
+    expect(() => {
+      v.parseAddress('bitcoincash:' + exampleAddresses.bchtest)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
+    expect(() => {
+      v.parseAddress('ecash:' + exampleAddresses.bitcoincash)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
+    expect(() => {
+      v.parseAddress('ecash:' + exampleAddresses.ectest)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
+    expect(() => {
+      v.parseAddress('bchtest:' + exampleAddresses.bitcoincash)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
+    expect(() => {
+      v.parseAddress('ectest:' + exampleAddresses.ecash)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
   })
 
   it('Reject mixed case address', () => {
+    expect(v.parseAddress(exampleAddresses.ecash.toUpperCase())).toStrictEqual('ecash:' + exampleAddresses.ecash)
     expect(() => {
-      v.parseAddresses((
-        'bitcoincash:qpz274aaJ98XXNNKUS8HZV367ZA28J900C7tv5v8pc'
+      v.parseAddress((
+        'bitcoincash:Qrju9PGZn3m84q57ldjvxph30zrm8q7dlc8r8a3eyp'
       ))
-    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
   })
 
   it('Reject legacy address', () => {
     expect(() => {
-      v.parseAddresses((
+      v.parseAddress((
         'ecash:1Nkmzb49MCUJThkpNWaVX9xCPmZvMKeu7Q'
       ))
-    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-  })
-
-  it('Reject address without chain', () => {
-    expect(() => {
-      v.parseAddresses((
-        'qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc'
-      ))
-    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
   })
 
   it('Reject non-supported chain', () => {
     expect(() => {
-      v.parseAddresses((
-        'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
-        'bitcoin:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc' // this is not
+      v.parseAddress((
+        'bitcoin:qrju9pgzn3m84q57ldjvxph30zrm8q7dlc8r8a3eyp'
       ))
-    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-  })
-
-  it('Reject non-supported address format', () => {
-    expect(() => {
-      v.parseAddresses((
-        'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' + // this is valid
-        'bitcoincash:bc1qvwhdfujkyulp8jxuql7h55zzxlsap6zg9f5wmj' // this is not
-      ))
-    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
-  })
-
-  it('Reject valid addresses of repeated chain', () => {
-    expect(() => {
-      v.parseAddresses((
-        'ecash:qpz274aaj98xxnnkus8hzv367za28j900c7tv5v8pc\n' +
-        'ecash:qz0dqjf6w6dp0lcs8cc68s720q9dv5zv8cs8fc0lt4'
-      ))
-    }).toThrow(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
   })
 
   it('Reject empty string', () => {
     expect(() => {
-      v.parseAddresses('')
-    }).toThrow(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
+      v.parseAddress('')
+    }).toThrow(RESPONSE_MESSAGES.ADDRESS_NOT_PROVIDED_400.message)
   })
 })
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -39,3 +39,10 @@ export const countPaybuttonAddresses = async (): Promise<number> => {
   const paybuttonAddressList = await prisma.paybuttonAddress.findMany({})
   return paybuttonAddressList.length
 }
+
+export const exampleAddresses = {
+  bitcoincash: 'qrju9pgzn3m84q57ldjvxph30zrm8q7dlc8r8a3eyp',
+  bchtest: 'qrcn673f42dl4z8l3xpc0gr5kpxg7ea5mqhj3atxd3',
+  ecash: 'qz3ye4namaqlca8zgvdju8uqa2wwx8twd5y8wjd9ru',
+  ectest: 'qrfekq9s0c8tcuh75wpcxqnyl5e7dhqk4gq6pjct44'
+}

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,41 +1,52 @@
-import { SUPPORTED_CHAINS, SUPPORTED_ADDRESS_PATTERN, RESPONSE_MESSAGES } from 'constants/index'
+import { RESPONSE_MESSAGES, SUPPORTED_ADDRESS_PATTERN } from 'constants/index'
 import { Prisma } from '@prisma/client'
 import { CreatePaybuttonInput } from 'services/paybuttonsService'
+import xecaddr from 'xecaddrjs'
 
-/* The functions here defined should validate the data structure / syntax of an input by throwing
- * an error in case something is different from the expected. The prefix for each function name
- * here defined shall be:
- * - 'parse', if the function validates the input and also uses it to create some other output;
- * - 'validate', if the function only validates the input
- */
+/* The functions exported here should validate the data structure / syntax of an
+ * input by throwing an error in case something is different from the expected.
+ * The prefix for each function name * here defined shall be:
+ * - 'parse', if the function validates the input and transforms it into another output;
+ * - 'validate', if the function only validates the input and returns `true` or `false`.
+--------------------------------------------------------------------------------------- */
 
-export const parseAddresses = function (prefixedAddressString: string | undefined): string[] {
-  /**
-   * Disallow addresses without a 'chain:' prefix
-   * Disallow addresses with an unknown prefix
-   * Disallow  addresses is in an invalid format
-   * Disallow  addresses with repeated prefixes (chains)
-   **/
-  if (prefixedAddressString === '' || prefixedAddressString === undefined) {
-    throw new Error(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
-  }
-  const prefixedAddressList = prefixedAddressString.trim().split('\n')
-  const seenPrefixes = new Set()
-  for (let i = 0; i < prefixedAddressList.length; i++) {
-    const addressWithPrefix = prefixedAddressList[i]
-    let [prefix, address] = addressWithPrefix.split(':')
-    prefix = prefix.toLowerCase()
-    if (
-      !addressWithPrefix.includes(':') ||
-      !SUPPORTED_CHAINS.includes(prefix) ||
-      (address.match(SUPPORTED_ADDRESS_PATTERN) == null) ||
-      seenPrefixes.has(prefix)
-    ) {
-      throw new Error(RESPONSE_MESSAGES.INVALID_INPUT_400.message)
+const getAddressPrefix = function (addressString: string): string {
+  const format = xecaddr.detectAddressFormat(addressString)
+  const network = xecaddr.detectAddressNetwork(addressString)
+  if (format === xecaddr.Format.Xecaddr) {
+    if (network === xecaddr.Network.Mainnet) {
+      return 'ecash'
+    } else if (network === xecaddr.Network.Testnet) {
+      return 'ectest'
     }
-    seenPrefixes.add(prefix)
+  } else if (format === xecaddr.Format.Cashaddr) {
+    if (network === xecaddr.Network.Mainnet) {
+      return 'bitcoincash'
+    } else if (network === xecaddr.Network.Testnet) {
+      return 'bchtest'
+    }
   }
-  return prefixedAddressList
+  throw new Error(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
+}
+
+/* Validates the address and adds a prefix to it, if it does not have it already.
+ */
+export const parseAddress = function (addressString: string): string {
+  if (addressString === '') throw new Error(RESPONSE_MESSAGES.ADDRESS_NOT_PROVIDED_400.message)
+  let parsedAddress: string
+  if (
+    addressString.match(SUPPORTED_ADDRESS_PATTERN) != null &&
+      xecaddr.isValidAddress(addressString.toLowerCase()) as boolean
+  ) {
+    if (addressString.includes(':')) {
+      parsedAddress = addressString
+    } else {
+      parsedAddress = getAddressPrefix(addressString.toLowerCase()) + ':' + addressString
+    }
+  } else {
+    throw new Error(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
+  }
+  return parsedAddress.toLowerCase()
 }
 
 export const parseButtonData = function (buttonDataString: string | undefined): string {
@@ -74,7 +85,8 @@ export interface POSTParameters {
 export const parsePaybuttonPOSTRequest = function (params: POSTParameters): CreatePaybuttonInput {
   if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
-  const parsedAddresses = parseAddresses(params.addresses)
+  if (params.addresses === '' || params.addresses === undefined) throw new Error(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
+  const parsedAddresses = params.addresses.trim().split('\n').map((addr) => parseAddress(addr))
   const parsedButtonData = parseButtonData(params.buttonData)
   return {
     userId: params.userId,

--- a/xecaddrjs.d.ts
+++ b/xecaddrjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'xecaddrjs';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,6 +1900,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-x@^3.0.2:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
+  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -1909,6 +1916,11 @@ base64id@2.0.0, base64id@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
   integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
+
+big-integer@1.6.36:
+  version "1.6.36"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.36.tgz#78631076265d4ae3555c04f85e7d9d2f3a071a36"
+  integrity sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -2003,6 +2015,22 @@ bs-logger@0.x:
   dependencies:
     fast-json-stable-stringify "2.x"
 
+bs58@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
+  dependencies:
+    base-x "^3.0.2"
+
+bs58check@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
+  integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
+  dependencies:
+    bs58 "^4.0.0"
+    create-hash "^1.1.0"
+    safe-buffer "^5.1.2"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -2027,6 +2055,14 @@ buffer@^5.6.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bytebuffer@~5:
   version "5.0.1"
@@ -2152,6 +2188,14 @@ ci-info@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.1.tgz#58331f6f472a25fe3a50a351ae3052936c2c7f32"
   integrity sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==
+
+cipher-base@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 cjs-module-lexer@^1.0.0:
   version "1.2.2"
@@ -2397,6 +2441,17 @@ country-flag-icons@^1.0.2:
   resolved "https://registry.yarnpkg.com/country-flag-icons/-/country-flag-icons-1.4.26.tgz#e324b2e79c00f180d4f44a8ce034a3e824097619"
   integrity sha512-fUBQ58zfQsSL12ErkFSfBxnQZapzdC8+5ZKqhD1z0EHqPnOuiFl7nZTv8Gqpms+jvweP+pbCYGp7G4aiO9eiMw==
 
+create-hash@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
+    sha.js "^2.4.0"
+
 cross-env@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
@@ -2623,6 +2678,13 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+ecashaddrjs@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/ecashaddrjs/-/ecashaddrjs-1.0.7.tgz#22dc0842d0c3e186f9f160ca55299b679ab17d8a"
+  integrity sha512-KsvHYLlYtLr/GBkEPiwwQDIDBzqRx61qC34n1puHKOjVE4Uwg3syHccjFCqNynLa6T6xI0Rd7ByCRUJcuJcoIw==
+  dependencies:
+    big-integer "1.6.36"
 
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
@@ -3278,6 +3340,15 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash-base@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
+  dependencies:
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    safe-buffer "^5.2.0"
+
 helmet@*:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/helmet/-/helmet-5.1.0.tgz#e98a5d4bf89ab8119c856018a3bcc82addadcd47"
@@ -3379,7 +3450,7 @@ iconv-lite@^0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -3438,7 +3509,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4407,6 +4478,15 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+md5.js@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
+
 mdn-data@2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
@@ -5234,7 +5314,7 @@ react@^16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-readable-stream@^3.6.0:
+readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -5369,6 +5449,14 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+ripemd160@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+
 rtl-css-js@^1.14.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.15.0.tgz#680ed816e570a9ebccba9e1cd0f202c6a8bb2dc0"
@@ -5383,7 +5471,7 @@ rxjs@^7.5.5:
   dependencies:
     tslib "^2.1.0"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -5494,7 +5582,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sha.js@^2.4.11:
+sha.js@^2.4.0, sha.js@^2.4.11:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
@@ -5699,6 +5787,14 @@ statuses@2.0.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+stream-browserify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
+  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
+  dependencies:
+    inherits "~2.0.4"
+    readable-stream "^3.5.0"
 
 string-argv@^0.3.1:
   version "0.3.1"
@@ -6290,6 +6386,16 @@ xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xecaddrjs@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/xecaddrjs/-/xecaddrjs-0.0.1.tgz#f28dd5565d87526dd2000ebd2a4c3ce0fbbda728"
+  integrity sha512-0cZA2ugfuAeWdLoyoq3siVbTUn5mFb5xOjs/bUrZhRdmMy5BdIGMNKBdecwfX4WBem6lkZEYBxTA9aI+jubRog==
+  dependencies:
+    bs58check "2.1.2"
+    buffer "^6.0.3"
+    ecashaddrjs "^1.0.7"
+    stream-browserify "^3.0.0"
 
 xss@^1.0.8:
   version "1.0.11"


### PR DESCRIPTION
**Description:**
Solves #145. Validation is now done by the `xecaddrjs` module. Now addresses without the chain prefix are accepted and their network is inferred, whenever possíble.

Remarks:
Since the functions in `xecaddrjs` do not differentiate the `bchreg` from the `bchtest` networks, an unprefixed test BCH address is interpreted as of the type `bchtest`. 


**Test Plan:**
All must be covered by the tests.

