### PR TITLE
[Issue #271, #272] bug: center login box, change button back behavior

### DIFF
--- a/components/Layout/layout.module.css
+++ b/components/Layout/layout.module.css
@@ -16,6 +16,7 @@
   max-height: 100vh;
   overflow-y: scroll;
   width: calc(100% - 220px);
+  margin: 0 auto;
 }
 
 .layout main::-webkit-scrollbar {

--- a/pages/auth/[[...path]].tsx
+++ b/pages/auth/[[...path]].tsx
@@ -25,10 +25,10 @@ export default function Auth() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className='login_ctn'>
+      <div className='login_ctn'>
       <Image src={logoImageSource} alt='PayButton' width={200} height={37} />
         <SuperTokensComponentNoSSR />
-      </main>
+      </div>
     </div>
   )
 }

--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ThirdPartyEmailPassword from 'supertokens-auth-react/recipe/thirdpartyemailpassword'
 import Page from 'components/Page'
-import Link from 'next/link'
+import Router from 'next/router'
 import { PaybuttonDetail } from 'components/Paybutton'
 import { AddressTransactions } from 'components/Transaction'
 import { Transaction, Paybutton } from '@prisma/client'
@@ -110,9 +110,7 @@ class ProtectedPage extends React.Component<PaybuttonProps, PaybuttonState> {
     if (this.state.paybutton !== undefined && Object.keys(this.state.transactions).length !== 0) {
       return (
         <>
-          <Link href='/buttons'>
-            <a className='back_btn'>Back</a>
-          </Link>
+          <div className='back_btn' onClick={() => Router.back()}>Back</div>
           <PaybuttonDetail paybutton={this.state.paybutton} />
           <h4>Transactions</h4>
           <AddressTransactions addressTransactions={this.state.transactions} />

--- a/styles/global.css
+++ b/styles/global.css
@@ -29,6 +29,10 @@ textarea {
   padding-top: 100px;
 }
 
+body[data-theme='dark'] .login_ctn img {
+  filter: brightness(100);
+}
+
 h2 {
   font-size: 30px;
   margin: 0;

--- a/styles/global.css
+++ b/styles/global.css
@@ -62,6 +62,8 @@ body[data-theme='dark'] button {
   margin-bottom: 0px;
   background-color: var(--secondary-bg-color);
   display: inline-block;
+  cursor: pointer;
+  user-select: none;
 }
 
 .back_btn:hover {


### PR DESCRIPTION
A couple edits to center the login box and make the back button on the /button/id page go back to the page you came from instead of always back to the /buttons page