### PR TITLE
[#Issue 317] feat: edit paybuttons backend

### DIFF
--- a/components/Paybutton/PaybuttonDetail.tsx
+++ b/components/Paybutton/PaybuttonDetail.tsx
@@ -24,12 +24,6 @@ export default ({ paybutton, onDelete }: IProps): FunctionComponent => {
               </div>
             ))}
           </div>
-          <h6>
-            Associated data:
-          </h6>
-          <div>
-            {paybutton.buttonData}
-          </div>
       </div>
     </div>
   )

--- a/pages/api/paybutton/[id].ts
+++ b/pages/api/paybutton/[id].ts
@@ -58,9 +58,6 @@ export default async (
         case RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message:
           res.status(400).json(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400)
           break
-        case RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message:
-          res.status(400).json(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400)
-          break
         default:
           res.status(500).json({ statusCode: 500, message: parsedError.message })
       }

--- a/pages/api/paybutton/[id].ts
+++ b/pages/api/paybutton/[id].ts
@@ -56,6 +56,11 @@ export default async (
         case RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message:
           res.status(404).json(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404)
           break
+        case RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400)
+          break
+        default:
+          res.status(500).json({ statusCode: 500, message: parsedError.message })
       }
     }
   }

--- a/pages/api/paybutton/[id].ts
+++ b/pages/api/paybutton/[id].ts
@@ -1,5 +1,5 @@
 import * as paybuttonService from 'services/paybuttonService'
-import { parseError } from 'utils/validators'
+import { parseError, parsePaybuttonPATCHRequest } from 'utils/validators'
 import { RESPONSE_MESSAGES } from 'constants/index'
 import { setSession } from 'utils/setSession'
 
@@ -40,6 +40,22 @@ export default async (
           break
         default:
           res.status(500).json({ statusCode: 500, message: parsedError.message })
+      }
+    }
+  }
+  if (req.method === 'PATCH') {
+    try {
+      const values = req.body
+      const updatePaybuttonInput = parsePaybuttonPATCHRequest(values)
+      console.log('inputs', updatePaybuttonInput)
+      const paybutton = await paybuttonService.updatePaybutton(Number(paybuttonId), updatePaybuttonInput)
+      res.status(200).json(paybutton)
+    } catch (err: any) {
+      const parsedError = parseError(err)
+      switch (parsedError.message) {
+        case RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message:
+          res.status(404).json(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404)
+          break
       }
     }
   }

