### PR TITLE
[Issue #306] feat: create default wallet for user

### DIFF
--- a/config/backendConfig.ts
+++ b/config/backendConfig.ts
@@ -3,6 +3,7 @@ import SessionNode from 'supertokens-node/recipe/session'
 import { appInfo } from './appInfo'
 import { TypeInput } from 'supertokens-node/types'
 import * as addressService from 'services/addressService'
+import * as walletService from 'services/walletService'
 import { syncTransactions } from 'services/transactionService'
 
 const getSocialLoginProviders = (): array => {
@@ -82,6 +83,7 @@ export const backendConfig = (): TypeInput => {
                 const response = await originalImplementation.emailPasswordSignUpPOST(input)
 
                 if (response.status === 'OK') {
+                  void walletService.createDefaultWalletForUser(response.user.id)
                   // post sign up logic goes here
                 }
 
@@ -117,6 +119,7 @@ export const backendConfig = (): TypeInput => {
                 if (response.status === 'OK') {
                   if (response.createdNewUser) {
                     // post sign up logic goes here
+                    void walletService.createDefaultWalletForUser(response.user.id)
                   } else {
                     // post sign in logic goes here
                     (await addressService.fetchAllUserAddresses(response.user.id)).forEach((addr) => {

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -107,6 +107,16 @@ export async function createWallet (values: CreateWalletInput): Promise<WalletWi
   })
 }
 
+export async function createDefaultWalletForUser (userId: string): Promise<WalletWithAddressesAndPaybuttons> {
+  const wallet = await createWallet({
+    userId,
+    name: 'Default Wallet',
+    paybuttonIdList: []
+  })
+  await setDefaultWallet(wallet, [XEC_NETWORK_ID, BCH_NETWORK_ID])
+  return wallet
+}
+
 export async function fetchWalletById (walletId: number | string): Promise<WalletWithAddressesAndPaybuttons | null> {
   return await prisma.wallet.findUnique({
     where: { id: Number(walletId) },

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -119,9 +119,6 @@ export async function setDefaultWallet (wallet: WalletWithAddressesAndPaybuttons
     throw new Error(RESPONSE_MESSAGES.NO_USER_PROFILE_FOUND_ON_WALLET_404.message)
   }
   if (networkIds.includes(XEC_NETWORK_ID)) {
-    if (!wallet.addresses.some((addr) => addr.networkId === XEC_NETWORK_ID)) {
-      throw new Error(RESPONSE_MESSAGES.DEFAULT_XEC_WALLET_MUST_HAVE_SOME_XEC_ADDRESS_400.message)
-    }
     // see if any wallet is already the default
     const prevXECDefault = await prisma.walletsOnUserProfile.findUnique({
       where: {
@@ -160,9 +157,6 @@ export async function setDefaultWallet (wallet: WalletWithAddressesAndPaybuttons
     })
   }
   if (networkIds.includes(BCH_NETWORK_ID)) {
-    if (!wallet.addresses.some((addr) => addr.networkId === BCH_NETWORK_ID)) {
-      throw new Error(RESPONSE_MESSAGES.DEFAULT_BCH_WALLET_MUST_HAVE_SOME_BCH_ADDRESS_400.message)
-    }
     // see if any wallet is already the default
     const prevBCHDefault = await prisma.walletsOnUserProfile.findUnique({
       where: {

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -4,7 +4,7 @@ import * as walletService from 'services/walletService'
 import * as addressService from 'services/addressService'
 import { prismaMock } from 'prisma/mockedClient'
 import { RESPONSE_MESSAGES } from 'constants/index'
-import { mockedWallet, mockedWalletsOnUserProfile, mockedWalletList, mockedPaybuttonList, mockedPaybutton, mockedNetwork, mockedBCHAddress } from '../mockedObjects'
+import { mockedWallet, mockedWalletList, mockedPaybuttonList, mockedPaybutton, mockedNetwork, mockedBCHAddress } from '../mockedObjects'
 
 describe('Fetch services', () => {
   it('Should fetch wallet by id', async () => {
@@ -202,58 +202,6 @@ describe('Update services', () => {
       await walletService.updateWallet(mockedWallet.id, data.updateWalletInput)
     } catch (e: any) {
       expect(e.message).toMatch(RESPONSE_MESSAGES.NO_USER_PROFILE_FOUND_ON_WALLET_404.message)
-    }
-  })
-  it('Fail if trying to set as BCH Default with no BCH addresses', async () => {
-    data.updateWalletInput.isBCHDefault = true
-    prismaMock.walletsOnUserProfile.update.mockResolvedValue(mockedWalletsOnUserProfile)
-    prisma.walletsOnUserProfile.update = prismaMock.walletsOnUserProfile.update
-    const noBCHAddressWallet = {
-      ...mockedWallet,
-      addresses: [
-        {
-          id: 2,
-          address: 'mockedaddress0nkush83z76az28900c7tj5vpc8f',
-          networkId: 1
-        }
-      ]
-    }
-
-    prismaMock.wallet.findUnique.mockResolvedValue(noBCHAddressWallet)
-    prisma.wallet.findUnique = prismaMock.wallet.findUnique
-    prismaMock.wallet.update.mockResolvedValue(noBCHAddressWallet)
-    prisma.wallet.update = prismaMock.wallet.update
-    expect.assertions(1)
-    try {
-      await walletService.updateWallet(mockedWallet.id, data.updateWalletInput)
-    } catch (e: any) {
-      expect(e.message).toMatch(RESPONSE_MESSAGES.DEFAULT_BCH_WALLET_MUST_HAVE_SOME_BCH_ADDRESS_400.message)
-    }
-  })
-  it('Fail if trying to set as XEC Default with no XEC addresses', async () => {
-    data.updateWalletInput.isXECDefault = true
-    prismaMock.walletsOnUserProfile.update.mockResolvedValue(mockedWalletsOnUserProfile)
-    prisma.walletsOnUserProfile.update = prismaMock.walletsOnUserProfile.update
-    const noXECAddressWallet = {
-      ...mockedWallet,
-      addresses: [
-        {
-          id: 2,
-          address: 'mockedaddress0nkush83z76az28900c7tj5vpc8f',
-          networkId: 2
-        }
-      ]
-    }
-
-    prismaMock.wallet.findUnique.mockResolvedValue(noXECAddressWallet)
-    prisma.wallet.findUnique = prismaMock.wallet.findUnique
-    prismaMock.wallet.update.mockResolvedValue(noXECAddressWallet)
-    prisma.wallet.update = prismaMock.wallet.update
-    expect.assertions(1)
-    try {
-      await walletService.updateWallet(mockedWallet.id, data.updateWalletInput)
-    } catch (e: any) {
-      expect(e.message).toMatch(RESPONSE_MESSAGES.DEFAULT_XEC_WALLET_MUST_HAVE_SOME_XEC_ADDRESS_400.message)
     }
   })
   it('Fail for empty name', async () => {


### PR DESCRIPTION
Description:
Upon registering, new users have now a wallet being created for them, set as the default for both XEC & BCH.

Test plan:
Log out, create a new user, confirm the email. A empty wallet should be there:
![image](https://user-images.githubusercontent.com/21281174/200661093-f6499415-3305-4752-b2c5-adbdb8cdc908.png)