### PR TITLE
[Issue #151] feat: Create dashboard API endpoint

### DIFF
--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -1,0 +1,134 @@
+import * as paybuttonsService from 'services/paybuttonsService'
+import * as addressesService from 'services/addressesService'
+import { Prisma, Transaction } from '@prisma/client'
+import moment from 'moment'
+
+const DUMMY_XEC_PRICE = 0.00003918
+const DUMMY_BCH_PRICE = 132
+
+interface ChartData {
+  labels: string[]
+  datasets: [
+    {
+      data: number[] | Prisma.Decimal[]
+      borderColor: string
+    }
+  ]
+}
+
+interface PeriodData {
+  revenue: ChartData
+  payments: ChartData
+  totalRevenue: number
+  totalPayments: number
+}
+
+interface DashboardData {
+  thirtyDays: PeriodData
+  year: PeriodData
+  sevenDays: PeriodData
+  total: {
+    revenue: Prisma.Decimal
+    payments: number
+    buttons: number
+  }
+}
+
+const getChartLabels = function (n: number, periodString: string, formatString = 'M/D'): string[] {
+  return [...new Array(n)].map((i, idx) => moment().startOf('day').subtract(idx, periodString).format(formatString))
+}
+
+const getChartRevenuePaymentData = function (n: number, periodString: string, transactions: Transaction[]): any {
+  const revenueArray: Prisma.Decimal[] = []
+  const paymentsArray: number[] = []
+  const _ = [...new Array(n)]
+  _.forEach((i, idx) => {
+    const lowerThreshold = moment().startOf('day').subtract(idx + 1, periodString)
+    const upperThreshold = moment().startOf('day').subtract(idx, periodString)
+    const periodTransactionAmountArray = filterLastTransactions(lowerThreshold, upperThreshold, transactions).map((t) => t.amount)
+    const revenue = periodTransactionAmountArray.reduce((a, b) => {
+      return a.plus(b)
+    }, new Prisma.Decimal(0))
+    const paymentCount = periodTransactionAmountArray.length
+    revenueArray.push(revenue)
+    paymentsArray.push(paymentCount)
+  })
+  return {
+    revenue: revenueArray,
+    payments: paymentsArray
+  }
+}
+
+const filterLastTransactions = function (lowerThreshold: moment.Moment, upperThreshold: moment.Moment, transactions: Transaction[]): Transaction[] {
+  return transactions.filter((t) => {
+    const tMoment = moment(t.timestamp * 1000)
+    return lowerThreshold < tMoment && tMoment < upperThreshold
+  })
+}
+
+const getChartData = function (n: number, periodString: string, dataArray: number[] | Prisma.Decimal[], borderColor: string, formatString = 'M/D'): ChartData {
+  return {
+    labels: getChartLabels(n, periodString, formatString),
+    datasets: [
+      {
+        data: dataArray,
+        borderColor
+      }
+    ]
+  }
+}
+
+const getPeriodData = function (n: number, periodString: string, transactions: Transaction[], borderColor: string, formatString = 'M/D'): PeriodData {
+  const revenuePaymentData = getChartRevenuePaymentData(n, periodString, transactions)
+  const revenue = getChartData(n, periodString, revenuePaymentData.revenue, borderColor, formatString)
+  const payments = getChartData(n, periodString, revenuePaymentData.payments, borderColor, formatString)
+  return {
+    revenue,
+    payments,
+    totalRevenue: 3, // revenue.datasets[0].data, //.reduce((a, b) => a.plus(b))
+    totalPayments: 4 // revenue.datasets[0].data, //.reduce((a, b) => a.plus(b))
+  }
+}
+
+const getUserDashboardData = async function (userId: string): Promise<DashboardData> {
+  const buttonsCount = (await paybuttonsService.fetchPaybuttonArrayByUserId(userId)).length
+  const addresses = await addressesService.fetchAllUserAddresses(userId, true)
+  const XECAddresses = addresses.filter((addr) => addr.id === 1)
+  const BCHAddresses = addresses.filter((addr) => addr.id === 2)
+  const BCHTransactions = Array.prototype.concat.apply([], BCHAddresses.map((addr) => addr.transactions))
+  const XECTransactions = Array.prototype.concat.apply([], XECAddresses.map((addr) => addr.transactions))
+  const transactionsInUSD = BCHTransactions.map((t) => {
+    t.amount = t.amount.times(DUMMY_BCH_PRICE)
+    return t
+  }).concat(XECTransactions.map((t) => {
+    t.amount = t.amount.times(DUMMY_XEC_PRICE)
+    return t
+  }))
+
+  const totalRevenue = transactionsInUSD.map((t) => t.amount).reduce((a, b) => a.plus(b))
+
+  const thirtyDays: PeriodData = getPeriodData(30, 'days', transactionsInUSD, '#66fe91')
+  const sevenDays: PeriodData = getPeriodData(7, 'days', transactionsInUSD, '#66fe91')
+  const year: PeriodData = getPeriodData(12, 'months', transactionsInUSD, '#66fe91', 'MMM')
+
+  return {
+    thirtyDays,
+    sevenDays,
+    year,
+    total: {
+      revenue: totalRevenue,
+      payments: transactionsInUSD.length,
+      buttons: buttonsCount
+    }
+  }
+}
+
+export default async (req: any, res: any): Promise<void> => {
+  if (req.method === 'GET') {
+    // await setSession(req, res)
+    // let userId = req.session.userId
+    const userId = 'dev-uid'
+
+    res.status(200).json(await getUserDashboardData(userId))
+  }
+}

--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -1,7 +1,7 @@
 import * as paybuttonsService from 'services/paybuttonsService'
 import * as addressesService from 'services/addressesService'
 import { Prisma, Transaction } from '@prisma/client'
-import moment from 'moment'
+import moment, { DurationInputArg2 } from 'moment'
 
 const DUMMY_XEC_PRICE = 0.00003918
 const DUMMY_BCH_PRICE = 132
@@ -35,7 +35,7 @@ interface DashboardData {
 }
 
 const getChartLabels = function (n: number, periodString: string, formatString = 'M/D'): string[] {
-  return [...new Array(n)].map((i, idx) => moment().startOf('day').subtract(idx, periodString).format(formatString))
+  return [...new Array(n)].map((i, idx) => moment().startOf('day').subtract(idx, periodString as DurationInputArg2).format(formatString))
 }
 
 const getChartRevenuePaymentData = function (n: number, periodString: string, transactions: Transaction[]): any {
@@ -43,8 +43,8 @@ const getChartRevenuePaymentData = function (n: number, periodString: string, tr
   const paymentsArray: number[] = []
   const _ = [...new Array(n)]
   _.forEach((i, idx) => {
-    const lowerThreshold = moment().startOf('day').subtract(idx + 1, periodString)
-    const upperThreshold = moment().startOf('day').subtract(idx, periodString)
+    const lowerThreshold = moment().startOf('day').subtract(idx + 1, periodString as DurationInputArg2)
+    const upperThreshold = moment().startOf('day').subtract(idx, periodString as DurationInputArg2)
     const periodTransactionAmountArray = filterLastTransactions(lowerThreshold, upperThreshold, transactions).map((t) => t.amount)
     const revenue = periodTransactionAmountArray.reduce((a, b) => {
       return a.plus(b)

--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -19,7 +19,7 @@ interface ChartData {
 interface PeriodData {
   revenue: ChartData
   payments: ChartData
-  totalRevenue: number
+  totalRevenue: Prisma.Decimal
   totalPayments: number
 }
 
@@ -82,11 +82,12 @@ const getPeriodData = function (n: number, periodString: string, transactions: T
   const revenuePaymentData = getChartRevenuePaymentData(n, periodString, transactions)
   const revenue = getChartData(n, periodString, revenuePaymentData.revenue, borderColor, formatString)
   const payments = getChartData(n, periodString, revenuePaymentData.payments, borderColor, formatString)
+
   return {
     revenue,
     payments,
-    totalRevenue: 3, // revenue.datasets[0].data, //.reduce((a, b) => a.plus(b))
-    totalPayments: 4 // revenue.datasets[0].data, //.reduce((a, b) => a.plus(b))
+    totalRevenue: (revenue.datasets[0].data as any).reduce((a: Prisma.Decimal, b: Prisma.Decimal) => a.plus(b)),
+    totalPayments: (payments.datasets[0].data as any).reduce((a: number, b: number) => a + b)
   }
 }
 
@@ -105,7 +106,7 @@ const getUserDashboardData = async function (userId: string): Promise<DashboardD
     return t
   }))
 
-  const totalRevenue = transactionsInUSD.map((t) => t.amount).reduce((a, b) => a.plus(b))
+  const totalRevenue = transactionsInUSD.map((t) => t.amount).reduce((a, b) => a.plus(b), new Prisma.Decimal(0))
 
   const thirtyDays: PeriodData = getPeriodData(30, 'days', transactionsInUSD, '#66fe91')
   const sevenDays: PeriodData = getPeriodData(7, 'days', transactionsInUSD, '#66fe91')

--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -35,7 +35,7 @@ interface DashboardData {
 }
 
 const getChartLabels = function (n: number, periodString: string, formatString = 'M/D'): string[] {
-  return [...new Array(n)].map((i, idx) => moment().startOf('day').subtract(idx, periodString as DurationInputArg2).format(formatString))
+  return [...new Array(n)].map((i, idx) => moment().startOf('day').subtract(idx, periodString as DurationInputArg2).format(formatString)).reverse()
 }
 
 const getChartRevenuePaymentData = function (n: number, periodString: string, transactions: Transaction[]): any {
@@ -54,8 +54,8 @@ const getChartRevenuePaymentData = function (n: number, periodString: string, tr
     paymentsArray.push(paymentCount)
   })
   return {
-    revenue: revenueArray,
-    payments: paymentsArray
+    revenue: revenueArray.reverse(),
+    payments: paymentsArray.reverse()
   }
 }
 

--- a/services/addressesService.ts
+++ b/services/addressesService.ts
@@ -1,4 +1,4 @@
-import { Prisma, Address } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 import prisma from 'prisma/clientInstance'
 import { RESPONSE_MESSAGES } from 'constants/index'
 
@@ -24,7 +24,13 @@ export async function fetchAddressBySubstring (substring: string): Promise<Addre
   return results[0]
 }
 
-export async function fetchAllUserAddresses (userId: string, includeTransactions = false): Promise<Address[]> {
+const addressWithTransactions = Prisma.validator<Prisma.AddressArgs>()({
+  include: { transactions: true }
+})
+
+type AddressWithTransactions = Prisma.AddressGetPayload<typeof addressWithTransactions>
+
+export async function fetchAllUserAddresses (userId: string, includeTransactions = false): Promise<AddressWithTransactions[]> {
   return await prisma.address.findMany({
     where: {
       paybuttons: {

--- a/services/addressesService.ts
+++ b/services/addressesService.ts
@@ -24,7 +24,7 @@ export async function fetchAddressBySubstring (substring: string): Promise<Addre
   return results[0]
 }
 
-export async function fetchAllUserAddresses (userId: string): Promise<Address[]> {
+export async function fetchAllUserAddresses (userId: string, includeTransactions = false): Promise<Address[]> {
   return await prisma.address.findMany({
     where: {
       paybuttons: {
@@ -34,6 +34,9 @@ export async function fetchAllUserAddresses (userId: string): Promise<Address[]>
           }
         }
       }
+    },
+    include: {
+      transactions: includeTransactions
     }
   })
 }

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -5,6 +5,7 @@ import paybuttonIdEndpoint from 'pages/api/paybutton/[id]'
 import transactionsEndpoint from 'pages/api/transactions/[address]'
 import transactionDetailsEndpoint from 'pages/api/transaction/[transactionId]'
 import balanceEndpoint from 'pages/api/balance/[address]'
+import dashboardEndpoint from 'pages/api/dashboard/index'
 import {
   exampleAddresses,
   testEndpoint,
@@ -322,7 +323,7 @@ describe('GET /api/transactions/[address]', () => {
         'Content-Type': 'application/json'
       },
       query: {
-          address: `ecash:${exampleAddresses.ecash}`
+        address: `ecash:${exampleAddresses.ecash}`
       }
     }
     const res = await testEndpoint(baseRequestOptions, transactionsEndpoint)
@@ -364,3 +365,42 @@ describe('GET /api/balance/[address]', () => {
   })
 })
 
+describe('GET /api/dashboard', () => {
+  const baseRequestOptions: RequestOptions = {
+    method: 'GET' as RequestMethod,
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    query: {}
+  }
+
+  const expectedPeriodData = expect.objectContaining({
+    revenue: expect.objectContaining({
+      labels: expect.any(Array),
+      datasets: expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.any(Array),
+          borderColor: expect.any(String)
+        })
+      ])
+    })
+  })
+
+  it('Should return HTTP 200', async () => {
+    const res = await testEndpoint(baseRequestOptions, dashboardEndpoint)
+    expect(res.statusCode).toBe(200)
+    const responseData = res._getJSONData()
+    expect(responseData).toEqual({
+      thirtyDays: expectedPeriodData,
+      sevenDays: expectedPeriodData,
+      year: expectedPeriodData,
+      total: {
+        revenue: expect.any(String),
+        payments: expect.any(Number),
+        buttons: expect.any(Number)
+      }
+    }
+    )
+    console.log(JSON.stringify(responseData))
+  })
+})


### PR DESCRIPTION
Description:
Create an API endpoint to retrieve data to be used in the dashboard.

Test plan:
This is not implemented in the front end yet (will be done in a separate PR), but it can be tested by running:
 `curl http://localhost:3000/api/dashboard | jq`

Remarks:
- Dummy prices are being used instead of fetching the actual prices at the time of the transaction, which will be addressed in a future PR.