### PR TITLE
Refactor/ POSTParameters -> paybuttonPOSTParemeters

### DIFF
--- a/components/Paybutton/EditButtonForm.tsx
+++ b/components/Paybutton/EditButtonForm.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
-import { POSTParameters } from 'utils/validators'
+import { paybuttonPOSTParameters } from 'utils/validators'
 import Image from 'next/image'
 import style from '../Paybutton/paybutton.module.css'
 import s from '../Wallet/wallet.module.css'
@@ -15,7 +15,7 @@ interface IProps {
 }
 
 export default function EditButtonForm ({ onSubmit, paybutton, error }: IProps): ReactElement {
-  const { register, handleSubmit, reset } = useForm<POSTParameters>()
+  const { register, handleSubmit, reset } = useForm<paybuttonPOSTParameters>()
   const [modal, setModal] = useState(false)
   const [buttonname, setButtonName] = useState(paybutton.name)
   const [deletemodal, setDeleteModal] = useState(false)

--- a/components/Paybutton/PaybuttonForm.tsx
+++ b/components/Paybutton/PaybuttonForm.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
-import { POSTParameters } from 'utils/validators'
+import { paybuttonPOSTParameters } from 'utils/validators'
 import Image from 'next/image'
 import style from './paybutton.module.css'
 import Plus from 'assets/plus.png'
@@ -12,7 +12,7 @@ interface IProps {
 }
 
 export default function PaybuttonForm ({ onSubmit, paybuttons, error }: IProps): ReactElement {
-  const { register, handleSubmit, reset } = useForm<POSTParameters>()
+  const { register, handleSubmit, reset } = useForm<paybuttonPOSTParameters>()
   const [modal, setModal] = useState(false)
   const [multipleAddresses, setMultipleAddresses] = useState(false)
 

--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
-import { POSTParameters } from 'utils/validators'
+import { paybuttonPOSTParameters } from 'utils/validators'
 import Image from 'next/image'
 import style from '../Paybutton/paybutton.module.css'
 import s from '../Wallet/wallet.module.css'
@@ -15,7 +15,7 @@ interface IProps {
 }
 
 export default function EditWalletForm ({ onSubmit, paybuttons, error, walletInfo }: IProps): ReactElement {
-  const { register, handleSubmit, reset } = useForm<POSTParameters>()
+  const { register, handleSubmit, reset } = useForm<paybuttonPOSTParameters>()
   const [modal, setModal] = useState(false)
 
   useEffect(() => {

--- a/components/Wallet/WalletForm.tsx
+++ b/components/Wallet/WalletForm.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
-import { POSTParameters } from 'utils/validators'
+import { paybuttonPOSTParameters } from 'utils/validators'
 import Image from 'next/image'
 import style from '../Paybutton/paybutton.module.css'
 import Plus from 'assets/plus.png'
@@ -13,7 +13,7 @@ interface IProps {
 }
 
 export default function WalletForm ({ onSubmit, paybuttons, error, editname }: IProps): ReactElement {
-  const { register, handleSubmit, reset } = useForm<POSTParameters>()
+  const { register, handleSubmit, reset } = useForm<paybuttonPOSTParameters>()
   const [modal, setModal] = useState(false)
 
   useEffect(() => {

--- a/pages/buttons/index.tsx
+++ b/pages/buttons/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ThirdPartyEmailPassword from 'supertokens-auth-react/recipe/thirdpartyemailpassword'
 import { PaybuttonList, PaybuttonForm } from 'components/Paybutton'
 import { Paybutton } from '@prisma/client'
-import { POSTParameters } from 'utils/validators'
+import { paybuttonPOSTParameters } from 'utils/validators'
 import dynamic from 'next/dynamic'
 import supertokensNode from 'supertokens-node'
 import * as SuperTokensConfig from '../../config/backendConfig'
@@ -76,7 +76,7 @@ class ProtectedPage extends React.Component<PaybuttonsProps, PaybuttonsState> {
     }
   }
 
-  async onSubmit (values: POSTParameters): Promise<void> {
+  async onSubmit (values: paybuttonPOSTParameters): Promise<void> {
     const res = await fetch('/api/paybutton', {
       method: 'POST',
       headers: {

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -147,7 +147,7 @@ describe('parseButtonData', () => {
 })
 
 describe('parsePaybuttonPOSTRequest', () => {
-  const data: v.POSTParameters = {
+  const data: v.paybuttonPOSTParameters = {
     userId: undefined,
     name: 'somename',
     buttonData: undefined,

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -58,14 +58,14 @@ export const parseError = function (error: Error): Error {
   return error
 }
 
-export interface POSTParameters {
+export interface paybuttonPOSTParameters {
   userId?: string
   name?: string
   buttonData?: string
   addresses?: string
 }
 
-export const parsePaybuttonPOSTRequest = function (params: POSTParameters): CreatePaybuttonInput {
+export const parsePaybuttonPOSTRequest = function (params: paybuttonPOSTParameters): CreatePaybuttonInput {
   if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
   if (params.addresses === '' || params.addresses === undefined) throw new Error(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)


### PR DESCRIPTION
Description:
Renames `POSTParameters` to `paybuttonPOSTParameters`. With the addition of the `Wallet` model and the need to create a `walletPOSTParameters` (not in this PR), it was confusing to have a "generic" `POSTParameters`.

Test plan:
Nothing should change.