### PR TITLE
[Issue #154] fix: wallet constraint name & prisma transaction

### DIFF
--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -70,7 +70,7 @@ CREATE TABLE `Wallet` (
     `name` VARCHAR(255) NOT NULL,
     `providerUserId` VARCHAR(255) NULL,
 
-    UNIQUE INDEX `Paybutton_name_providerUserId_unique_constraint`(`name`, `providerUserId`),
+    UNIQUE INDEX `Wallet_name_providerUserId_unique_constraint`(`name`, `providerUserId`),
     PRIMARY KEY (`id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,5 +83,5 @@ model Wallet {
   addresses      Address[]
   paybuttons     Paybutton[]
 
-  @@unique([name, providerUserId], map: "Paybutton_name_providerUserId_unique_constraint")
+  @@unique([name, providerUserId], map: "Wallet_name_providerUserId_unique_constraint")
 }

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -13,7 +13,7 @@ export interface CreateWalletInput {
 export async function createWallet (values: CreateWalletInput): Promise<Wallet> {
   const paybuttonList = await paybuttonService.fetchPaybuttonArrayByIds(values.paybuttonIdList)
   let wallet: Wallet
-  return await prisma.$transaction(async (_) => {
+  return await prisma.$transaction(async (prisma) => {
     wallet = await prisma.wallet.create({
       data: {
         providerUserId: values.userId,
@@ -29,7 +29,7 @@ export async function createWallet (values: CreateWalletInput): Promise<Wallet> 
     })
     for (const paybutton of paybuttonList) {
       if (paybutton.walletId !== null) {
-        throw Error(RESPONSE_MESSAGES.PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400.message)
+        throw new Error(RESPONSE_MESSAGES.PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400.message)
       }
 
       await prisma.paybutton.update({
@@ -42,7 +42,7 @@ export async function createWallet (values: CreateWalletInput): Promise<Wallet> 
       })
       for (const connector of paybutton.addresses) {
         if (connector.address.walletId !== null) {
-          throw Error(RESPONSE_MESSAGES.ADDRESS_ALREADY_BELONGS_TO_WALLET_400.message)
+          throw new Error(RESPONSE_MESSAGES.ADDRESS_ALREADY_BELONGS_TO_WALLET_400.message)
         }
         await prisma.address.update({
           data: {

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -43,7 +43,9 @@ describe('Create services', () => {
     prismaMock.wallet.create.mockResolvedValue(mockedWallet)
     prisma.wallet.create = prismaMock.wallet.create
     prismaMock.$transaction.mockImplementation(
-      (fn: (prisma: any) => any) => fn('')
+      (fn: (prisma: any) => any) => {
+        return fn(prisma)
+      }
     )
     prisma.$transaction = prismaMock.$transaction
     prismaMock.paybutton.update.mockResolvedValue(mockedPaybuttonList[0])


### PR DESCRIPTION
Description:
The unique constraint for the wallet name was mentioning "Paybutton" instead of "Wallet". Furthermore, the `$transaction` call was also not working and it was fixed.

Test plan:
Nothing should change. 