### PR TITLE
[Issue  #222] feat: add transaction blockHeight field

### DIFF
--- a/prisma/migrations/20220831141824_transaction_block_height/migration.sql
+++ b/prisma/migrations/20220831141824_transaction_block_height/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `blockHeight` to the `Transaction` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `Transaction` ADD COLUMN `blockHeight` INTEGER NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Transaction {
   id                 Int                @id @default(autoincrement())
   hash               String             @db.VarChar(255)
   amount             Decimal            @db.Decimal(24,8)
+  blockHeight        Int
   timestamp          Int
   addressId Int
   address   Address   @relation(fields: [addressId], references: [id], onDelete: Cascade, onUpdate: Restrict)

--- a/services/transactionsService.ts
+++ b/services/transactionsService.ts
@@ -59,7 +59,8 @@ export async function upsertTransaction (transaction: BCHTransaction.AsObject, a
     hash,
     amount: receivedAmount,
     addressId: address.id,
-    timestamp: transaction.timestamp
+    timestamp: transaction.timestamp,
+    blockHeight: transaction.blockHeight
   }
   return await prisma.transaction.upsert({
     where: {

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -126,7 +126,8 @@ export const mockedTransaction = {
   hash: 'Yh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
   addressId: 1,
   amount: new Prisma.Decimal('4.31247724'),
-  timestamp: 1657130467
+  timestamp: 1657130467,
+  blockHeight: 23847
 }
 
 // BCH GRPC


### PR DESCRIPTION
Description:
Related to  #222, adds the `blockHeight` field to the `Transaction` table.

Test Plan:
`make reset-dev` then, after logging in in the front end to sync the transactions, run `curl http://localhost:3000/address/transactions/ecash:qrmm7edwuj4jf7tnvygjyztyy0a0qxvl7quss2vxek| jq` and check if the `blockHeight` is also included.
