### PR TITLE
[Issue #154] feat: payment info services

### DIFF
--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -1,5 +1,6 @@
 // import * as networkService from 'services/networkService'
 import * as paybuttonService from 'services/paybuttonService'
+import * as addressService from 'services/addressService'
 import { Prisma, Wallet } from '@prisma/client'
 import prisma from 'prisma/clientInstance'
 import { RESPONSE_MESSAGES } from 'constants/index'
@@ -31,7 +32,7 @@ const walletWithAddressesAndPaybuttons = Prisma.validator<Prisma.WalletArgs>()(
   { include: includeAddressesAndPaybuttons }
 )
 
-type WalletWithAddressesAndPaybuttons = Prisma.WalletGetPayload<typeof walletWithAddressesAndPaybuttons>
+export type WalletWithAddressesAndPaybuttons = Prisma.WalletGetPayload<typeof walletWithAddressesAndPaybuttons>
 
 export async function createWallet (values: CreateWalletInput): Promise<Wallet> {
   const paybuttonList = await paybuttonService.fetchPaybuttonArrayByIds(values.paybuttonIdList)
@@ -79,6 +80,31 @@ export async function fetchWalletById (walletId: number | string): Promise<Walle
     where: { id: Number(walletId) },
     include: includeAddressesAndPaybuttons
   })
+}
+
+export interface WalletPaymentInfo {
+  XECBalance: Prisma.Decimal
+  BCHBalance: Prisma.Decimal
+  paymentCount: number
+}
+
+export async function getWalletBalance (wallet: WalletWithAddressesAndPaybuttons): Promise<WalletPaymentInfo> {
+  const ret: WalletPaymentInfo = {
+    XECBalance: new Prisma.Decimal(0),
+    BCHBalance: new Prisma.Decimal(0),
+    paymentCount: 0
+  }
+  for (const addr of wallet.addresses) {
+    const addrBalance = await addressService.getAddressPaymentInfo(addr.address)
+    if (addr.networkId === 1) {
+      ret.XECBalance = ret.XECBalance.plus(addrBalance.balance)
+    }
+    if (addr.networkId === 2) {
+      ret.BCHBalance = ret.BCHBalance.plus(addrBalance.balance)
+    }
+    ret.paymentCount += addrBalance.paymentCount
+  }
+  return ret
 }
 
 export async function fetchWalletArrayByUserId (userId: string): Promise<WalletWithAddressesAndPaybuttons[]> {

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -21,7 +21,8 @@ const includeAddressesAndPaybuttons = {
   addresses: {
     select: {
       id: true,
-      address: true
+      address: true,
+      networkId: true
     }
   }
 }

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -406,10 +406,12 @@ describe('GET /api/wallets/', () => {
       expect.arrayContaining([
         {
           address: expect.any(String),
+          networkId: expect.any(Number),
           id: expect.any(Number)
         },
         {
           address: expect.any(String),
+          networkId: expect.any(Number),
           id: expect.any(Number)
         }
       ])
@@ -480,10 +482,12 @@ describe('GET /api/wallet/[id]', () => {
         expect.arrayContaining([
           {
             id: expect.any(Number),
+            networkId: expect.any(Number),
             address: expect.any(String)
           },
           {
             id: expect.any(Number),
+            networkId: expect.any(Number),
             address: expect.any(String)
           }
         ])

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -133,7 +133,8 @@ export const mockedWallet = {
   createdAt: new Date('2022-09-30T18:01:32.456Z'),
   updatedAt: new Date('2022-09-30T18:01:32.456Z'),
   name: 'mockedWallet',
-  providerUserId: 'mocked-uid'
+  providerUserId: 'mocked-uid',
+  userProfile: null
   // "paybuttons": [],
   // "addresses": []
 }
@@ -172,6 +173,30 @@ export const mockedTransaction = {
   amount: new Prisma.Decimal('4.31247724'),
   timestamp: 1657130467
 }
+
+export const mockedTransactionList = [
+  {
+    id: 1,
+    hash: 'Yh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
+    addressId: 1,
+    amount: new Prisma.Decimal('4.31247724'),
+    timestamp: 1657130467
+  },
+  {
+    id: 2,
+    hash: 'hh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
+    addressId: 1,
+    amount: new Prisma.Decimal('1.5'),
+    timestamp: 1657130467
+  },
+  {
+    id: 3,
+    hash: '5h5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
+    addressId: 1,
+    amount: new Prisma.Decimal('0.2'),
+    timestamp: 1657130467
+  }
+]
 
 // BCH GRPC
 export const unspentOutputFromObject = (obj: UnspentOutput.AsObject): UnspentOutput => {

--- a/tests/unittests/addressService.test.ts
+++ b/tests/unittests/addressService.test.ts
@@ -1,7 +1,8 @@
 import prisma from 'prisma/clientInstance'
+import { Prisma } from '@prisma/client'
 import * as addressService from 'services/addressService'
 import { prismaMock } from 'prisma/mockedClient'
-import { mockedBCHAddress } from '../mockedObjects'
+import { mockedBCHAddress, mockedNetwork, mockedTransactionList } from '../mockedObjects'
 import { RESPONSE_MESSAGES } from 'constants/index'
 
 describe('Find by substring', () => {
@@ -19,5 +20,17 @@ describe('Find by substring', () => {
     await expect(addressService.fetchAddressBySubstring('mock')).rejects.toThrow(
       RESPONSE_MESSAGES.NO_ADDRESS_FOUND_404.message
     )
+  })
+  it('Get address payment info', async () => {
+    jest.spyOn(addressService, 'fetchAddressBySubstring').mockImplementation(async (_: string) => {
+      return {
+        network: mockedNetwork,
+        transactions: mockedTransactionList,
+        ...mockedBCHAddress
+      }
+    })
+    const result = await addressService.getAddressPaymentInfo('mock')
+    expect(result).toHaveProperty('balance', new Prisma.Decimal('6.01247724'))
+    expect(result).toHaveProperty('paymentCount', 3)
   })
 })


### PR DESCRIPTION
Description:
Adds services & tests for addresses and wallets payment info (balance, # of payments). Necessary for displaying the actual wallets info in http://localhost:3000/wallets (to be implemented in a next PR).

Test plan:
Should be covered by the tests.