### PR TITLE
[Issue #154] refactor: wallet edit form refresh & button id list

### DIFF
--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { Paybutton } from '@prisma/client'
 import { useForm } from 'react-hook-form'
+import { WalletPATCHParameters } from 'utils/validators'
 import Image from 'next/image'
 import style from '../Paybutton/paybutton.module.css'
 import s from '../Wallet/wallet.module.css'
@@ -10,17 +11,11 @@ import { WalletWithAddressesAndPaybuttons } from 'services/walletService'
 interface IProps {
   wallet: WalletWithAddressesAndPaybuttons
   userPaybuttons: Paybutton[]
+  refreshWalletList: Function
 }
 
-interface IForm {
-  name: string
-  isXECDefault: boolean
-  isBCHDefault: boolean
-  paybuttons: Array<{id: number, checked: boolean}>
-}
-
-export default function EditWalletForm ({ wallet, userPaybuttons }: IProps): ReactElement {
-  const { register, handleSubmit, reset } = useForm<IForm>()
+export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletList }: IProps): ReactElement {
+  const { register, handleSubmit, reset } = useForm<WalletPATCHParameters>()
   const [modal, setModal] = useState(false)
 
   useEffect(() => {
@@ -28,11 +23,12 @@ export default function EditWalletForm ({ wallet, userPaybuttons }: IProps): Rea
     reset()
   }, [wallet, userPaybuttons])
 
-  function onSubmit (params: IForm): void {
+  function onSubmit (params: WalletPATCHParameters): void {
     if (params.name === '' || params.name === undefined) {
       params.name = wallet.name
     }
     console.log('edit wallet params', params)
+    refreshWalletList()
   }
 
   return (
@@ -80,13 +76,14 @@ export default function EditWalletForm ({ wallet, userPaybuttons }: IProps): Rea
       <h4>Paybuttons</h4>
       <div className={s.buttonlist_ctn}>
       {userPaybuttons.map((pb, index) => (
-        <div className={s.input_field} key={pb.id}>
-          <input {...register(`paybuttons.${index}`)}
-          name={`paybuttons.${index}`}
+        <div className={s.input_field} key={`pb-${pb.id}`}>
+          <input {...register(`paybuttonIdList`)}
           type='checkbox'
+          value={pb.id}
+          id={`paybuttonIdList.${index}`}
           defaultChecked={pb.walletId === wallet.id}
           />
-          <label htmlFor={`paybuttons.${index}`}>{pb.name}</label>
+          <label htmlFor={`paybuttonIdList.${index}`}>{pb.name}</label>
         </div>
       ))}
       </div>

--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -13,9 +13,10 @@ interface IProps {
   wallet: WalletWithAddressesAndPaybuttons
   paymentInfo: WalletPaymentInfo
   userPaybuttons: Paybutton[]
+  refreshWalletList: Function
 }
 
-export default ({ wallet, paymentInfo, userPaybuttons }: IProps): FunctionComponent => {
+export default ({ wallet, paymentInfo, userPaybuttons, refreshWalletList }: IProps): FunctionComponent => {
   const networks = wallet.addresses.map((addr) => addr.networkId)
   return (
     <div className={style.wallet_card}>
@@ -30,7 +31,7 @@ export default ({ wallet, paymentInfo, userPaybuttons }: IProps): FunctionCompon
         <div className={style.edit_button_ctn}>
           {wallet.userProfile?.isXECDefault === true && <div className={style.default_wallet}>Default XEC Wallet</div>}
           {wallet.userProfile?.isBCHDefault === true && <div className={style.default_wallet}>Default BCH Wallet</div>}
-          <EditWalletForm wallet={wallet} userPaybuttons={userPaybuttons}/>
+          <EditWalletForm wallet={wallet} userPaybuttons={userPaybuttons} refreshWalletList={refreshWalletList}/>
         </div>
       </div>
 

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -87,6 +87,12 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
     }
   }
 
+  refreshWalletList = (): void => {
+    this.setState(() => {
+      void this.fetchWallets()
+    })
+  }
+
   render (): React.ReactElement {
     return (
       <>
@@ -96,17 +102,17 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
           /* Sorts in the following order, from first to last, if they exist:
            * Default XEC Wallet, Default BCH Wallet, other wallets.
            */
-          if (a.wallet.userProfile?.isXECDefault === true ) {
-            return -1;
-          } else if (a.wallet.userProfile?.isBCHDefault === true ) {
-            if (b.wallet.userProfile?.isXECDefault === true ) {
-              return 1;
+          if (a.wallet.userProfile?.isXECDefault === true) {
+            return -1
+          } else if (a.wallet.userProfile?.isBCHDefault === true) {
+            if (b.wallet.userProfile?.isXECDefault === true) {
+              return 1
             }
             return -1
           }
           return a.wallet.name.localeCompare(b.wallet.name)
         }).map(walletWithPaymentInfo => {
-          return <WalletCard wallet={walletWithPaymentInfo.wallet} paymentInfo={walletWithPaymentInfo.paymentInfo} userPaybuttons={this.state.userPaybuttons} />
+          return <WalletCard wallet={walletWithPaymentInfo.wallet} paymentInfo={walletWithPaymentInfo.paymentInfo} userPaybuttons={this.state.userPaybuttons} refreshWalletList={this.refreshWalletList}/>
         }
         )}
         <WalletForm />


### PR DESCRIPTION
Description:
- Refresh wallets list upon pressing the **Submit** button, when editing a wallet
- Some other refactors needed for upcoming functionality 

Test plan:
At http://localhost:3000/wallets, when editing a wallet, clicking on the submit button should now close the modal (and reload the wallets).