### PR TITLE
[Issue #222] feat: sync transactions in chunks

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -17,3 +17,9 @@ export const RESPONSE_MESSAGES = {
   NO_ADDRESS_FOUND_404: { statusCode: 404, message: 'No address found.' },
   MULTIPLE_ADDRESSES_FOUND_400: { statusCode: 400, message: 'Multiple addresses found.' }
 }
+
+// When fetching some address transactions, number of transactions to fetch at a time.
+export const FETCH_N = 100
+
+// When fetching some address transactions, delay (in ms) between each fetch.
+export const FETCH_DELAY = 100

--- a/pages/api/transactions/[address].ts
+++ b/pages/api/transactions/[address].ts
@@ -41,11 +41,12 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
         case ADDRESS_NOT_PROVIDED_400.message:
           res.status(ADDRESS_NOT_PROVIDED_400.statusCode).json(ADDRESS_NOT_PROVIDED_400)
           break
-        case NO_ADDRESS_FOUND_404.message:
+        case NO_ADDRESS_FOUND_404.message: {
           const address = parseAddress(req.query.address as string)
-          const transactions = await grpcService.getAddress(address)
+          const transactions = await grpcService.getAddress({ address })
           res.status(200).send(transactions)
-          break;
+          break
+        }
         default:
           res.status(500).json({ statusCode: 500, message: err.message })
       }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider      = "prisma-client-js"
   binaryTargets = ["native", "linux-musl"]
+  previewFeatures = ["interactiveTransactions"]
 }
 
 datasource db {

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -42,11 +42,20 @@ export interface OutputsList {
   slpToken: string | undefined;
 }
 
-export const getAddress = async (
+interface GetAddressParameters {
   address: string
+  nbSkip?: number
+  nbFetch?: number
+  height?: number
+  hash?: string
+  reversedHashOrder?: boolean
+}
+
+export const getAddress = async (
+  parameters: GetAddressParameters
 ): Promise<GetAddressTransactionsResponse.AsObject> => {
-  const client = getClientForAddress(address)
-  return (await client.getAddressTransactions({ address })).toObject();
+  const client = getClientForAddress(parameters.address)
+  return (await client.getAddressTransactions(parameters)).toObject();
 };
 
 export const getUtxos = async (

--- a/services/transactionsService.ts
+++ b/services/transactionsService.ts
@@ -74,6 +74,20 @@ export async function upsertTransaction (transaction: BCHTransaction.AsObject, a
   })
 }
 
+export async function getAllTransactions (addressString: string): Promise<void> {
+  let newTransactionsCount = -1
+  let totalFetched = 0
+  while (newTransactionsCount !== 0) {
+    const nextTransactions = (await grpcService.getAddress({
+      address: addressString,
+      nbFetch: 50,
+      nbSkip: totalFetched
+    })).confirmedTransactionsList
+    newTransactionsCount = nextTransactions.length
+    totalFetched += newTransactionsCount
+  }
+}
+
 export async function syncTransactions (addressString: string): Promise<void> {
   const address = parseAddress(addressString)
   if (address === '' || address === undefined) {

--- a/services/transactionsService.ts
+++ b/services/transactionsService.ts
@@ -6,7 +6,7 @@ import { parseAddress } from 'utils/validators'
 import { satoshisToUnit } from 'utils/index'
 import { fetchAddressBySubstring } from 'services/addressesService'
 import _ from 'lodash'
-import { RESPONSE_MESSAGES } from 'constants/index'
+import { RESPONSE_MESSAGES, FETCH_N, FETCH_DELAY } from 'constants/index'
 import xecaddr from 'xecaddrjs'
 
 const { ADDRESS_NOT_PROVIDED_400 } = RESPONSE_MESSAGES
@@ -92,13 +92,13 @@ export async function fetchAllTransactions (addressString: string): Promise<bool
   while (newTransactionsCount !== 0) {
     const nextTransactions = (await grpcService.getAddress({
       address: address.address,
-      nbFetch: 100,
+      nbFetch: FETCH_N,
       nbSkip: seenTransactionsCount
     })).confirmedTransactionsList
     newTransactionsCount = nextTransactions.length
     seenTransactionsCount += newTransactionsCount
     await upsertManyTransactions(nextTransactions, address)
-    await new Promise(resolve => setTimeout(resolve, 1000))
+    await new Promise(resolve => setTimeout(resolve, FETCH_DELAY))
   }
   return true
 }

--- a/services/transactionsService.ts
+++ b/services/transactionsService.ts
@@ -79,7 +79,7 @@ export async function syncTransactions (addressString: string): Promise<void> {
   if (address === '' || address === undefined) {
     throw new Error(ADDRESS_NOT_PROVIDED_400.message)
   }
-  const transactions = await grpcService.getAddress(address)
+  const transactions = await grpcService.getAddress({ address })
   for (const t of transactions.confirmedTransactionsList) {
     void upsertTransaction(t, address)
   }

--- a/services/transactionsService.ts
+++ b/services/transactionsService.ts
@@ -93,8 +93,8 @@ export async function syncTransactions (addressString: string): Promise<void> {
   if (address === '' || address === undefined) {
     throw new Error(ADDRESS_NOT_PROVIDED_400.message)
   }
-  const transactions = await grpcService.getAddress({ address })
-  for (const t of transactions.confirmedTransactionsList) {
+  const transactions = await getAllTransactions(address)
+  for (const t of transactions) {
     void upsertTransaction(t, address)
   }
 }

--- a/services/transactionsService.ts
+++ b/services/transactionsService.ts
@@ -73,18 +73,19 @@ export async function upsertTransaction (transaction: BCHTransaction.AsObject, a
   })
 }
 
-export async function getAllTransactions (addressString: string): Promise<void> {
+export async function getAllTransactions (addressString: string): Promise<BCHTransaction.AsObject[]> {
   let newTransactionsCount = -1
-  let totalFetched = 0
+  let transactions: BCHTransaction.AsObject[] = []
   while (newTransactionsCount !== 0) {
     const nextTransactions = (await grpcService.getAddress({
       address: addressString,
       nbFetch: 50,
-      nbSkip: totalFetched
+      nbSkip: transactions.length
     })).confirmedTransactionsList
+    transactions = transactions.concat(nextTransactions)
     newTransactionsCount = nextTransactions.length
-    totalFetched += newTransactionsCount
   }
+  return transactions
 }
 
 export async function syncTransactions (addressString: string): Promise<void> {

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -401,6 +401,5 @@ describe('GET /api/dashboard', () => {
       }
     }
     )
-    console.log(JSON.stringify(responseData))
   })
 })

