### PR TITLE
[Issue #234] feat: add second dev user to prisma seed

### DIFF
--- a/prisma/seeds/devUser.ts
+++ b/prisma/seeds/devUser.ts
@@ -1,6 +1,11 @@
 export const createDevUserRawQueryList = [
+  // user dev@paybutton.org
   'USE supertokens;',
   'INSERT INTO emailpassword_users VALUES (\'dev-uid\', \'dev@paybutton.org\', \'$2a$11$AGppTnFU3HBeHuH1z3kPb.A1WFUxHVVNmAmiMaHJ3QvVkWT58jxBO\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id',
   'INSERT INTO emailverification_verified_emails VALUES (\'dev-uid\', \'dev@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;',
-  'INSERT INTO all_auth_recipe_users VALUES (\'dev-uid\', \'emailpassword\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;'
+  'INSERT INTO all_auth_recipe_users VALUES (\'dev-uid\', \'emailpassword\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
+  // user dev2@paybutton.org
+  'INSERT INTO emailpassword_users VALUES (\'dev2-uid\', \'dev2@paybutton.org\', \'$2a$11$AGppTnFU3HBeHuH1z3kPb.A1WFUxHVVNmAmiMaHJ3QvVkWT58jxBO\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id',
+  'INSERT INTO emailverification_verified_emails VALUES (\'dev2-uid\', \'dev2@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO all_auth_recipe_users VALUES (\'dev2-uid\', \'emailpassword\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;'
 ]


### PR DESCRIPTION
Description:
Now the projects creates two users automatically: dev@paybutton.org and dev2@paybutton.org

Test Plan:
`make reset-dev`
Try to log in as `dev2@paybutton.org` with password `dev`