### PR TITLE
[Issue #154] refactor: createWallet returning model with related fields; test objects

### DIFF
--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -23,7 +23,7 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
     reset()
   }, [wallet, userPaybuttons])
 
-  function onSubmit (params: WalletPATCHParameters): void {
+  async function onSubmit (params: WalletPATCHParameters): Promise<void> {
     if (params.name === '' || params.name === undefined) {
       params.name = wallet.name
     }

--- a/pages/api/wallet/[id].ts
+++ b/pages/api/wallet/[id].ts
@@ -6,16 +6,16 @@ export default async (
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> => {
+  const walletId = req.query.id as string
   if (req.method === 'GET') {
-    const walletId = req.query.id as string
     try {
       const wallet = await walletService.fetchWalletById(walletId)
-      if (wallet == null) throw new Error(RESPONSE_MESSAGES.NOT_FOUND_404.message)
+      if (wallet == null) throw new Error(RESPONSE_MESSAGES.NO_WALLET_FOUND_404.message)
       res.status(200).json(wallet)
     } catch (err: any) {
       switch (err.message) {
-        case RESPONSE_MESSAGES.NOT_FOUND_404.message:
-          res.status(404).json(RESPONSE_MESSAGES.NOT_FOUND_404)
+        case RESPONSE_MESSAGES.NO_WALLET_FOUND_404.message:
+          res.status(404).json(RESPONSE_MESSAGES.NO_WALLET_FOUND_404)
           break
         default:
           res.status(500).json({ statusCode: 500, message: err.message })

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -541,7 +541,7 @@ describe('GET /api/wallet/[id]', () => {
     const res = await testEndpoint(baseRequestOptions, walletIdEndpoint)
     expect(res.statusCode).toBe(404)
     const responseData = res._getJSONData()
-    expect(responseData.message).toBe(RESPONSE_MESSAGES.NOT_FOUND_404.message)
+    expect(responseData.message).toBe(RESPONSE_MESSAGES.NO_WALLET_FOUND_404.message)
   })
 })
 

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -6,8 +6,10 @@ import {
 } from 'grpc-bchrpc-node'
 
 import { Prisma } from '@prisma/client'
+import { PaybuttonWithAddresses } from 'services/paybuttonService'
+import { WalletWithAddressesAndPaybuttons } from 'services/walletService'
 
-export const mockedPaybutton = {
+export const mockedPaybutton: PaybuttonWithAddresses = {
   id: 4,
   providerUserId: 'mocked-uid',
   name: 'mocked-name',
@@ -15,7 +17,7 @@ export const mockedPaybutton = {
   uuid: '730bfa24-eb57-11ec-b722-0242ac150002',
   createdAt: new Date('2022-05-27T15:18:42.000Z'),
   updatedAt: new Date('2022-05-27T15:18:42.000Z'),
-  walletId: null,
+  walletId: 1,
   addresses: [
     {
       address: {
@@ -24,7 +26,7 @@ export const mockedPaybutton = {
         createdAt: new Date('2022-05-27T15:18:42.000Z'),
         updatedAt: new Date('2022-05-27T15:18:42.000Z'),
         networkId: 1,
-        walletId: null
+        walletId: 1
       }
     },
     {
@@ -34,7 +36,7 @@ export const mockedPaybutton = {
         createdAt: new Date('2022-05-27T15:18:42.000Z'),
         updatedAt: new Date('2022-05-27T15:18:42.000Z'),
         networkId: 2,
-        walletId: null
+        walletId: 1
       }
     }
   ]
@@ -128,13 +130,39 @@ export const mockedPaybuttonList = [
 ]
 
 // Wallet
-export const mockedWallet = {
+export const mockedWallet: WalletWithAddressesAndPaybuttons = {
   id: 1,
   createdAt: new Date('2022-09-30T18:01:32.456Z'),
   updatedAt: new Date('2022-09-30T18:01:32.456Z'),
   name: 'mockedWallet',
   providerUserId: 'mocked-uid',
-  userProfile: null
+  userProfile: {
+    isXECDefault: null,
+    isBCHDefault: null,
+    userProfileId: 1
+  },
+  paybuttons: [{
+    id: 4,
+    providerUserId: 'mocked-uid',
+    name: 'mocked-name',
+    buttonData: 'mockedData',
+    uuid: '730bfa24-eb57-11ec-b722-0242ac150002',
+    createdAt: new Date('2022-05-27T15:18:42.000Z'),
+    updatedAt: new Date('2022-05-27T15:18:42.000Z'),
+    walletId: 1
+  }],
+  addresses: [
+    {
+      id: 1,
+      address: 'mockedaddress0nkus8hzv367za28j900c7tv5v8pc',
+      networkId: 1
+    },
+    {
+      id: 2,
+      address: 'mockedaddress0nkush83z76az28900c7tj5vpc8f',
+      networkId: 2
+    }
+  ]
   // "paybuttons": [],
   // "addresses": []
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,9 +1,8 @@
 import * as httpMocks from 'node-mocks-http'
 import prisma from 'prisma/clientInstance'
 import { createPaybutton, PaybuttonWithAddresses } from 'services/paybuttonService'
-import { createWallet } from 'services/walletService'
+import { createWallet, WalletWithAddressesAndPaybuttons } from 'services/walletService'
 import { SUPPORTED_ADDRESS_PATTERN } from 'constants/index'
-import { Wallet } from '@prisma/client'
 import RandExp from 'randexp'
 
 export const testEndpoint = async (requestOptions: httpMocks.RequestOptions, endpoint: Function): Promise<httpMocks.MockResponse<any>> => {
@@ -26,7 +25,7 @@ export const clearPaybuttonsAndAddresses = async (): Promise<void> => {
 
 const addressRandexp = new RandExp(SUPPORTED_ADDRESS_PATTERN)
 
-export const createWalletForUser = async (userId: string, paybuttonIdList: number[]): Promise<Wallet> => {
+export const createWalletForUser = async (userId: string, paybuttonIdList: number[]): Promise<WalletWithAddressesAndPaybuttons> => {
   const name = Math.random().toString(36).slice(2)
   return await createWallet({ userId, name, paybuttonIdList })
 }


### PR DESCRIPTION
Description:
More requisites to the PRs that will implement the wallet functionality in the front end.

Test plan:
Creating a wallet, e.g. with:
```
curl -X POST localhost:3000/api/wallet -H "Content-Type: application/json"  -d '{"userId": "dev-uid", "name":"otherwallet", "paybuttonIdList":[6] }'
```

now returns the wallet with its paybuttons & addresses.