### PR TITLE
Fix: add --forceExit flag to ignore pending log issue on gh test actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint-master:
 	npx --yes ts-standard --stdin --stdin-filename DIFF
 
 test-unit:
-	DATABASE_URL="mysql://paybutton-test:paybutton-test@db:3306/paybutton-test" npx ts-node -O '{"module":"commonjs"}' node_modules/jest/bin/jest.js tests/unittests
+	DATABASE_URL="mysql://paybutton-test:paybutton-test@db:3306/paybutton-test" npx ts-node -O '{"module":"commonjs"}' node_modules/jest/bin/jest.js tests/unittests --forceExit
 
 test-integration:
 	sleep 15

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pretest": "dotenv -e .env.test -- prisma migrate reset --force",
     "prisma": "dotenv -e .env.development -- prisma",
     "docker": "./scripts/docker-exec-shortcuts.sh",
-    "ci:integration:test": "yarn pretest && dotenv -e .env.test -- ts-node -O '{\"module\":\"commonjs\"}' node_modules/jest/bin/jest.js tests/integration-tests"
+    "ci:integration:test": "yarn pretest && dotenv -e .env.test -- ts-node -O '{\"module\":\"commonjs\"}' node_modules/jest/bin/jest.js tests/integration-tests --forceExit"
   },
   "dependencies": {
     "@data-driven-forms/mui-component-mapper": "^3.16.10",


### PR DESCRIPTION
**Description:**
Sometimes the github checks would fail with the following error message:
```
  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "grpc-bchrpc-node: failed network integrity check".
```

This happened because the `grpc-bchrpc-node` module [client constructor](https://github.com/simpleledgerinc/grpc-bchrpc-node/blob/f26e8b3bc8e45c0a96bb73756298fc4a50754e51/src/client.ts#L32) checks for the network integrity automatically upon the declaration of a `new GrpcClient`, and if it fails, it tries to print the message `"grpc-bchrpc-node: failed network integrity check"`.

Since this check is not optional and it's coded in the `GrpcClient` constructor, mocking the method `_checkNetworkIntegrity` does not work, because the client variable is created before some of its methods are overwritten with the mock (using `rewire`).

Therefore, the solution being applied here is to force jest to exit pending processes after the tests are completed. It's not the ideal solution, so if anyone sees a better way of solving it, we should try.

**Test plan:**
The github "Checks" should always pass.