### PR TITLE
[Issue #219] fix: change uniqueness of Transaction hash -> hash & addressId

### DIFF
--- a/prisma/migrations/20220825134419_transaction_hash_and_address_unique_together/migration.sql
+++ b/prisma/migrations/20220825134419_transaction_hash_and_address_unique_together/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[hash,addressId]` on the table `Transaction` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX `Transaction_hash_key` ON `Transaction`;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `Transaction_hash_addressId_key` ON `Transaction`(`hash`, `addressId`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,9 +58,11 @@ model Network {
 
 model Transaction {
   id                 Int                @id @default(autoincrement())
-  hash               String             @unique @db.VarChar(255)
+  hash               String             @db.VarChar(255)
   amount             Decimal            @db.Decimal(24,8)
   timestamp          Int
   addressId Int
   address   Address   @relation(fields: [addressId], references: [id], onDelete: Cascade, onUpdate: Restrict)
+
+  @@unique([hash, addressId], name: "Transaction_hash_addressId_unique_constraint")
 }

--- a/services/transactionsService.ts
+++ b/services/transactionsService.ts
@@ -56,14 +56,17 @@ export async function upsertTransaction (transaction: BCHTransaction.AsObject, a
   const address = await fetchAddressBySubstring(addressString)
   const hash = await base64HashToHex(transaction.hash as string)
   const transactionParams = {
-    hash: hash,
+    hash,
     amount: receivedAmount,
     addressId: address.id,
     timestamp: transaction.timestamp
   }
   return await prisma.transaction.upsert({
     where: {
-      hash: transactionParams.hash
+      Transaction_hash_addressId_unique_constraint: {
+        hash: transactionParams.hash,
+        addressId: address.id
+      }
     },
     update: transactionParams,
     create: transactionParams


### PR DESCRIPTION
Description:
Solves #219 

Test Plan:
Create a button for the address [qzchtgjam2fs68tunggjgvf9h7v9yuv0dqal9p5pcs](https://ecashexplorer.com/address/ecash:qzchtgjam2fs68tunggjgvf9h7v9yuv0dqal9p5pcs). Then log out & back in to sync the transactions: two transactions should appear:
![image](https://user-images.githubusercontent.com/21281174/186687888-66ed0cfa-d7c3-4a9c-8dbf-fe6794930dbe.png)


On master, only the first one would have appeared.