--- a/pages/api/paybutton/[id].ts
+++ b/pages/api/paybutton/[id].ts
@@ -47,7 +47,6 @@ export default async (
     try {
       const values = req.body
       const updatePaybuttonInput = parsePaybuttonPATCHRequest(values)
-      console.log('inputs', updatePaybuttonInput)
       const paybutton = await paybuttonService.updatePaybutton(Number(paybuttonId), updatePaybuttonInput)
       res.status(200).json(paybutton)
     } catch (err: any) {
@@ -55,6 +54,9 @@ export default async (
       switch (parsedError.message) {
         case RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message:
           res.status(404).json(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404)
+          break
+        case RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400)
           break
         case RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message:
           res.status(400).json(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400)

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -5,7 +5,6 @@ import { RESPONSE_MESSAGES } from 'constants/index'
 
 export interface UpdatePaybuttonInput {
   name?: string
-  buttonData?: string
   prefixedAddressList?: string[]
 }
 
@@ -119,9 +118,6 @@ export async function updatePaybutton (paybuttonId: number, params: UpdatePaybut
   const updateData: Prisma.PaybuttonUpdateInput = {}
   if (params.name !== undefined && params.name !== '') {
     updateData.name = params.name
-  }
-  if (params.buttonData !== undefined && params.buttonData !== '') {
-    updateData.buttonData = params.buttonData
   }
   if (params.prefixedAddressList !== undefined && params.prefixedAddressList.length !== 0) {
     const addressesToCreateOrConnect = await getAddressObjectsToCreateOrConnect(params.prefixedAddressList)

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -116,9 +116,12 @@ export async function fetchPaybuttonArrayByUserId (userId: string): Promise<Payb
 }
 
 export async function updatePaybutton (paybuttonId: number, params: UpdatePaybuttonInput): Promise<PaybuttonWithAddresses> {
-  const updateData: Prisma.PaybuttonUpdateInput = {
-    name: params.name,
-    buttonData: params.buttonData
+  const updateData: Prisma.PaybuttonUpdateInput = {}
+  if (params.name !== undefined && params.name !== '') {
+    updateData.name = params.name
+  }
+  if (params.buttonData !== undefined && params.buttonData !== '') {
+    updateData.buttonData = params.buttonData
   }
   if (params.prefixedAddressList !== undefined && params.prefixedAddressList.length !== 0) {
     const addressesToCreateOrConnect = await getAddressObjectsToCreateOrConnect(params.prefixedAddressList)

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -2,6 +2,7 @@ import * as networkService from 'services/networkService'
 import { Prisma } from '@prisma/client'
 import prisma from 'prisma/clientInstance'
 import { RESPONSE_MESSAGES } from 'constants/index'
+import { parsePaybuttonPATCHRequest } from 'utils/validators'
 
 export interface UpdatePaybuttonInput {
   name?: string
@@ -111,14 +112,14 @@ export async function fetchPaybuttonArrayByUserId (userId: string): Promise<Payb
 }
 
 export async function updatePaybutton (paybuttonId: number, params: UpdatePaybuttonInput): Promise<PaybuttonWithAddresses> {
-  // (parsed)params = parseparams...
+  const parsedParams = parsePaybuttonPATCHRequest(params)
   return await prisma.paybutton.update({
     where: {
       id: paybuttonId
     },
     data: {
-      name: params.name,
-      buttonData: params.buttonData
+      name: parsedParams.name,
+      buttonData: parsedParams.buttonData
     },
     include: includeAddresses
   })

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -135,11 +135,21 @@ export async function updatePaybutton (paybuttonId: number, params: UpdatePaybut
     }
   }
 
-  return await prisma.paybutton.update({
-    where: {
-      id: paybuttonId
-    },
-    data: updateData,
-    include: includeAddresses
+  return await prisma.$transaction(async (prisma) => {
+    // remove previous address connections, if new address list sent
+    if (params.prefixedAddressList !== undefined && params.prefixedAddressList.length !== 0) {
+      void await prisma.addressesOnButtons.deleteMany({
+        where: {
+          paybuttonId
+        }
+      })
+    }
+    return await prisma.paybutton.update({
+      where: {
+        id: paybuttonId
+      },
+      data: updateData,
+      include: includeAddresses
+    })
   })
 }

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -3,6 +3,11 @@ import { Prisma } from '@prisma/client'
 import prisma from 'prisma/clientInstance'
 import { RESPONSE_MESSAGES } from 'constants/index'
 
+export interface UpdatePaybuttonInput {
+  name?: string
+  buttonData?: string
+}
+
 export interface CreatePaybuttonInput {
   userId: string
   name: string
@@ -101,6 +106,20 @@ export async function fetchPaybuttonById (paybuttonId: number | string): Promise
 export async function fetchPaybuttonArrayByUserId (userId: string): Promise<PaybuttonWithAddresses[]> {
   return await prisma.paybutton.findMany({
     where: { providerUserId: userId },
+    include: includeAddresses
+  })
+}
+
+export async function updatePaybutton (paybuttonId: number, params: UpdatePaybuttonInput): Promise<PaybuttonWithAddresses> {
+  // (parsed)params = parseparams...
+  return await prisma.paybutton.update({
+    where: {
+      id: paybuttonId
+    },
+    data: {
+      name: params.name,
+      buttonData: params.buttonData
+    },
     include: includeAddresses
   })
 }

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -185,8 +185,7 @@ describe('PATCH /api/paybutton/', () => {
     },
     body: {
       addresses: undefined,
-      name: undefined,
-      buttonData: undefined
+      name: undefined
     },
     query: {}
   }
@@ -195,7 +194,6 @@ describe('PATCH /api/paybutton/', () => {
     if (baseRequestOptions.query != null) baseRequestOptions.query.id = createdPaybuttons[0].id
     baseRequestOptions.body = {
       name: 'blablabla',
-      buttonData: undefined,
       addresses: undefined
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonIdEndpoint)
@@ -203,38 +201,7 @@ describe('PATCH /api/paybutton/', () => {
     expect(res.statusCode).toBe(200)
     expect(responseData.providerUserId).toBe('test-u-id')
     expect(responseData.name).toBe('blablabla')
-    expect(responseData.buttonData).toBe('{"someCustom":"userData"}')
     expect(responseData.uuid).not.toBeNull()
-    expect(responseData.addresses).toEqual(
-      expect.arrayContaining([
-        {
-          address: expect.objectContaining({
-            address: createdPaybuttons[0].addresses.map((addr) => addr.address.address)[0]
-          })
-        },
-        {
-          address:
-          expect.objectContaining({
-            address: createdPaybuttons[0].addresses.map((addr) => addr.address.address)[1]
-          })
-        }
-      ])
-    )
-  })
-
-  it('Update a paybutton buttonData', async () => {
-    if (baseRequestOptions.query != null) baseRequestOptions.query.id = createdPaybuttons[0].id
-    baseRequestOptions.body = {
-      name: undefined,
-      buttonData: '{"new-data": 3}',
-      addresses: undefined
-    }
-    const res = await testEndpoint(baseRequestOptions, paybuttonIdEndpoint)
-    const responseData = res._getJSONData()
-    expect(res.statusCode).toBe(200)
-    expect(responseData.providerUserId).toBe('test-u-id')
-    expect(responseData.name).toBe('blablabla')
-    expect(responseData.buttonData).toBe('{"new-data":3}')
     expect(responseData.addresses).toEqual(
       expect.arrayContaining([
         {
@@ -262,7 +229,6 @@ describe('PATCH /api/paybutton/', () => {
     const responseData = res._getJSONData()
     expect(responseData.providerUserId).toBe('test-u-id')
     expect(responseData.name).toBe('blablabla')
-    expect(responseData.buttonData).toBe('{"new-data":3}')
     expect(responseData.addresses).toEqual(
       expect.arrayContaining([
         {
@@ -284,7 +250,6 @@ describe('PATCH /api/paybutton/', () => {
     if (baseRequestOptions.query != null) baseRequestOptions.query.id = createdPaybuttons[0].id
     baseRequestOptions.body = {
       name: createdPaybuttons[1].name,
-      buttonData: undefined,
       addresses: undefined
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonIdEndpoint)
@@ -292,23 +257,10 @@ describe('PATCH /api/paybutton/', () => {
     const responseData = res._getJSONData()
     expect(responseData.message).toBe(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message)
   })
-  it('Should fail with invalid button data', async () => {
-    if (baseRequestOptions.query != null) baseRequestOptions.query.id = createdPaybuttons[0].id
-    baseRequestOptions.body = {
-      name: undefined,
-      buttonData: 'lsakj',
-      addresses: undefined
-    }
-    const res = await testEndpoint(baseRequestOptions, paybuttonIdEndpoint)
-    expect(res.statusCode).toBe(400)
-    const responseData = res._getJSONData()
-    expect(responseData.message).toBe(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message)
-  })
   it('Should fail for non non-existent button', async () => {
     if (baseRequestOptions.query != null) baseRequestOptions.query.id = 9128371987912
     baseRequestOptions.body = {
       name: 'some-different-name',
-      buttonData: undefined,
       addresses: undefined
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonIdEndpoint)

--- a/tests/unittests/paybuttonService.test.ts
+++ b/tests/unittests/paybuttonService.test.ts
@@ -55,3 +55,21 @@ describe('Delete services', () => {
     expect(result).toEqual(mockedPaybutton)
   })
 })
+
+describe('Update services', () => {
+  it('Should return paybutton nested', async () => {
+    prismaMock.paybutton.update.mockResolvedValue(mockedPaybutton)
+    prisma.paybutton.update = prismaMock.paybutton.update
+
+    prismaMock.network.findUnique.mockResolvedValue(mockedNetwork)
+    prisma.network.findUnique = prismaMock.network.findUnique
+    const updatePaybuttonInput = {
+      userId: 'mocked-uid',
+      name: 'mocked-name',
+      prefixedAddressList: ['mockednetwork:mockaddress'],
+      buttonData: ''
+    }
+    const result = await paybuttonService.updatePaybutton(1, updatePaybuttonInput)
+    expect(result).toEqual(mockedPaybutton)
+  })
+})

--- a/tests/unittests/paybuttonService.test.ts
+++ b/tests/unittests/paybuttonService.test.ts
@@ -62,6 +62,13 @@ describe('Update services', () => {
     prisma.paybutton.update = prismaMock.paybutton.update
     prismaMock.addressesOnButtons.deleteMany.mockResolvedValue({ count: 0 })
     prisma.addressesOnButtons.deleteMany = prismaMock.addressesOnButtons.deleteMany
+    prisma.addressesOnButtons.deleteMany = prismaMock.addressesOnButtons.deleteMany
+    prismaMock.$transaction.mockImplementation(
+      (fn: (prisma: any) => any) => {
+        return fn(prisma)
+      }
+    )
+    prisma.$transaction = prismaMock.$transaction
 
     prismaMock.network.findUnique.mockResolvedValue(mockedNetwork)
     prisma.network.findUnique = prismaMock.network.findUnique

--- a/tests/unittests/paybuttonService.test.ts
+++ b/tests/unittests/paybuttonService.test.ts
@@ -60,6 +60,8 @@ describe('Update services', () => {
   it('Should return paybutton nested', async () => {
     prismaMock.paybutton.update.mockResolvedValue(mockedPaybutton)
     prisma.paybutton.update = prismaMock.paybutton.update
+    prismaMock.addressesOnButtons.deleteMany.mockResolvedValue({ count: 0 })
+    prisma.addressesOnButtons.deleteMany = prismaMock.addressesOnButtons.deleteMany
 
     prismaMock.network.findUnique.mockResolvedValue(mockedNetwork)
     prisma.network.findUnique = prismaMock.network.findUnique

--- a/tests/unittests/paybuttonService.test.ts
+++ b/tests/unittests/paybuttonService.test.ts
@@ -66,8 +66,7 @@ describe('Update services', () => {
     const updatePaybuttonInput = {
       userId: 'mocked-uid',
       name: 'mocked-name',
-      prefixedAddressList: ['mockednetwork:mockaddress'],
-      buttonData: ''
+      prefixedAddressList: ['mockednetwork:mockaddress']
     }
     const result = await paybuttonService.updatePaybutton(1, updatePaybuttonInput)
     expect(result).toEqual(mockedPaybutton)

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -181,3 +181,33 @@ describe('parsePaybuttonPOSTRequest', () => {
     }).toThrow(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
   })
 })
+
+describe('parsePaybuttonPATCHRequest', () => {
+  const data: v.paybuttonPOSTParameters = {
+    name: 'somename',
+    buttonData: undefined,
+    addresses: undefined
+  }
+  it('Invalid button data throws error', () => {
+    expect(() => {
+      data.buttonData = '{test:}'
+      v.parsePaybuttonPATCHRequest(data)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message)
+  })
+  it('Invalid addresses throws error', () => {
+    expect(() => {
+      data.buttonData = undefined
+      data.addresses = 'ecash:lkajsdl\nll'
+      v.parsePaybuttonPATCHRequest(data)
+    }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
+  })
+  it('Addresses text is split', () => {
+    data.buttonData = undefined
+    data.addresses = `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`
+    const res = v.parsePaybuttonPATCHRequest(data)
+    expect(res.prefixedAddressList).toStrictEqual([
+      `ecash:${exampleAddresses.ecash}`,
+      `bitcoincash:${exampleAddresses.bitcoincash}`
+    ])
+  })
+})

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -185,24 +185,15 @@ describe('parsePaybuttonPOSTRequest', () => {
 describe('parsePaybuttonPATCHRequest', () => {
   const data: v.paybuttonPOSTParameters = {
     name: 'somename',
-    buttonData: undefined,
     addresses: undefined
   }
-  it('Invalid button data throws error', () => {
-    expect(() => {
-      data.buttonData = '{test:}'
-      v.parsePaybuttonPATCHRequest(data)
-    }).toThrow(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message)
-  })
   it('Invalid addresses throws error', () => {
     expect(() => {
-      data.buttonData = undefined
       data.addresses = 'ecash:lkajsdl\nll'
       v.parsePaybuttonPATCHRequest(data)
     }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
   })
   it('Addresses text is split', () => {
-    data.buttonData = undefined
     data.addresses = `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`
     const res = v.parsePaybuttonPATCHRequest(data)
     expect(res.prefixedAddressList).toStrictEqual([

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -96,7 +96,7 @@ export interface WalletPOSTParameters {
 
 export interface PaybuttonPATCHParameters {
   name?: string
-  buttonData?: boolean
+  buttonData?: string
 }
 
 export interface WalletPATCHParameters {
@@ -129,5 +129,8 @@ export const parseWalletPATCHRequest = function (params: WalletPATCHParameters):
 }
 
 export const parsePaybuttonPATCHRequest = function (params: PaybuttonPATCHParameters): UpdatePaybuttonInput {
-  return params as UpdatePaybuttonInput
+  return {
+    name: params.name,
+    buttonData: parseButtonData(params.buttonData)
+  }
 }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -104,7 +104,6 @@ export interface WalletPOSTParameters {
 
 export interface PaybuttonPATCHParameters {
   name?: string
-  buttonData?: string
   addresses?: string
 }
 
@@ -140,9 +139,6 @@ export const parseWalletPATCHRequest = function (params: WalletPATCHParameters):
 export const parsePaybuttonPATCHRequest = function (params: PaybuttonPATCHParameters): UpdatePaybuttonInput {
   const ret: UpdatePaybuttonInput = {
     name: params.name
-  }
-  if (params.buttonData !== '' && params.buttonData !== undefined) {
-    ret.buttonData = parseButtonData(params.buttonData)
   }
 
   if (params.addresses !== '' && params.addresses !== undefined) {

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,6 +1,6 @@
 import { RESPONSE_MESSAGES, SUPPORTED_ADDRESS_PATTERN } from '../constants/index'
 import { Prisma } from '@prisma/client'
-import { CreatePaybuttonInput } from '../services/paybuttonService'
+import { CreatePaybuttonInput, UpdatePaybuttonInput } from '../services/paybuttonService'
 import { CreateWalletInput, UpdateWalletInput } from '../services/walletService'
 import { getAddressPrefix } from './index'
 import xecaddr from 'xecaddrjs'
@@ -94,6 +94,11 @@ export interface WalletPOSTParameters {
   paybuttonIdList?: number[]
 }
 
+export interface PaybuttonPATCHParameters {
+  name?: string
+  buttonData?: boolean
+}
+
 export interface WalletPATCHParameters {
   name: string
   isXECDefault?: boolean
@@ -121,4 +126,8 @@ export const parseWalletPATCHRequest = function (params: WalletPATCHParameters):
     isXECDefault: params.isXECDefault,
     isBCHDefault: params.isBCHDefault
   }
+}
+
+export const parsePaybuttonPATCHRequest = function (params: PaybuttonPATCHParameters): UpdatePaybuttonInput {
+  return params as UpdatePaybuttonInput
 }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -63,9 +63,13 @@ export const parseError = function (error: Error): Error {
         }
         break
       case 'P2025':
-        if (error.message.includes('prisma.paybutton.delete')) {
+        if (
+          error.message.includes('prisma.paybutton.delete') ||
+          error.message.includes('prisma.paybutton.update')
+        ) {
           return new Error(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message)
         }
+        break
     }
   }
   return error

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -14,6 +14,10 @@ import xecaddr from 'xecaddrjs'
 
 /* Validates the address and adds a prefix to it, if it does not have it already.
  */
+const parseAddressTextBlock = function (addressBlock: string): string[] {
+  return addressBlock.trim().split('\n').map((addr) => parseAddress(addr))
+}
+
 export const parseAddress = function (addressString: string | undefined): string {
   if (addressString === '' || addressString === undefined) throw new Error(RESPONSE_MESSAGES.ADDRESS_NOT_PROVIDED_400.message)
   let parsedAddress: string
@@ -78,7 +82,7 @@ export const parsePaybuttonPOSTRequest = function (params: paybuttonPOSTParamete
   if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
   if (params.addresses === '' || params.addresses === undefined) throw new Error(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
-  const parsedAddresses = params.addresses.trim().split('\n').map((addr) => parseAddress(addr))
+  const parsedAddresses = parseAddressTextBlock(params.addresses)
   const parsedButtonData = parseButtonData(params.buttonData)
   return {
     userId: params.userId,
@@ -97,6 +101,7 @@ export interface WalletPOSTParameters {
 export interface PaybuttonPATCHParameters {
   name?: string
   buttonData?: string
+  addresses?: string
 }
 
 export interface WalletPATCHParameters {
@@ -129,8 +134,12 @@ export const parseWalletPATCHRequest = function (params: WalletPATCHParameters):
 }
 
 export const parsePaybuttonPATCHRequest = function (params: PaybuttonPATCHParameters): UpdatePaybuttonInput {
-  return {
+  const ret: UpdatePaybuttonInput = {
     name: params.name,
     buttonData: parseButtonData(params.buttonData)
   }
+  if (params.addresses !== '' && params.addresses !== undefined) {
+    ret.prefixedAddressList = parseAddressTextBlock(params.addresses)
+  }
+  return ret
 }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -135,9 +135,12 @@ export const parseWalletPATCHRequest = function (params: WalletPATCHParameters):
 
 export const parsePaybuttonPATCHRequest = function (params: PaybuttonPATCHParameters): UpdatePaybuttonInput {
   const ret: UpdatePaybuttonInput = {
-    name: params.name,
-    buttonData: parseButtonData(params.buttonData)
+    name: params.name
   }
+  if (params.buttonData !== '' && params.buttonData !== undefined) {
+    ret.buttonData = parseButtonData(params.buttonData)
+  }
+
   if (params.addresses !== '' && params.addresses !== undefined) {
     ret.prefixedAddressList = parseAddressTextBlock(params.addresses)
   }


### PR DESCRIPTION
Description:
Create API endpoint to edit paybuttons. No front end for accessing it implemented yet.

Test plan:
Tests should be covering it. There will be a next PR implementing the front end logic that depends on this one and makes testing from the front end possible; `curl` commands won't work because of the supertokens session authentication.

~Depends on:~ 
~- [ ] #318~