### PR TITLE
[Issue #171] feat:sync transactions endpoint

### DIFF
--- a/pages/api/transactions/[address].ts
+++ b/pages/api/transactions/[address].ts
@@ -3,9 +3,8 @@ import { parseAddress } from 'utils/validators'
 import { RESPONSE_MESSAGES } from 'constants/index'
 import { fetchAddressTransactions } from 'services/transactionService'
 import Cors from 'cors'
-import grpcService from 'services/grpcService'
 
-const { ADDRESS_NOT_PROVIDED_400, NO_ADDRESS_FOUND_404 } = RESPONSE_MESSAGES
+const { ADDRESS_NOT_PROVIDED_400, NO_ADDRESS_FOUND_404, INVALID_ADDRESS_400 } = RESPONSE_MESSAGES
 const cors = Cors({
   methods: ['GET', 'HEAD']
 })
@@ -42,9 +41,11 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
           res.status(ADDRESS_NOT_PROVIDED_400.statusCode).json(ADDRESS_NOT_PROVIDED_400)
           break
         case NO_ADDRESS_FOUND_404.message: {
-          const address = parseAddress(req.query.address as string)
-          const transactions = await grpcService.getAddress({ address })
-          res.status(200).send(transactions)
+          res.status(NO_ADDRESS_FOUND_404.statusCode).send(NO_ADDRESS_FOUND_404)
+          break
+        }
+        case INVALID_ADDRESS_400.message: {
+          res.status(INVALID_ADDRESS_400.statusCode).send(INVALID_ADDRESS_400)
           break
         }
         default:

--- a/pages/api/transactions/sync/[address].ts
+++ b/pages/api/transactions/sync/[address].ts
@@ -1,0 +1,54 @@
+import { NextApiResponse, NextApiRequest } from 'next'
+import { parseAddress } from 'utils/validators'
+import { RESPONSE_MESSAGES } from 'constants/index'
+import { syncTransactionsForAddress } from 'services/transactionService'
+import { upsertAddress } from 'services/addressService'
+import Cors from 'cors'
+
+const { ADDRESS_NOT_PROVIDED_400, INVALID_ADDRESS_400 } = RESPONSE_MESSAGES
+const cors = Cors({
+  methods: ['GET', 'HEAD']
+})
+
+async function runMiddleware (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  fn: Function
+): Promise<any> {
+  return await new Promise((resolve, reject) => {
+    fn(req, res, (result: any) => {
+      if (result instanceof Error) {
+        return reject(result)
+      }
+
+      return resolve(result)
+    })
+  })
+}
+
+export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+  await runMiddleware(req, res, cors)
+  if (req.method === 'GET') {
+    try {
+      if (req.query.address === '' || req.query.address === undefined) {
+        throw new Error(ADDRESS_NOT_PROVIDED_400.message)
+      }
+      const addressString = parseAddress(req.query.address as string)
+      void await upsertAddress(addressString)
+      const transactions = await syncTransactionsForAddress(addressString)
+      res.status(200).send(transactions)
+    } catch (err: any) {
+      switch (err.message) {
+        case ADDRESS_NOT_PROVIDED_400.message:
+          res.status(ADDRESS_NOT_PROVIDED_400.statusCode).json(ADDRESS_NOT_PROVIDED_400)
+          break
+        case INVALID_ADDRESS_400.message: {
+          res.status(INVALID_ADDRESS_400.statusCode).json(INVALID_ADDRESS_400)
+          break
+        }
+        default:
+          res.status(500).json({ statusCode: 500, message: err.message })
+      }
+    }
+  }
+}

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -6,6 +6,7 @@ import walletsEndpoint from 'pages/api/wallets/index'
 import walletEndpoint from 'pages/api/wallet/index'
 import walletIdEndpoint from 'pages/api/wallet/[id]'
 import transactionsEndpoint from 'pages/api/transactions/[address]'
+import transactionsSyncEndpoint from 'pages/api/transactions/sync/[address]'
 import transactionDetailsEndpoint from 'pages/api/transaction/[transactionId]'
 import balanceEndpoint from 'pages/api/balance/[address]'
 import dashboardEndpoint from 'pages/api/dashboard/index'
