### PR TITLE
[Issue #317] feat: show button data on button detail

### DIFF
--- a/components/Paybutton/PaybuttonDetail.tsx
+++ b/components/Paybutton/PaybuttonDetail.tsx
@@ -8,7 +8,6 @@ interface IProps {
   onDelete: Function
 }
 export default ({ paybutton, onDelete }: IProps): FunctionComponent => {
-  console.log(paybutton)
   return (
     <div className={style.paybutton_list_ctn}>
       <div className={`${style.paybutton_card} ${style.paybutton_card_no_hover}`}>

--- a/components/Paybutton/PaybuttonDetail.tsx
+++ b/components/Paybutton/PaybuttonDetail.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react'
-import  { PaybuttonWithAddresses } from 'services/paybuttonService'
+import { PaybuttonWithAddresses } from 'services/paybuttonService'
 import style from './paybutton.module.css'
 import EditButtonForm from './EditButtonForm'
 
@@ -23,6 +23,12 @@ export default ({ paybutton, onDelete }: IProps): FunctionComponent => {
                 {item.address.address}
               </div>
             ))}
+          </div>
+          <h6>
+            Associated data:
+          </h6>
+          <div>
+            {paybutton.buttonData}
           </div>
       </div>
     </div>

--- a/components/Paybutton/PaybuttonDetail.tsx
+++ b/components/Paybutton/PaybuttonDetail.tsx
@@ -8,6 +8,7 @@ interface IProps {
   onDelete: Function
 }
 export default ({ paybutton, onDelete }: IProps): FunctionComponent => {
+  console.log(paybutton)
   return (
     <div className={style.paybutton_list_ctn}>
       <div className={`${style.paybutton_card} ${style.paybutton_card_no_hover}`}>
@@ -24,12 +25,17 @@ export default ({ paybutton, onDelete }: IProps): FunctionComponent => {
               </div>
             ))}
           </div>
-          <h6>
-            Associated data:
-          </h6>
-          <div>
-            {paybutton.buttonData}
-          </div>
+          {paybutton.buttonData === '{}' || paybutton.buttonData === undefined
+            ? null
+            : <>
+              <h6>
+                Associated data:
+              </h6>
+              <div>
+                {paybutton.buttonData}
+              </div>
+            </>
+          }
       </div>
     </div>
   )

--- a/components/Paybutton/paybutton.module.css
+++ b/components/Paybutton/paybutton.module.css
@@ -21,6 +21,10 @@
   margin: 0;
 }
 
+.paybutton_card h6 {
+  margin: 20px 0 5px 0;
+}
+
 .address {
   color: var(--secondary-text-color);
 }


### PR DESCRIPTION
Description:
Show the button data in the paybutton detail view.
![image](https://user-images.githubusercontent.com/21281174/203162949-4a661896-bb1f-4786-9b15-6fe6ce7f4422.png)

Part of #317 so that the editing of this data is visible.

Test plan:
Go to any button detail view and see if the info shown above is present.