--- a/tests/unittests/grpcService.test.ts
+++ b/tests/unittests/grpcService.test.ts
@@ -3,7 +3,7 @@ import grpcService from '../../services/grpcService'
 
 describe('Test service returned objects consistency', () => {
   it('test getAddress for real address', async () => {
-    const res = await grpcService.getAddress(mockedBCHAddress.address)
+    const res = await grpcService.getAddress({ address: mockedBCHAddress.address })
     expect(res).toEqual(expect.objectContaining({
       confirmedTransactionsList: [
         mockedGrpc.transaction1.toObject(),

--- a/tests/unittests/transactionsService.test.ts
+++ b/tests/unittests/transactionsService.test.ts
@@ -12,7 +12,7 @@ describe('Create services', () => {
 
     const result = await transactionsService.upsertTransaction(
       mockedGrpc.transaction1.toObject(),
-      mockedBCHAddress.address
+      mockedBCHAddress
     )
     expect(result).toEqual(mockedTransaction)
   })


### PR DESCRIPTION
Description:
Part of #222. Makes so that all transactions of some address are fetched and added to our DB in chunks.

Test plan:
- Create a button for some address with significantly many transactions, e.g: [this address](https://ecashexplorer.com/address/ecash:qrv5hwntl5h4mypkg5kek6cj5f2d764txysuu0wffd) has 399 transactions,
- Log in and out to make it sync the transactions, and wait for it.
- Check the database to see if the numbers match:
  - Enter the docker container database with `yd db`,
  -   Get all transactions for newly created address:
```
MariaDB [paybutton]> SELECT * FROM Transaction where addressId=3;
[...]
399 rows in set (0.001 sec)
```