### PR TITLE
[Issue #215]feat:close mobile menu when item is clicked

### DIFF
--- a/components/Sidebar/index.tsx
+++ b/components/Sidebar/index.tsx
@@ -87,6 +87,10 @@ const Sidebar = ({chart, setChart, loggedin}) => {
 
   const isBreakpoint = useMediaQuery(1200)
 
+  const setCheckBox = () => {
+    document.getElementById("menu__toggle").checked = false
+  }
+
   return (
   <>
   {loggedin === undefined ? null :
@@ -109,9 +113,9 @@ const Sidebar = ({chart, setChart, loggedin}) => {
           <Image className={style.image} src={logoImageSource} alt='PayButton' width={140} height={26} />
         </section>
         }
-     
+
         <nav>
-          <ul className={style.ul}>
+          <ul className={style.ul} onClick={isBreakpoint ? () => { setMenu(!menu); setCheckBox() } : null}>
             {MENU_ITEMS.map(itemName =>
               <MenuItem key={itemName.name} name={itemName.name} image={itemName.image} />
             )}


### PR DESCRIPTION
Improvement to close the mobile menu when a nav item is selected.
Test plan: Run the app in desktop and mobile size and ensure the menu works as intended