### PR TITLE
[Issue #229] fix: revert addition of blockHeight field

### DIFF
--- a/prisma/migrations/20220831141824_transaction_block_height/migration.sql
+++ b/prisma/migrations/20220831141824_transaction_block_height/migration.sql
@@ -1,8 +1,0 @@
-/*
-  Warnings:
-
-  - Added the required column `blockHeight` to the `Transaction` table without a default value. This is not possible if the table is not empty.
-
-*/
--- AlterTable
-ALTER TABLE `Transaction` ADD COLUMN `blockHeight` INTEGER NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,7 +60,6 @@ model Transaction {
   id                 Int                @id @default(autoincrement())
   hash               String             @db.VarChar(255)
   amount             Decimal            @db.Decimal(24,8)
-  blockHeight        Int
   timestamp          Int
   addressId Int
   address   Address   @relation(fields: [addressId], references: [id], onDelete: Cascade, onUpdate: Restrict)

--- a/services/transactionsService.ts
+++ b/services/transactionsService.ts
@@ -59,8 +59,7 @@ export async function upsertTransaction (transaction: BCHTransaction.AsObject, a
     hash,
     amount: receivedAmount,
     addressId: address.id,
-    timestamp: transaction.timestamp,
-    blockHeight: transaction.blockHeight
+    timestamp: transaction.timestamp
   }
   return await prisma.transaction.upsert({
     where: {

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -126,8 +126,7 @@ export const mockedTransaction = {
   hash: 'Yh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
   addressId: 1,
   amount: new Prisma.Decimal('4.31247724'),
-  timestamp: 1657130467,
-  blockHeight: 23847
+  timestamp: 1657130467
 }
 
 // BCH GRPC


### PR DESCRIPTION
Description:
Undoes #229. #229 was build on the supposition that transactions were fetched from oldest to lastest; since the contrary is actually the case, solving #222 is much easier, see [this comment](https://github.com/PayButton/paybutton-server/issues/222#issuecomment-1234419829).

Test Plan:
None.