### PR TITLE
[Issue #154]: Wallet front end list

### DIFF
--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -26,8 +26,8 @@ export default ({ wallet, paymentInfo }: IProps): FunctionComponent => {
           </div>
         </div>
         <div className={style.edit_button_ctn}>
-          {wallet.userProfile?.isDefaultForNetworkId === 1 && <div className={style.default_wallet}>Default XEC Wallet</div>}
-          {wallet.userProfile?.isDefaultForNetworkId === 2 && <div className={style.default_wallet}>Default BCH Wallet</div>}
+          {wallet.userProfile?.isDefaultForNetworkId === XEC_NETWORK_ID && <div className={style.default_wallet}>Default XEC Wallet</div>}
+          {wallet.userProfile?.isDefaultForNetworkId === BCH_NETWORK_ID && <div className={style.default_wallet}>Default BCH Wallet</div>}
           <EditWalletForm wallet={wallet} />
         </div>
       </div>

--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -6,6 +6,7 @@ import XECIcon from 'assets/xec-logo.png'
 import BCHIcon from 'assets/bch-logo.png'
 import EditWalletForm from './EditWalletForm'
 import { WalletWithAddressesAndPaybuttons, WalletPaymentInfo } from 'services/walletService'
+import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 
 interface IProps {
   wallet: WalletWithAddressesAndPaybuttons
@@ -20,8 +21,8 @@ export default ({ wallet, paymentInfo }: IProps): FunctionComponent => {
         <div className={style.wallet_card_header}>
           <h4>{wallet.name}</h4>
           <div className={style.walletcard_icons}>
-            {networks.includes(1) && <div><Image src={XECIcon} alt='XEC' /></div>}
-            {networks.includes(2) && <div><Image src={BCHIcon} alt='BCH' /></div>}
+            {networks.includes(XEC_NETWORK_ID) && <div><Image src={XECIcon} alt='XEC' /></div>}
+            {networks.includes(BCH_NETWORK_ID) && <div><Image src={BCHIcon} alt='BCH' /></div>}
           </div>
         </div>
         <div className={style.edit_button_ctn}>

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ThirdPartyEmailPassword from 'supertokens-auth-react/recipe/thirdpartyemailpassword'
 import dynamic from 'next/dynamic'
+import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 import supertokensNode from 'supertokens-node'
 import * as SuperTokensConfig from '../../config/backendConfig'
 import Session from 'supertokens-node/recipe/session'
@@ -88,9 +89,9 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
           const aNetworkId = Number(a.wallet.userProfile?.isDefaultForNetworkId)
           const bNetworkId = Number(b.wallet.userProfile?.isDefaultForNetworkId)
           switch (aNetworkId | bNetworkId) {
-            case 1 | 2:
+            case XEC_NETWORK_ID | BCH_NETWORK_ID:
               return 1
-            case 2 | 1:
+            case BCH_NETWORK_ID | XEC_NETWORK_ID:
               return -1
             default:
               return (bNetworkId - aNetworkId)


### PR DESCRIPTION
**Description:**
http://localhost:3000/wallets now shows the real wallets in the database.

**Test plan:**
Should be covered by the tests.
Nonetheless, the reviewer can create paybuttons and then wallets and see if the information is making sense. Check #263 `curl` POST example to see how to create a wallet.

**Remarks:**
- The function to edit the wallets, accessible when clicking in the pencil icon, has not been addressed in this PR and is not expected to work;
- The `default_wallet` is not implemented, so the `wallets` endpoint is returning all wallets as if this property was `false`. This also will be addressed in a next PR.

**Depends on:**
- [x] #266 