### PR TITLE
[Issue #246] feat: 'All' option for dashboard charts

### DIFF
--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -106,7 +106,7 @@ const getPeriodData = function (n: number, periodString: string, transactions: T
 const getAllMonths = function (transactions: any[]): AllMonths {
   const oldestdate = transactions.reduce(
     (prev, cur) => (prev?.timestamp < cur.timestamp ? prev : cur),
-    null
+    { timestamp: Date.now() / 1000 }
   )
   const currentDate = Date.now() / 1000
   const diff = currentDate - oldestdate.timestamp

--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -103,8 +103,11 @@ const getPeriodData = function (n: number, periodString: string, transactions: T
   }
 }
 
-const getAllMonths = function (n: any[]): AllMonths {
-  const oldestdate = n.reduce((r, o) => o.timestamp < r.timestamp ? o : r)
+const getAllMonths = function (transactions: any[]): AllMonths {
+  const oldestdate = transactions.reduce(
+    (prev, cur) => (prev?.timestamp < cur.timestamp ? prev : cur),
+    null
+  )
   const currentDate = Date.now() / 1000
   const diff = currentDate - oldestdate.timestamp
   const min = diff / 60
@@ -137,7 +140,7 @@ const getUserDashboardData = async function (userId: string): Promise<DashboardD
   const thirtyDays: PeriodData = getPeriodData(30, 'days', incomingTransactionsInUSD, { revenue: '#66fe91', payments: '#669cfe' })
   const sevenDays: PeriodData = getPeriodData(7, 'days', incomingTransactionsInUSD, { revenue: '#66fe91', payments: '#669cfe' })
   const year: PeriodData = getPeriodData(12, 'months', incomingTransactionsInUSD, { revenue: '#66fe91', payments: '#669cfe' }, 'MMM')
-  const all: PeriodData = getPeriodData(allmonths.months, 'months', incomingTransactionsInUSD, { revenue: '#66fe91', payments: '#669cfe' }, 'MMM YY')
+  const all: PeriodData = getPeriodData(allmonths.months, 'months', incomingTransactionsInUSD, { revenue: '#66fe91', payments: '#669cfe' }, 'MMM YYYY')
 
   return {
     thirtyDays,

--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -50,8 +50,8 @@ const getChartRevenuePaymentData = function (n: number, periodString: string, tr
   const paymentsArray: number[] = []
   const _ = [...new Array(n)]
   _.forEach((i, idx) => {
-    const lowerThreshold = moment().startOf('day').subtract(idx + 1, periodString as DurationInputArg2)
-    const upperThreshold = moment().startOf('day').subtract(idx, periodString as DurationInputArg2)
+    const lowerThreshold = moment().startOf(periodString === 'months' ? 'month' : 'day').subtract(idx, periodString as DurationInputArg2)
+    const upperThreshold = moment().endOf(periodString === 'months' ? 'month' : 'day').subtract(idx, periodString as DurationInputArg2)
     const periodTransactionAmountArray = filterLastTransactions(lowerThreshold, upperThreshold, transactions).map((t) => t.amount)
     const revenue = periodTransactionAmountArray.reduce((a, b) => {
       return a.plus(b)
@@ -122,10 +122,10 @@ const getUserDashboardData = async function (userId: string): Promise<DashboardD
   const BCHTransactions = Array.prototype.concat.apply([], BCHAddresses.map((addr) => addr.transactions))
   const XECTransactions = Array.prototype.concat.apply([], XECAddresses.map((addr) => addr.transactions))
   const incomingTransactionsInUSD = BCHTransactions.map((t) => {
-    t.amount = t.amount.times(DUMMY_BCH_PRICE).toFixed(2)
+    t.amount = t.amount.times(DUMMY_BCH_PRICE)
     return t
   }).concat(XECTransactions.map((t) => {
-    t.amount = t.amount.times(DUMMY_XEC_PRICE).toFixed(2)
+    t.amount = t.amount.times(DUMMY_XEC_PRICE)
     return t
   })).filter((t) => {
     return t.amount > 0

--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -132,7 +132,7 @@ const getUserDashboardData = async function (userId: string): Promise<DashboardD
   })
 
   const totalRevenue = incomingTransactionsInUSD.map((t) => t.amount).reduce((a, b) => a.plus(b), new Prisma.Decimal(0))
-  const allmonths = getAllMonths(incomingTransactionsInUSD)
+  const allmonths: AllMonths = getAllMonths(incomingTransactionsInUSD)
 
   const thirtyDays: PeriodData = getPeriodData(30, 'days', incomingTransactionsInUSD, { revenue: '#66fe91', payments: '#669cfe' })
   const sevenDays: PeriodData = getPeriodData(7, 'days', incomingTransactionsInUSD, { revenue: '#66fe91', payments: '#669cfe' })

--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -98,8 +98,8 @@ const getPeriodData = function (n: number, periodString: string, transactions: T
   return {
     revenue,
     payments,
-    totalRevenue: (revenue.datasets[0].data as any).reduce((a: Prisma.Decimal, b: Prisma.Decimal) => a.plus(b)),
-    totalPayments: (payments.datasets[0].data as any).reduce((a: number, b: number) => a + b)
+    totalRevenue: (revenue.datasets[0].data as any).reduce((a: Prisma.Decimal, b: Prisma.Decimal) => a.plus(b), new Prisma.Decimal(0)),
+    totalPayments: (payments.datasets[0].data as any).reduce((a: number, b: number) => a + b, 0)
   }
 }
 

--- a/pages/dashboard/Chart.tsx
+++ b/pages/dashboard/Chart.tsx
@@ -72,6 +72,7 @@ const Chart: NextPage<Props> = ({ data, usd }) => {
           color: cssvar('--chart-line-color')
         },
         grace: '0%',
+        beginAtZero: true,
         ticks: {
           color: cssvar('--primary-text-color'),
           callback: function (value) {

--- a/pages/dashboard/Chart.tsx
+++ b/pages/dashboard/Chart.tsx
@@ -1,5 +1,6 @@
 import type { NextPage } from 'next'
 import React from 'react'
+import { FormatNumber } from 'utils/general'
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -46,7 +47,7 @@ const Chart: NextPage<Props> = ({ data, usd }) => {
         displayColors: false,
         callbacks: {
           label: function (context) {
-            return usd ? '$' + context.formattedValue : context.formattedValue
+            return usd ? '$' + FormatNumber(context.raw, 'dollars') : FormatNumber(context.raw)
           }
         },
         mode: 'nearest',

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -84,12 +84,13 @@ export default function Dashboard ({ userId }: PaybuttonsProps): React.ReactElem
         <button className={activePeriod === dashboardData.sevenDays ? `${style.active_btn} ${style.toggle_btn}` : style.toggle_btn} onClick={() => { setActivePeriod(dashboardData.sevenDays) }}>1W</button>
         <button className={activePeriod === dashboardData.thirtyDays ? `${style.active_btn} ${style.toggle_btn}` : style.toggle_btn} onClick={() => { setActivePeriod(dashboardData.thirtyDays) }}>1M</button>
         <button className={activePeriod === dashboardData.year ? `${style.active_btn} ${style.toggle_btn}` : style.toggle_btn} onClick={() => { setActivePeriod(dashboardData.year) }}>1Y</button>
+        {dashboardData.all.revenue.labels.length > 12 && <button className={activePeriod === dashboardData.all ? `${style.active_btn} ${style.toggle_btn}` : style.toggle_btn} onClick={() => { setActivePeriod(dashboardData.all) }}>All</button>}
       </div>
       <div className={style.chart_outer_ctn}>
         <div className={style.chart_inner_ctn}>
           <div className={style.chart_title_ctn}>
             <h4>Revenue</h4>
-            <h5>{activePeriod === dashboardData.year ? 'Year' : activePeriod === dashboardData.thirtyDays ? '30 Day' : '7 Day'} Total: ${FormatNumber(activePeriod.totalRevenue, 'dollars')}</h5>
+            <h5>{activePeriod === dashboardData.all ? 'Lifetime' : activePeriod === dashboardData.year ? 'Year' : activePeriod === dashboardData.thirtyDays ? '30 Day' : '7 Day'} Total: ${FormatNumber(activePeriod.totalRevenue, 'dollars')}</h5>
           </div>
           <div className={style.chart_ctn}>
             <Chart data={activePeriod.revenue} usd={true} />
@@ -98,7 +99,7 @@ export default function Dashboard ({ userId }: PaybuttonsProps): React.ReactElem
         <div className={style.chart_inner_ctn}>
           <div className={style.chart_title_ctn}>
             <h4>Payments</h4>
-            <h5>{activePeriod === dashboardData.year ? 'Year' : activePeriod === dashboardData.thirtyDays ? '30 Day' : '7 Day'} Total: {FormatNumber(activePeriod.totalPayments)}</h5>
+            <h5>{activePeriod === dashboardData.all ? 'Lifetime' : activePeriod === dashboardData.year ? 'Year' : activePeriod === dashboardData.thirtyDays ? '30 Day' : '7 Day'} Total: {FormatNumber(activePeriod.totalPayments)}</h5>
           </div>
           <div className={style.chart_ctn}>
             <Chart data={activePeriod.payments} />

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -677,6 +677,7 @@ describe('GET /api/dashboard', () => {
       thirtyDays: expectedPeriodData,
       sevenDays: expectedPeriodData,
       year: expectedPeriodData,
+      all: expectedPeriodData,
       total: {
         revenue: expect.any(String),
         payments: expect.any(Number),

--- a/utils/general.ts
+++ b/utils/general.ts
@@ -7,7 +7,7 @@ export const copyText = function (id: string): string {
 
 export const FormatNumber = (x, type) => {
   if (type === 'dollars') {
-    const addcommas = parseFloat(x).toLocaleString(undefined, { minimumFractionDigits: 2 })
+    const addcommas = parseFloat(x).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
     return addcommas
   } else {
     const addcommas = parseFloat(x).toLocaleString()


### PR DESCRIPTION
Adding an all option to the dashboard charts. Also fixed a few bugs that were causing sub $0.01 transactions to not register, and causing some date misalignments in the charts 

Test plan: Run the app and test out the all button, and see if the transactions line up on the chart 