### PR TITLE
[Issue #200] fix: seeds networkId

### DIFF
--- a/prisma/seeds/networks.ts
+++ b/prisma/seeds/networks.ts
@@ -1,5 +1,12 @@
 export const networks = [
   {
+    slug: 'ecash',
+    ticker: 'xec',
+    title: 'eCash',
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
     slug: 'bitcoincash',
     ticker: 'bch',
     title: 'Bitcoin Cash',
@@ -7,9 +14,9 @@ export const networks = [
     updatedAt: new Date()
   },
   {
-    slug: 'ecash',
+    slug: 'ectest',
     ticker: 'xec',
-    title: 'eCash',
+    title: 'eCash Testnet Faucet',
     createdAt: new Date(),
     updatedAt: new Date()
   },
@@ -24,13 +31,6 @@ export const networks = [
     slug: 'bchreg',
     ticker: 'bch',
     title: 'Bitcoin Cash Regtest',
-    createdAt: new Date(),
-    updatedAt: new Date()
-  },
-  {
-    slug: 'ectest',
-    ticker: 'xec',
-    title: 'eCash Testnet Faucet',
     createdAt: new Date(),
     updatedAt: new Date()
   }

--- a/prisma/seeds/paybuttons.ts
+++ b/prisma/seeds/paybuttons.ts
@@ -23,7 +23,7 @@ export const addresses = [
   },
   {
     address: 'bitcoincash:qzqh7ej2vz26a9xaxq7capzfwgxt5gem9g8rvfxc5t',
-    networkId: 1
+    networkId: 2
   }
 ]
 


### PR DESCRIPTION
**Description:**
Solves #200 by making `ecash` the network with `id == 1` and the BCH seed address to have `networkId: 2`

**Test plan**:
Nothing should change.