### PR TITLE
test: mock GrpcClient from grpc-bchrpc-node

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   modulePaths: ['./'],
-  setupFilesAfterEnv: ["./tests/setup.js"]
+  setupFilesAfterEnv: ["./tests/setup.js", "./tests/setupMocks.ts"]
 };

--- a/tests/mockGrpcClient.ts
+++ b/tests/mockGrpcClient.ts
@@ -1,0 +1,66 @@
+import { mockedGrpc, unspentOutputFromObject, transactionFromObject } from './mockedObjects'
+import {
+  GetTransactionResponse,
+  GetAddressTransactionsResponse,
+  GetAddressUnspentOutputsResponse
+} from 'grpc-bchrpc-node'
+
+export default class MockGrpcClient {
+  private _checkNetworkIntegrity = false
+
+  public get checkNetworkIntegrity (): boolean {
+    return this._checkNetworkIntegrity
+  }
+
+  public set checkNetworkIntegrity (value) {
+    this._checkNetworkIntegrity = value
+  }
+
+  getAddressTransactions (_: object): GetAddressTransactionsResponse {
+    const res = new GetAddressTransactionsResponse()
+    res.setConfirmedTransactionsList([mockedGrpc.transaction1, mockedGrpc.transaction2])
+    return res
+  }
+
+  getAddressUtxos (_: object): GetAddressUnspentOutputsResponse {
+    const res = new GetAddressUnspentOutputsResponse()
+    res.setOutputsList([
+      unspentOutputFromObject({
+        pubkeyScript: 'dqkUYF1GSq6KqSQSKPbQtcOJWRBPEFaIrA==',
+        value: 547,
+        isCoinbase: false,
+        blockHeight: 684161
+      }),
+      unspentOutputFromObject({
+        pubkeyScript: 'dqkUYF1GSq6KqSQSKPbQtcOJWRBPEFaIrA==',
+        value: 122,
+        isCoinbase: false,
+        blockHeight: 657711
+      }),
+      unspentOutputFromObject({
+        pubkeyScript: 'dqkUYF1GSq6KqSQSKPbQtcOJWRBPEFaIrA==',
+        value: 1111,
+        isCoinbase: false,
+        blockHeight: 596627
+      })
+    ])
+    return res
+  }
+
+  getTransaction (_: object): GetTransactionResponse {
+    const res = new GetTransactionResponse()
+    res.setTransaction(transactionFromObject({
+      hash: 'hu9m3BZg/zlxis7ehc0x/+9qELXC8dkbimOtc5v598s=',
+      version: 2,
+      lockTime: 0,
+      size: 518,
+      timestamp: 1653653100,
+      confirmations: 0,
+      blockHeight: 0,
+      blockHash: '',
+      inputsList: [],
+      outputsList: []
+    }))
+    return res
+  }
+}

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -2,10 +2,7 @@
 // GRPC-BCHRPC
 import {
   Transaction,
-  UnspentOutput,
-  GetTransactionResponse,
-  GetAddressTransactionsResponse,
-  GetAddressUnspentOutputsResponse
+  UnspentOutput
 } from 'grpc-bchrpc-node'
 
 import { Prisma } from '@prisma/client'
@@ -133,7 +130,7 @@ export const mockedTransaction = {
 }
 
 // BCH GRPC
-const unspentOutputFromObject = (obj: UnspentOutput.AsObject): UnspentOutput => {
+export const unspentOutputFromObject = (obj: UnspentOutput.AsObject): UnspentOutput => {
   const uo = new UnspentOutput()
   uo.setPubkeyScript(obj.pubkeyScript)
   uo.setValue(obj.value)
@@ -164,7 +161,7 @@ const inputFromObject = (obj: Transaction.Input.AsObject): Transaction.Input => 
   return inp
 }
 
-const transactionFromObject = (obj: Transaction.AsObject): Transaction => {
+export const transactionFromObject = (obj: Transaction.AsObject): Transaction => {
   const t = new Transaction()
   t.setHash(obj.hash)
   t.setVersion(obj.version)
@@ -275,50 +272,5 @@ export const mockedGrpc = {
       }
     ],
     outputsList: []
-  }),
-  getAddressTransactions: (_: object) => {
-    const res = new GetAddressTransactionsResponse()
-    res.setConfirmedTransactionsList([mockedGrpc.transaction1, mockedGrpc.transaction2])
-    return res
-  },
-  getAddressUtxos: (_: object) => {
-    const res = new GetAddressUnspentOutputsResponse()
-    res.setOutputsList([
-      unspentOutputFromObject({
-        pubkeyScript: 'dqkUYF1GSq6KqSQSKPbQtcOJWRBPEFaIrA==',
-        value: 547,
-        isCoinbase: false,
-        blockHeight: 684161
-      }),
-      unspentOutputFromObject({
-        pubkeyScript: 'dqkUYF1GSq6KqSQSKPbQtcOJWRBPEFaIrA==',
-        value: 122,
-        isCoinbase: false,
-        blockHeight: 657711
-      }),
-      unspentOutputFromObject({
-        pubkeyScript: 'dqkUYF1GSq6KqSQSKPbQtcOJWRBPEFaIrA==',
-        value: 1111,
-        isCoinbase: false,
-        blockHeight: 596627
-      })
-    ])
-    return res
-  },
-  getTransaction: (_: object) => {
-    const res = new GetTransactionResponse()
-    res.setTransaction(transactionFromObject({
-      hash: 'hu9m3BZg/zlxis7ehc0x/+9qELXC8dkbimOtc5v598s=',
-      version: 2,
-      lockTime: 0,
-      size: 518,
-      timestamp: 1653653100,
-      confirmations: 0,
-      blockHeight: 0,
-      blockHash: '',
-      inputsList: [],
-      outputsList: []
-    }))
-    return res
-  }
+  })
 }

--- a/tests/setupMocks.ts
+++ b/tests/setupMocks.ts
@@ -1,0 +1,7 @@
+import MockGrpcClient from './mockGrpcClient'
+
+jest.mock('grpc-bchrpc-node', () => ({
+  ...jest.requireActual('grpc-bchrpc-node'),
+  _HAS_NETWORK_INTEGRITY: false,
+  GrpcClient: jest.fn(() => new MockGrpcClient())
+}))

--- a/tests/unittests/grpcService.test.ts
+++ b/tests/unittests/grpcService.test.ts
@@ -1,9 +1,5 @@
-import rewire from 'rewire'
 import { mockedGrpc, mockedBCHAddress, mockedXECAddress } from '../mockedObjects'
-const grpcService = rewire('../../services/grpcService')
-
-grpcService.__set__('grpcBCH', mockedGrpc)
-grpcService.__set__('grpcXEC', mockedGrpc)
+import grpcService from '../../services/grpcService'
 
 describe('Test service returned objects consistency', () => {
   it('test getAddress for real address', async () => {


### PR DESCRIPTION
Description: related to #169 #195 and many others. This PR adds a mock for GrpcClient, enabling more test cases for the API, removing the need for the `rewire` library or other workarounds.

Test Plan: `make dev`, then `yarn docker test`. All tests should pass. No network integrity error should appear in the logs.