### PR TITLE
[Issue #154] feat: UserProfile and WalletsOnUserProfile tables

### DIFF
--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -86,15 +86,15 @@ CREATE TABLE `UserProfile` (
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
-CREATE TABLE `WalletOnUserProfiles` (
+CREATE TABLE `WalletsOnUserProfile` (
     `walletId` INTEGER NOT NULL,
     `userProfileId` INTEGER NOT NULL,
     `isDefaultForNetworkId` INTEGER NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
 
-    UNIQUE INDEX `WalletOnUserProfiles_walletId_key`(`walletId`),
-    UNIQUE INDEX `WalletOnUserProfiles_userProfileId_isDefaultForNetworkId_key`(`userProfileId`, `isDefaultForNetworkId`),
+    UNIQUE INDEX `WalletsOnUserProfile_walletId_key`(`walletId`),
+    UNIQUE INDEX `WalletsOnUserProfile_userProfileId_isDefaultForNetworkId_key`(`userProfileId`, `isDefaultForNetworkId`),
     PRIMARY KEY (`walletId`, `userProfileId`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
@@ -117,7 +117,7 @@ ALTER TABLE `Paybutton` ADD CONSTRAINT `Paybutton_walletId_fkey` FOREIGN KEY (`w
 ALTER TABLE `Address` ADD CONSTRAINT `Address_walletId_fkey` FOREIGN KEY (`walletId`) REFERENCES `Wallet`(`id`) ON DELETE SET NULL ON UPDATE RESTRICT;
 
 -- AddForeignKey
-ALTER TABLE `WalletOnUserProfiles` ADD CONSTRAINT `WalletOnUserProfiles_walletId_fkey` FOREIGN KEY (`walletId`) REFERENCES `Wallet`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE `WalletsOnUserProfile` ADD CONSTRAINT `WalletsOnUserProfile_walletId_fkey` FOREIGN KEY (`walletId`) REFERENCES `Wallet`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE `WalletOnUserProfiles` ADD CONSTRAINT `WalletOnUserProfiles_userProfileId_fkey` FOREIGN KEY (`userProfileId`) REFERENCES `UserProfile`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE `WalletsOnUserProfile` ADD CONSTRAINT `WalletsOnUserProfile_userProfileId_fkey` FOREIGN KEY (`userProfileId`) REFERENCES `UserProfile`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -80,12 +80,23 @@ CREATE TABLE `UserProfile` (
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
     `userId` VARCHAR(255) NOT NULL,
-    `defaultWalletId` INTEGER NULL,
 
     UNIQUE INDEX `UserProfile_userId_key`(`userId`),
     PRIMARY KEY (`id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
+-- CreateTable
+CREATE TABLE `WalletOnUserProfiles` (
+    `walletId` INTEGER NOT NULL,
+    `userProfileId` INTEGER NOT NULL,
+    `isDefaultForNetworkId` INTEGER NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `WalletOnUserProfiles_walletId_key`(`walletId`),
+    UNIQUE INDEX `WalletOnUserProfiles_userProfileId_isDefaultForNetworkId_key`(`userProfileId`, `isDefaultForNetworkId`),
+    PRIMARY KEY (`walletId`, `userProfileId`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- AddForeignKey
 ALTER TABLE `Address` ADD CONSTRAINT `Address_networkId_fkey` FOREIGN KEY (`networkId`) REFERENCES `Network`(`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
@@ -106,4 +117,7 @@ ALTER TABLE `Paybutton` ADD CONSTRAINT `Paybutton_walletId_fkey` FOREIGN KEY (`w
 ALTER TABLE `Address` ADD CONSTRAINT `Address_walletId_fkey` FOREIGN KEY (`walletId`) REFERENCES `Wallet`(`id`) ON DELETE SET NULL ON UPDATE RESTRICT;
 
 -- AddForeignKey
-ALTER TABLE `UserProfile` ADD CONSTRAINT `UserProfile_defaultWalletId_fkey` FOREIGN KEY (`defaultWalletId`) REFERENCES `Wallet`(`id`) ON DELETE SET NULL ON UPDATE RESTRICT;
+ALTER TABLE `WalletOnUserProfiles` ADD CONSTRAINT `WalletOnUserProfiles_walletId_fkey` FOREIGN KEY (`walletId`) REFERENCES `Wallet`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `WalletOnUserProfiles` ADD CONSTRAINT `WalletOnUserProfiles_userProfileId_fkey` FOREIGN KEY (`userProfileId`) REFERENCES `UserProfile`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -74,6 +74,18 @@ CREATE TABLE `Wallet` (
     PRIMARY KEY (`id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
+-- CreateTable
+CREATE TABLE `UserProfile` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `userId` VARCHAR(255) NOT NULL,
+    `defaultWalletId` INTEGER NULL,
+
+    UNIQUE INDEX `UserProfile_userId_key`(`userId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
 
 -- AddForeignKey
 ALTER TABLE `Address` ADD CONSTRAINT `Address_networkId_fkey` FOREIGN KEY (`networkId`) REFERENCES `Network`(`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
@@ -92,3 +104,6 @@ ALTER TABLE `Paybutton` ADD CONSTRAINT `Paybutton_walletId_fkey` FOREIGN KEY (`w
 
 -- AddForeignKey
 ALTER TABLE `Address` ADD CONSTRAINT `Address_walletId_fkey` FOREIGN KEY (`walletId`) REFERENCES `Wallet`(`id`) ON DELETE SET NULL ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `UserProfile` ADD CONSTRAINT `UserProfile_defaultWalletId_fkey` FOREIGN KEY (`defaultWalletId`) REFERENCES `Wallet`(`id`) ON DELETE SET NULL ON UPDATE RESTRICT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,16 +82,28 @@ model Wallet {
   providerUserId String?     @db.VarChar(255)
   addresses      Address[]
   paybuttons     Paybutton[]
-  userProfile    UserProfile[]
+  userProfile    WalletOnUserProfiles?
 
   @@unique([name, providerUserId], map: "Wallet_name_providerUserId_unique_constraint")
 }
 
+model WalletOnUserProfiles {
+  walletId              Int         @unique
+  userProfileId         Int
+  isDefaultForNetworkId Int?
+  createdAt             DateTime    @default(now())
+  updatedAt             DateTime    @updatedAt
+  wallet                Wallet      @relation(fields: [walletId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  userProfile           UserProfile @relation(fields: [userProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  @@id([walletId, userProfileId])
+  @@unique([userProfileId, isDefaultForNetworkId], name: "WalletOnUserProfiles_userProfileId_isDefaultForNetworkId_unique_constraint")
+}
+
 model UserProfile {
-  id              Int      @id @default(autoincrement())
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-  userId          String   @unique @db.VarChar(255)
-  defaultWalletId Int?
-  wallet          Wallet?  @relation(fields: [defaultWalletId], references: [id], onUpdate: Restrict)
+  id              Int                    @id @default(autoincrement())
+  createdAt       DateTime               @default(now())
+  updatedAt       DateTime               @updatedAt
+  userId          String                 @unique @db.VarChar(255)
+  wallets         WalletOnUserProfiles[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
-  provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-musl"]
+  provider        = "prisma-client-js"
+  binaryTargets   = ["native", "linux-musl"]
   previewFeatures = ["interactiveTransactions"]
 }
 
@@ -18,7 +18,7 @@ model Address {
   networkId    Int
   walletId     Int?
   network      Network              @relation(fields: [networkId], references: [id], onUpdate: Restrict)
-  Wallet       Wallet?              @relation(fields: [walletId], references: [id], onUpdate: Restrict)
+  wallet       Wallet?              @relation(fields: [walletId], references: [id], onUpdate: Restrict)
   paybuttons   AddressesOnButtons[]
   transactions Transaction[]
 
@@ -34,7 +34,7 @@ model Paybutton {
   walletId       Int?
   createdAt      DateTime             @default(now())
   updatedAt      DateTime             @updatedAt
-  Wallet         Wallet?              @relation(fields: [walletId], references: [id], onUpdate: Restrict)
+  wallet         Wallet?              @relation(fields: [walletId], references: [id], onUpdate: Restrict)
   addresses      AddressesOnButtons[]
 
   @@unique([name, providerUserId], map: "Paybutton_name_providerUserId_unique_constraint")
@@ -82,6 +82,16 @@ model Wallet {
   providerUserId String?     @db.VarChar(255)
   addresses      Address[]
   paybuttons     Paybutton[]
+  userProfile    UserProfile[]
 
   @@unique([name, providerUserId], map: "Wallet_name_providerUserId_unique_constraint")
+}
+
+model UserProfile {
+  id              Int      @id @default(autoincrement())
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  userId          String   @unique @db.VarChar(255)
+  defaultWalletId Int?
+  wallet          Wallet?  @relation(fields: [defaultWalletId], references: [id], onUpdate: Restrict)
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,12 +82,12 @@ model Wallet {
   providerUserId String?     @db.VarChar(255)
   addresses      Address[]
   paybuttons     Paybutton[]
-  userProfile    WalletOnUserProfiles?
+  userProfile    WalletsOnUserProfile?
 
   @@unique([name, providerUserId], map: "Wallet_name_providerUserId_unique_constraint")
 }
 
-model WalletOnUserProfiles {
+model WalletsOnUserProfile {
   walletId              Int         @unique
   userProfileId         Int
   isDefaultForNetworkId Int?
@@ -97,7 +97,7 @@ model WalletOnUserProfiles {
   userProfile           UserProfile @relation(fields: [userProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
 
   @@id([walletId, userProfileId])
-  @@unique([userProfileId, isDefaultForNetworkId], name: "WalletOnUserProfiles_userProfileId_isDefaultForNetworkId_unique_constraint")
+  @@unique([userProfileId, isDefaultForNetworkId], name: "WalletsOnUserProfile_userProfileId_isDefaultForNetworkId_unique_constraint")
 }
 
 model UserProfile {
@@ -105,5 +105,5 @@ model UserProfile {
   createdAt       DateTime               @default(now())
   updatedAt       DateTime               @updatedAt
   userId          String                 @unique @db.VarChar(255)
-  wallets         WalletOnUserProfiles[]
+  wallets         WalletsOnUserProfile[]
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -32,8 +32,8 @@ async function main (): Promise<void> {
     await prisma.userProfile.createMany({ data: userProfiles })
   }
   // create wallet user profiles connectors
-  if (await prisma.walletOnUserProfiles.count() === 0) {
-    await prisma.walletOnUserProfiles.createMany({ data: walletUserConnectors })
+  if (await prisma.walletsOnUserProfile.count() === 0) {
+    await prisma.walletsOnUserProfile.createMany({ data: walletUserConnectors })
   }
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,7 +4,7 @@ import { paybuttons } from './seeds/paybuttons'
 import { addresses } from './seeds/addresses'
 import { connectors } from './seeds/connectors'
 import { wallets } from './seeds/wallets'
-import { createDevUserRawQueryList } from './seeds/devUser'
+import { createDevUserRawQueryList, userProfiles } from './seeds/devUser'
 const prisma = new PrismaClient()
 
 async function main (): Promise<void> {
@@ -25,6 +25,10 @@ async function main (): Promise<void> {
   // create default dev user
   for (const q of createDevUserRawQueryList) {
     await prisma.$executeRawUnsafe(q)
+  }
+  // create user profiles
+  if (await prisma.userProfile.count() === 0) {
+    await prisma.userProfile.createMany({ data: userProfiles })
   }
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,6 +3,7 @@ import { networks } from './seeds/networks'
 import { paybuttons } from './seeds/paybuttons'
 import { addresses } from './seeds/addresses'
 import { connectors } from './seeds/connectors'
+import { walletUserConnectors } from './seeds/walletUserConnectors'
 import { wallets } from './seeds/wallets'
 import { createDevUserRawQueryList, userProfiles } from './seeds/devUser'
 const prisma = new PrismaClient()
@@ -29,6 +30,10 @@ async function main (): Promise<void> {
   // create user profiles
   if (await prisma.userProfile.count() === 0) {
     await prisma.userProfile.createMany({ data: userProfiles })
+  }
+  // create wallet user profiles connectors
+  if (await prisma.walletOnUserProfiles.count() === 0) {
+    await prisma.walletOnUserProfiles.createMany({ data: walletUserConnectors })
   }
 }
 

--- a/prisma/seeds/devUser.ts
+++ b/prisma/seeds/devUser.ts
@@ -9,3 +9,20 @@ export const createDevUserRawQueryList = [
   'INSERT INTO emailverification_verified_emails VALUES (\'dev2-uid\', \'dev2@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO all_auth_recipe_users VALUES (\'dev2-uid\', \'emailpassword\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;'
 ]
+
+export const userProfiles = [
+  {
+    id: 1,
+    userId: 'dev-uid',
+    defaultWalletId: 1,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    id: 2,
+    userId: 'dev2-uid',
+    defaultWalletId: null,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+]

--- a/prisma/seeds/devUser.ts
+++ b/prisma/seeds/devUser.ts
@@ -14,14 +14,12 @@ export const userProfiles = [
   {
     id: 1,
     userId: 'dev-uid',
-    defaultWalletId: 1,
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
     id: 2,
     userId: 'dev2-uid',
-    defaultWalletId: null,
     createdAt: new Date(),
     updatedAt: new Date()
   }

--- a/prisma/seeds/walletUserConnectors.ts
+++ b/prisma/seeds/walletUserConnectors.ts
@@ -1,0 +1,23 @@
+export const walletUserConnectors = [
+  {
+    walletId: 1,
+    userProfileId: 1,
+    isDefaultForNetworkId: 2,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    walletId: 2,
+    userProfileId: 1,
+    isDefaultForNetworkId: null,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    walletId: 3,
+    userProfileId: 1,
+    isDefaultForNetworkId: 1,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+]

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -11,6 +11,12 @@ export interface CreateWalletInput {
 }
 
 const includeAddressesAndPaybuttons = {
+  userProfile: {
+    select: {
+      userProfileId: true,
+      isDefaultForNetworkId: true
+    }
+  },
   paybuttons: true,
   addresses: {
     select: {

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -414,9 +414,10 @@ describe('GET /api/wallets/', () => {
         }
       ])
     )
-    expect(responseData[0]).toHaveProperty('providerUserId')
+    expect(responseData[0]).toHaveProperty('providerUserId', 'test-other-u-id')
     expect(responseData[0]).toHaveProperty('name')
     expect(responseData[0]).toHaveProperty('paybuttons')
+    expect(responseData[0]).toHaveProperty('userProfile')
   })
 
   it('Get no wallets for unknown user', async () => {


### PR DESCRIPTION
Description:
Creates the `UserProfile` and `WalletsOnUserProfile` tables.

`UserProfile` is a table for storing user settings. `WalletsOnUserProfile` is a connector model that connects multiple wallets to an user and defines which one of them are default and for which network through the field `isDefaultForNetworkId`.

Test Plan:
Nothing should change, one can explore the newly created model instances with:
```
$ yarn docker db
MariaDB [paybutton]> SELECT * FROM UserProfile;
MariaDB [paybutton]> SELECT * FROM WalletsOnUserProfile;
```