### PR TITLE
[Issue #155] feat: showing networks connection info

### DIFF
--- a/components/Network/NetworkList.tsx
+++ b/components/Network/NetworkList.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react'
-import { Network } from '@prisma/client'
+import { NetworkWithConnectionInfo } from 'services/networkService'
 import style from './network.module.css'
 
-interface IProps { networks: Network[] }
+interface IProps { networks: NetworkWithConnectionInfo[] }
 export default ({ networks }: IProps): FunctionComponent<IProps> => {
   return (
     <div className={style.network_ctn}>
@@ -10,8 +10,8 @@ export default ({ networks }: IProps): FunctionComponent<IProps> => {
         <div key={network.id} className={style.card_wrapper}>
             <div className={style.network_card_text}>
               <div className={style.cardTitle}>{network.title}</div>
-              <div>Last block: X time ago</div>
-                {network.title === 'eCash' ? 
+              <div>Last block: {network.minutesSinceLastBlock ?? '-'} time ago</div>
+                {network.connected === true ? 
                   <div className={style.cardStatus} style={{ color: '#04b504' }}>Connected</div> :
                   <div className={style.cardStatus}>Disconnected</div>
                 }

--- a/components/Network/NetworkList.tsx
+++ b/components/Network/NetworkList.tsx
@@ -10,10 +10,12 @@ export default ({ networks }: IProps): FunctionComponent<IProps> => {
         <div key={network.id} className={style.card_wrapper}>
             <div className={style.network_card_text}>
               <div className={style.cardTitle}>{network.title}</div>
-              <div>Last block: {network.minutesSinceLastBlock ?? '-'} time ago</div>
-                {network.connected === true ? 
-                  <div className={style.cardStatus} style={{ color: '#04b504' }}>Connected</div> :
-                  <div className={style.cardStatus}>Disconnected</div>
+                {network.connected
+                  ? <>
+                    <div className={style.cardStatus} style={{ color: '#04b504' }}>Connected</div>
+                    <div>Last block: {network.minutesSinceLastBlock ?? '-'} time ago</div>
+                  </>
+                  : <div className={style.cardStatus}>Disconnected</div>
                 }
             </div>
         </div>

--- a/components/Network/NetworkList.tsx
+++ b/components/Network/NetworkList.tsx
@@ -13,7 +13,7 @@ export default ({ networks }: IProps): FunctionComponent<IProps> => {
                 {network.connected
                   ? <>
                     <div className={style.cardStatus} style={{ color: '#04b504' }}>Connected</div>
-                    <div>Last block: {network.minutesSinceLastBlock ?? '-'} time ago</div>
+                    <div>Last block: {network.minutesSinceLastBlock ?? '-'} {network.minutesSinceLastBlock === 1 ? 'minute' : 'minutes'} ago</div>
                   </>
                   : <div className={style.cardStatus}>Disconnected</div>
                 }

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -29,7 +29,8 @@ export const RESPONSE_MESSAGES = {
   DEFAULT_XEC_WALLET_MUST_HAVE_SOME_XEC_ADDRESS_400: { statusCode: 400, message: 'Default XEC wallet must have some XEC address.' },
   DEFAULT_BCH_WALLET_MUST_HAVE_SOME_BCH_ADDRESS_400: { statusCode: 400, message: 'Default BCH wallet must have some BCH address.' },
   MISSING_PRICE_API_URL_400: { statusCode: 400, message: 'Missing PRICE_API_URL environment variable.' },
-  MISSING_PRICE_FOR_TRANSACTION_400: { statusCode: 400, message: 'Missing price for transaction.' }
+  MISSING_PRICE_FOR_TRANSACTION_400: { statusCode: 400, message: 'Missing price for transaction.' },
+  COULD_NOT_GET_BLOCK_INFO: { statusCode: 500, message: "Couldn't get block info." }
 }
 
 // When fetching some address transactions, number of transactions to fetch at a time.

--- a/pages/api/networks/index.ts
+++ b/pages/api/networks/index.ts
@@ -5,12 +5,7 @@ import { appInfo } from 'config/appInfo'
 export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   if (req.method === 'GET') {
     try {
-      let networkList
-      if (appInfo.showTestNetworks === true) {
-        networkList = await networkService.getAllNetworks()
-      } else {
-        networkList = await networkService.getAllMainNetworks()
-      }
+      const networkList = await networkService.getNetworks(appInfo.showTestNetworks)
       res.status(200).json(networkList)
     } catch (err: any) {
       switch (err.message) {

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -5,6 +5,8 @@ import {
   GetTransactionResponse,
   GetAddressTransactionsResponse,
   GetAddressUnspentOutputsResponse,
+  GetBlockchainInfoResponse,
+  GetBlockInfoResponse
 } from 'grpc-bchrpc-node'
 
 import { getAddressPrefix } from '../utils/index'
@@ -50,6 +52,16 @@ interface GetAddressParameters {
   hash?: string
   reversedHashOrder?: boolean
 }
+
+export const getBlockchainInfo = async (networkSlug: string): Promise<GetBlockchainInfoResponse.AsObject> => {
+  const client = getClientForNetworkSlug(networkSlug)
+  return (await client.getBlockchainInfo()).toObject();
+};
+
+export const getBlockInfo = async (networkSlug: string, height: number): Promise<GetBlockInfoResponse.AsObject> => {
+  const client = getClientForNetworkSlug(networkSlug)
+  return (await client.getBlockInfo({index: height})).toObject();
+};
 
 export const getAddress = async (
   parameters: GetAddressParameters

--- a/services/networkService.ts
+++ b/services/networkService.ts
@@ -1,22 +1,59 @@
-import { Network } from '@prisma/client'
+import { Network, Prisma } from '@prisma/client'
+import { RESPONSE_MESSAGES } from 'constants/index'
 import prisma from 'prisma/clientInstance'
+import { getBlockchainInfo, getBlockInfo }from 'services/grpcService'
 
 export async function getNetworkFromSlug (slug: string): Promise<Network | null> {
   return await prisma.network.findUnique({ where: { slug } })
 }
 
-export async function getAllMainNetworks (): Promise<Network[] | null> {
-  return await prisma.network.findMany({
+export interface ConnectionInfo {
+  connected: boolean
+  minutesSinceLastBlock?: number
+}
+
+export interface NetworkWithConnectionInfo extends Network, ConnectionInfo {}
+
+async function isConnected(networkSlug: string): Promise<ConnectionInfo> {
+  try {
+    let blockchainInfo = await getBlockchainInfo(networkSlug)
+    let lastBlockInfo = await getBlockInfo(networkSlug, blockchainInfo.bestHeight)
+    if (lastBlockInfo.info === undefined) throw new Error(RESPONSE_MESSAGES.COULD_NOT_GET_BLOCK_INFO.message)
+    let minutesSinceLastBlock = (Math.floor(
+      (
+        Date.now()/1000 - lastBlockInfo.info?.timestamp
+      ) / 60
+    ))
+    return {
+      connected: true,
+      minutesSinceLastBlock
+    }
+  } catch (e: any) {
+    return {
+      connected: false,
+    }
+  }
+}
+
+export async function getNetworks (includeTestNetworks?: boolean): Promise<NetworkWithConnectionInfo[] | null> {
+  let findManyInput: Prisma.NetworkFindManyArgs = includeTestNetworks === true ? {} : {
     where: {
       slug: {
         in: ['ecash', 'bitcoincash']
       }
     }
-  })
-}
+  }
+  let networks = await prisma.network.findMany(findManyInput)
 
-export async function getAllNetworks (): Promise<Network[] | null> {
-  return await prisma.network.findMany({ })
+  let networksWithConnectionInfo = await Promise.all(
+    networks.map(async (network) => {
+      return {
+      ...network,
+      ...await isConnected(network.slug)
+      }
+    })
+  )
+  return networksWithConnectionInfo
 }
 
 export async function getAllNetworkSlugs (): Promise<string[] | null> {


### PR DESCRIPTION
Description:
Solves #155. Shows network info in the front end.
![image](https://user-images.githubusercontent.com/21281174/200720618-0cc2208b-4500-4d8a-aabb-5d5b61fe5db9.png)

Test plan:
Go to http://localhost:3000/networks and see if the info is there. Then mess up something of the `.env` file, run `make reset-dev` and see if it shows "Disconnected" for the messed up network(s).