### PR TITLE
[Issue #154] feat: wallet edit back end defaults deps

### DIFF
--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -13,10 +13,10 @@ interface IProps {
 }
 
 interface IForm {
-  newName: string
-  makeDefaultXEC: boolean
-  makeDefaultBCH: boolean
-  selectedPaybuttons: Array<{id: number, checked: boolean}>
+  name: string
+  isXECDefault: boolean
+  isBCHDefault: boolean
+  paybuttons: Array<{id: number, checked: boolean}>
 }
 
 export default function EditWalletForm ({ wallet, userPaybuttons }: IProps): ReactElement {
@@ -59,21 +59,21 @@ export default function EditWalletForm ({ wallet, userPaybuttons }: IProps): Rea
                 <div className={s.makedefault_ctn} key={wallet.id}>
                   <div className={s.input_field}>
                     <input
-                        {...register('makeDefaultXEC')}
+                        {...register('isXECDefault')}
                         defaultChecked={wallet.userProfile?.isXECDefault === true}
                         type="checkbox"
-                        name='makeDefaultXEC'
+                        name='isXECDefault'
                     />
                     <label htmlFor='xec-default' className={s.makedefault_margin}>Make Default XEC Wallet</label>
                   </div>
                   <div className={s.input_field}>
                     <input
-                        {...register('makeDefaultBCH')}
+                        {...register('isBCHDefault')}
                         defaultChecked={wallet.userProfile?.isBCHDefault === true}
                         type="checkbox"
-                        name='makeDefaultBCH'
+                        name='isBCHDefault'
                     />
-                    <label htmlFor='bch-default'>Make Default BCH Wallet</label>
+                    <label htmlFor='bch-default' className={s.makedefault_margin}>Make Default BCH Wallet</label>
                   </div>
                 </div>
 

--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -80,14 +80,14 @@ export default function EditWalletForm ({ wallet, userPaybuttons }: IProps): Rea
       <h4>Paybuttons</h4>
       <div className={s.buttonlist_ctn}>
       {userPaybuttons.map((pb, index) => (
-          <div className={s.input_field} key={pb.id}>
-            <input {...register(`selectedPaybuttons.${index}`)}
-            name={`selectedPaybuttons.${index}`}
-            type='checkbox'
-            defaultChecked={pb.walletId === wallet.id}
-            />
-            <label htmlFor={`selectedPaybuttons.${index}`}>{pb.name}</label>
-          </div>
+        <div className={s.input_field} key={pb.id}>
+          <input {...register(`paybuttons.${index}`)}
+          name={`paybuttons.${index}`}
+          type='checkbox'
+          defaultChecked={pb.walletId === wallet.id}
+          />
+          <label htmlFor={`paybuttons.${index}`}>{pb.name}</label>
+        </div>
       ))}
       </div>
 

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -13,6 +13,7 @@ export const RESPONSE_MESSAGES = {
   BUTTON_IDS_NOT_PROVIDED_400: { statusCode: 400, message: "'paybuttonIdList' not provided." },
   TRANSACTION_ID_NOT_PROVIDED_400: { statusCode: 400, message: "'transactionId' not provided." },
   INVALID_NETWORK_SLUG_400: { statusCode: 400, message: 'Invalid network slug.' },
+  INVALID_NETWORK_ID_400: { statusCode: 400, message: 'Invalid network id.' },
   INVALID_BUTTON_DATA_400: { statusCode: 400, message: "'buttonData' is not valid JSON." },
   PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400: { statusCode: 400, message: 'One or more buttons already belong to another wallet.' },
   WALLET_CREATION_FAILED_400: { statusCode: 400, message: 'Wallet creation failed.' },
@@ -21,7 +22,12 @@ export const RESPONSE_MESSAGES = {
   INVALID_ADDRESS_400: { statusCode: 400, message: 'Invalid address.' },
   NO_ADDRESS_FOUND_404: { statusCode: 404, message: 'No address found.' },
   NO_BUTTON_FOUND_404: { statusCode: 404, message: 'No button found.' },
-  MULTIPLE_ADDRESSES_FOUND_400: { statusCode: 400, message: 'Multiple addresses found.' }
+  NO_WALLET_FOUND_404: { statusCode: 404, message: 'No wallet found.' },
+  NO_USER_PROFILE_FOUND_ON_WALLET_404: { statusCode: 404, message: 'No user profile found for wallet.' },
+  MULTIPLE_ADDRESSES_FOUND_400: { statusCode: 400, message: 'Multiple addresses found.' },
+  RESOURCE_DOES_NOT_BELONG_TO_USER_400: { statusCode: 400, message: 'Resource does not belong to user.' },
+  DEFAULT_XEC_WALLET_MUST_HAVE_SOME_XEC_ADDRESS_400: { statusCode: 400, message: 'Default XEC wallet must have some XEC address.' },
+  DEFAULT_BCH_WALLET_MUST_HAVE_SOME_BCH_ADDRESS_400: { statusCode: 400, message: 'Default BCH wallet must have some BCH address.' }
 }
 
 // When fetching some address transactions, number of transactions to fetch at a time.

--- a/pages/api/wallet/index.ts
+++ b/pages/api/wallet/index.ts
@@ -33,6 +33,9 @@ export default async (req: any, res: any): Promise<void> => {
         case RESPONSE_MESSAGES.BUTTON_IDS_NOT_PROVIDED_400.message:
           res.status(400).json(RESPONSE_MESSAGES.BUTTON_IDS_NOT_PROVIDED_400)
           break
+        case RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400)
+          break
         default:
           res.status(500).json({ statusCode: 500, message: parsedErr.message })
       }

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -42,12 +42,24 @@ export async function createWallet (values: CreateWalletInput): Promise<Wallet> 
     wallet = await prisma.wallet.create({
       data: {
         providerUserId: values.userId,
-        name: values.name
+        name: values.name,
+        userProfile: {
+          create: {
+            userProfile: {
+              connect: {
+                userId: values.userId
+              }
+            }
+          }
+        }
       }
     })
     for (const paybutton of paybuttonList) {
       if (paybutton.walletId !== null) {
         throw new Error(RESPONSE_MESSAGES.PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400.message)
+      }
+      if (paybutton.providerUserId !== values.userId) {
+        throw new Error(RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400.message)
       }
 
       await prisma.paybutton.update({

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -11,6 +11,13 @@ export interface CreateWalletInput {
   paybuttonIdList: number[]
 }
 
+export interface UpdateWalletInput {
+  name: string
+  isXECDefault?: boolean
+  isBCHDefault?: boolean
+  paybuttonIdList: number[]
+}
+
 const includeAddressesAndPaybuttons = {
   userProfile: {
     select: {

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -53,8 +53,13 @@ export async function createWallet (values: CreateWalletInput): Promise<Wallet> 
         userProfile: {
           create: {
             userProfile: {
-              connect: {
-                userId: values.userId
+              connectOrCreate: {
+                where: {
+                  userId: values.userId
+                },
+                create: {
+                  userId: values.userId
+                }
               }
             }
           }

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -64,7 +64,8 @@ export async function createWallet (values: CreateWalletInput): Promise<Wallet> 
             }
           }
         }
-      }
+      },
+      include: includeAddressesAndPaybuttons
     })
     for (const paybutton of paybuttonList) {
       if (paybutton.walletId !== null) {

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -289,6 +289,11 @@ describe('POST /api/wallets/', () => {
     expect(res.statusCode).toBe(200)
     expect(responseData.providerUserId).toBe('test-u-id')
     expect(responseData.name).toBe('test-wallet')
+    expect(responseData.userProfile).toStrictEqual({
+      isXECDefault: null,
+      isBCHDefault: null,
+      userProfileId: 3
+    })
     void expect(countWallets()).resolves.toBe(1)
   })
 

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -259,6 +259,8 @@ describe('POST /api/wallets/', () => {
       let button
       if (i === 2) {
         button = await createPaybuttonForUser('test-u-id', [lastAddress])
+      } else if (i === 3) {
+        button = await createPaybuttonForUser('test-other-u-id')
       } else {
         button = await createPaybuttonForUser('test-u-id')
       }
@@ -312,6 +314,18 @@ describe('POST /api/wallets/', () => {
     const responseData = res._getJSONData()
     expect(res.statusCode).toBe(400)
     expect(responseData.message).toBe(RESPONSE_MESSAGES.WALLET_NAME_ALREADY_EXISTS_400.message)
+  })
+
+  it('Fail with paybutton of other user', async () => {
+    baseRequestOptions.body = {
+      userId: 'test-u-id',
+      name: 'test-other-wallet',
+      paybuttonIdList: [buttonIds[3]]
+    }
+    const res = await testEndpoint(baseRequestOptions, walletEndpoint)
+    const responseData = res._getJSONData()
+    expect(res.statusCode).toBe(400)
+    expect(responseData.message).toBe(RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400.message)
   })
 
   it('Fail without paybuttonIdList', async () => {

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,7 +1,7 @@
 import { RESPONSE_MESSAGES, SUPPORTED_ADDRESS_PATTERN } from '../constants/index'
 import { Prisma } from '@prisma/client'
 import { CreatePaybuttonInput } from '../services/paybuttonService'
-import { CreateWalletInput } from '../services/walletService'
+import { CreateWalletInput, UpdateWalletInput } from '../services/walletService'
 import { getAddressPrefix } from './index'
 import xecaddr from 'xecaddrjs'
 
@@ -90,6 +90,13 @@ export interface WalletPOSTParameters {
   paybuttonIdList?: number[]
 }
 
+export interface WalletPATCHParameters {
+  name: string
+  isXECDefault?: boolean
+  isBCHDefault?: boolean
+  paybuttonIdList: number[]
+}
+
 export const parseWalletPOSTRequest = function (params: WalletPOSTParameters): CreateWalletInput {
   if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
@@ -98,5 +105,16 @@ export const parseWalletPOSTRequest = function (params: WalletPOSTParameters): C
     userId: params.userId,
     name: params.name,
     paybuttonIdList: params.paybuttonIdList
+  }
+}
+
+export const parseWalletPATCHRequest = function (params: WalletPATCHParameters): UpdateWalletInput {
+  if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
+  if (params.paybuttonIdList === undefined || params.paybuttonIdList === []) throw new Error(RESPONSE_MESSAGES.BUTTON_IDS_NOT_PROVIDED_400.message)
+  return {
+    name: params.name,
+    paybuttonIdList: params.paybuttonIdList,
+    isXECDefault: params.isXECDefault,
+    isBCHDefault: params.isBCHDefault
   }
 }


### PR DESCRIPTION
Description:
Provides functionalities and fixes needed for subsequent PRs that will implement the wallet editing on the back end.

- Creating a wallet now also creates the `WalletsOnUserProfile` connector (there is one for each wallet);
-  Also, it creates the `UserProfile` if it does not already exists.
- Cannot create a wallet if one of the paybuttons belongs to another user.

Test plan:
Should be covered by the tests.

Depends on:
- [x] #283 