@@ -750,7 +751,6 @@ describe('DELETE /api/paybutton/[id]', () => {
   }
 
   it('Delete paybutton', async () => {
-    console.log('heya', createdPaybuttonsIds)
     if (baseRequestOptions.query != null) baseRequestOptions.query.id = createdPaybuttonsIds[0]
     const res = await testEndpoint(baseRequestOptions, paybuttonIdEndpoint)
     const responseData = res._getJSONData()
@@ -803,7 +803,21 @@ describe('GET /api/transactions/[address]', () => {
     expect(responseData.message).toBe(RESPONSE_MESSAGES.ADDRESS_NOT_PROVIDED_400.message)
   })
 
-  it('Should return HTTP 200 in case address is valid but not yet on the system', async () => {
+  it('Should return HTTP 400 in case address is invalid', async () => {
+    const baseRequestOptions: RequestOptions = {
+      method: 'GET' as RequestMethod,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      query: {
+        address: 'lkdasjfçlajdsfl'
+      }
+    }
+    const res = await testEndpoint(baseRequestOptions, transactionsEndpoint)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('Should return HTTP 404 in case address is valid but not yet on the system', async () => {
     const baseRequestOptions: RequestOptions = {
       method: 'GET' as RequestMethod,
       headers: {
@@ -814,6 +828,53 @@ describe('GET /api/transactions/[address]', () => {
       }
     }
     const res = await testEndpoint(baseRequestOptions, transactionsEndpoint)
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+describe('GET /api/transactions/sync/[address]', () => {
+  const baseRequestOptions: RequestOptions = {
+    method: 'GET' as RequestMethod,
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    query: {}
+  }
+
+  it('Should return HTTP 400 (Bad Request) if no address specified', async () => {
+    const res = await testEndpoint(baseRequestOptions, transactionsSyncEndpoint)
+    const responseData = res._getJSONData()
+    expect(res.statusCode).toBe(400)
+    expect(responseData.message).toBe(RESPONSE_MESSAGES.ADDRESS_NOT_PROVIDED_400.message)
+  })
+
+  it('Should return HTTP 400 in case address is invalid', async () => {
+    const baseRequestOptions: RequestOptions = {
+      method: 'GET' as RequestMethod,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      query: {
+        address: 'ulkjas8hfn29-hnro123ihj42890h'
+      }
+    }
+    const res = await testEndpoint(baseRequestOptions, transactionsSyncEndpoint)
+    const responseData = res._getJSONData()
+    expect(res.statusCode).toBe(400)
+    expect(responseData.message).toBe(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
+  })
+
+  it('Should return HTTP 200 in case address is valid but not yet on the system', async () => {
+    const baseRequestOptions: RequestOptions = {
+      method: 'GET' as RequestMethod,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      query: {
+        address: `ecash:${exampleAddresses.ecash}`
+      }
+    }
+    const res = await testEndpoint(baseRequestOptions, transactionsSyncEndpoint)
     expect(res.statusCode).toBe(200)
   })
 })

--- a/tests/mockGrpcClient.ts
+++ b/tests/mockGrpcClient.ts
@@ -16,9 +16,13 @@ export default class MockGrpcClient {
     this._checkNetworkIntegrity = value
   }
 
-  getAddressTransactions (_: object): GetAddressTransactionsResponse {
+  getAddressTransactions (_: any): GetAddressTransactionsResponse {
     const res = new GetAddressTransactionsResponse()
-    res.setConfirmedTransactionsList([mockedGrpc.transaction1, mockedGrpc.transaction2])
+    if (_.nbSkip > 0) {
+      res.setConfirmedTransactionsList([])
+    } else {
+      res.setConfirmedTransactionsList([mockedGrpc.transaction1, mockedGrpc.transaction2])
+    }
     return res
   }
 

--- a/tests/unittests/addressService.test.ts
+++ b/tests/unittests/addressService.test.ts
@@ -36,3 +36,23 @@ describe('Find by substring', () => {
     expect(result).toHaveProperty('paymentCount', 3)
   })
 })
+
+describe('Create by substring', () => {
+  it('Fail to create address with invalid address', async () => {
+    prismaMock.address.upsert.mockResolvedValue(mockedBCHAddress)
+    prisma.address.upsert = prismaMock.address.upsert
+
+    await expect(addressService.upsertAddress('mock')).rejects.toThrow(
+      RESPONSE_MESSAGES.INVALID_ADDRESS_400.message
+    )
+  })
+  it('Create single address', async () => {
+    prismaMock.address.upsert.mockResolvedValue(mockedBCHAddress)
+    prisma.address.upsert = prismaMock.address.upsert
+    prismaMock.network.findUnique.mockResolvedValue(mockedNetwork)
+    prisma.network.findUnique = prismaMock.network.findUnique
+
+    const result = await addressService.upsertAddress(mockedBCHAddress.address)
+    expect(result).toEqual(mockedBCHAddress)
+  })
+})


### PR DESCRIPTION
Description:
Create a new endpoint `http://localhost:3000/transactions/sync/[address]` to sync transactions for an address.

Test plan:
Run `curl http://localhost:3000/transactions/sync/[address-that-does-not-exist-in-the-database] | jq`. It should create the `Address` object & its transactions on the database and respond with the addresses transactions.

Furthermore, the endpoint `curl http://localhost:3000/transactions/[address]` now should return `404: No address found.` if run with an address that is not present on the database.