### PR TITLE
Refactor/ rename error message constant

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -7,7 +7,7 @@ export const RESPONSE_MESSAGES = {
   USER_ID_NOT_PROVIDED_400: { statusCode: 400, message: "'userId' not provided." },
   MULTIPLE_USER_IDS_PROVIDED_400: { statusCode: 400, message: "Multiple 'userId' provided." },
   NAME_NOT_PROVIDED_400: { statusCode: 400, message: "'name' not provided." },
-  NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Button name already exists for this user.' },
+  PAYBUTTON_NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Button name already exists for this user.' },
   ADDRESSES_NOT_PROVIDED_400: { statusCode: 400, message: "'addresses' not provided." },
   TRANSACTION_ID_NOT_PROVIDED_400: { statusCode: 400, message: "'transactionId' not provided." },
   INVALID_NETWORK_SLUG_400: { statusCode: 400, message: 'Invalid network slug.' },

--- a/pages/api/paybutton/index.ts
+++ b/pages/api/paybutton/index.ts
@@ -27,8 +27,8 @@ export default async (req: any, res: any): Promise<void> => {
         case RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message:
           res.status(400).json(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400)
           break
-        case RESPONSE_MESSAGES.NAME_ALREADY_EXISTS_400.message:
-          res.status(400).json(RESPONSE_MESSAGES.NAME_ALREADY_EXISTS_400)
+        case RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400)
           break
         case RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message:
           res.status(400).json(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400)

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -115,7 +115,7 @@ describe('POST /api/paybutton/', () => {
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)
     expect(res.statusCode).toBe(400)
     const responseData = res._getJSONData()
-    expect(responseData.message).toBe(RESPONSE_MESSAGES.NAME_ALREADY_EXISTS_400.message)
+    expect(responseData.message).toBe(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message)
   })
 
   it('Fail without addresses', async () => {

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -117,7 +117,7 @@ describe('parseError', () => {
       'P2002',
       'foo'
     )
-    expect(v.parseError(error)).toStrictEqual(new Error(RESPONSE_MESSAGES.NAME_ALREADY_EXISTS_400.message))
+    expect(v.parseError(error)).toStrictEqual(new Error(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message))
   })
 })
 

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -51,7 +51,7 @@ export const parseError = function (error: Error): Error {
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     if (error.code === 'P2002') {
       if (error.message.includes('Paybutton_name_providerUserId_unique_constraint')) {
-        return new Error(RESPONSE_MESSAGES.NAME_ALREADY_EXISTS_400.message)
+        return new Error(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message)
       }
     }
   }


### PR DESCRIPTION
Description:
Renames variable
`NAME_ALREADY_EXISTS_400` -> `PAYBUTTON_NAME_ALREADY_EXISTS_400`: because there will also be a `WALLET_NAME_ALREADY_EXISTS_400` in a future PR, so this makes it all more clear.

Test plan:
Nothing should change.