### PR TITLE
[Issue #332] feat: add redis

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,4 +4,5 @@ APP_NAME="PayButton"
 API_BASE_PATH=/api
 API_DOMAIN=http://localhost:3000
 WEBSITE_DOMAIN=http://localhost:3000
+REDIS_URL="redis://paybutton-cache:6379"
 WEBSITE_BASE_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+redis/dump.rdb

--- a/config/appInfo.ts
+++ b/config/appInfo.ts
@@ -7,5 +7,6 @@ export const appInfo = {
   websiteBasePath: `${websiteBasePath}/auth`,
   websiteDomain: process.env.WEBSITE_DOMAIN ?? 'localhost:3000',
   showTestNetworks: JSON.parse(process.env.SHOW_TEST_NETWORKS ?? 'false'),
-  priceAPIURL: process.env.PRICE_API_URL ?? ''
+  priceAPIURL: process.env.PRICE_API_URL ?? '',
+  redisURL: process.env.REDIS_URL ?? 'redis://paybutton-cache:6379'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     depends_on: 
       - db
       - users-service
+      - cache
     build: .
     ports:
       - "3000:3000"
@@ -33,6 +34,7 @@ services:
     container_name: paybutton-users-service
     depends_on:
       - db
+      - cache
     image: registry.supertokens.io/supertokens/supertokens-mysql
     restart: always
     ports:
@@ -43,3 +45,15 @@ services:
       MYSQL_PASSWORD: supertokens
       MYSQL_HOST: db
       MYSQL_PORT: 3306
+
+  cache:
+    container_name: paybutton-cache
+    image: redis:6.2-alpine
+    restart: always
+    user: redis
+    ports:
+      - 6379:6379
+    volumes:
+      - ./redis:/data/redis
+    # dump the dataset each 20 seconds if there was at least 1 change
+    command: sh -c "umask 000 && redis-server /data/redis/redis.conf --save 20 1 --loglevel warning"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "jest-mock-extended": "^2.0.6",
     "lint-staged": "^12.4.1",
     "nodemon": "^2.0.4",
+    "redis": "^4.5.1",
     "ts-jest": "^28.0.2",
     "ts-node": "^8.10.2",
     "typescript": "^4.6.4"

--- a/redis/clientInstance.ts
+++ b/redis/clientInstance.ts
@@ -1,9 +1,9 @@
 import { createClient } from 'redis'
 import { appInfo } from 'config/appInfo'
 
-export const client = createClient({ url: appInfo.redisURL })
-client.on('error', (err) => console.log('Redis Client Error', err))
+export const redis = createClient({ url: appInfo.redisURL })
+redis.on('error', (err) => console.log('Redis Client Error', err))
 
-void client.connect()
+void redis.connect()
 
-export default client
+export default redis

--- a/redis/clientInstance.ts
+++ b/redis/clientInstance.ts
@@ -1,6 +1,7 @@
 import { createClient } from 'redis'
+import { appInfo } from 'config/appInfo'
 
-export const client = createClient({ url: 'redis://paybutton-cache:6379' })
+export const client = createClient({ url: appInfo.redisURL })
 client.on('error', (err) => console.log('Redis Client Error', err))
 
 void client.connect()

--- a/redis/clientInstance.ts
+++ b/redis/clientInstance.ts
@@ -1,0 +1,8 @@
+import { createClient } from 'redis'
+
+export const client = createClient({ url: 'redis://paybutton-cache:6379' })
+client.on('error', (err) => console.log('Redis Client Error', err))
+
+void client.connect()
+
+export default client

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -1,0 +1,1 @@
+dir redis/

--- a/scripts/docker-exec-shortcuts.sh
+++ b/scripts/docker-exec-shortcuts.sh
@@ -2,9 +2,11 @@
 
 node_container_name="paybutton-dev"
 db_container_name="paybutton-db"
+cache_container_name="paybutton-cache"
 base_command_node="docker exec -it $node_container_name"
 base_command_node_root="docker exec  -it -u 0 $node_container_name"
 base_command_db="docker exec -it $db_container_name"
+base_command_cache="docker exec -it $cache_container_name"
 command="$1"
 
 shift
@@ -69,6 +71,12 @@ case "$command" in
     "prismagenerate" | "pg")
         eval "$base_command_node" yarn prisma generate "$@"
         ;;
+    "cache" | "c")
+        eval "$base_command_cache" redis-cli
+        ;;
+    "cacheshell" | "cs")
+        eval "$base_command_cache" ash -l
+        ;;
     *)
         echo Avaiable commands:
         echo "  shortcut, command name      [container_name]    command description"
@@ -92,6 +100,8 @@ case "$command" in
         echo "  mr, migratereset            [$node_container_name]     recreate the database"
         echo "  pd, prismadb                [$node_container_name]     run \`prisma db ARGS\`"
         echo "  pg, prismagenerate          [$node_container_name]     run \`prisma generate\` to generate client from scheme"
+        echo "  c, cache                    [$cache_container_name]   enter the redis command-line interface"
+        echo "  cs, cacheshell              [$node_container_name]    enter the redis container"
         ;;
 esac
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,6 +960,40 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@redis/bloom@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.1.0.tgz#64e310ddee72010676e14296076329e594a1f6c7"
+  integrity sha512-9QovlxmpRtvxVbN0UBcv8WfdSMudNZZTFqCsnBszcQXqaZb/TVe30ScgGEO7u1EAIacTPAo7/oCYjYAxiHLanQ==
+
+"@redis/client@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.4.2.tgz#2a3f5e98bc33b7b979390442e6e08f96e57fabdd"
+  integrity sha512-oUdEjE0I7JS5AyaAjkD3aOXn9NhO7XKyPyXEyrgFDu++VrVBHUPnV6dgEya9TcMuj5nIJRuCzCm8ZP+c9zCHPw==
+  dependencies:
+    cluster-key-slot "1.1.1"
+    generic-pool "3.9.0"
+    yallist "4.0.0"
+
+"@redis/graph@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.1.0.tgz#cc2b82e5141a29ada2cce7d267a6b74baa6dd519"
+  integrity sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==
+
+"@redis/json@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.4.tgz#f372b5f93324e6ffb7f16aadcbcb4e5c3d39bda1"
+  integrity sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==
+
+"@redis/search@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.1.0.tgz#7abb18d431f27ceafe6bcb4dd83a3fa67e9ab4df"
+  integrity sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==
+
+"@redis/time-series@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.0.4.tgz#af85eb080f6934580e4d3b58046026b6c2b18717"
+  integrity sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==
+
 "@sinclair/typebox@^0.23.3":
   version "0.23.5"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.5.tgz#93f7b9f4e3285a7a9ade7557d9a8d36809cbc47d"
@@ -2149,6 +2183,11 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+cluster-key-slot@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz#10ccb9ded0729464b6d2e7d714b100a2d1259d43"
+  integrity sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==
+
 co-body@6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/co-body/-/co-body-6.1.0.tgz#d87a8efc3564f9bfe3aced8ef5cd04c7a8766547"
@@ -3200,6 +3239,11 @@ generate-function@^2.3.1:
   integrity sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==
   dependencies:
     is-property "^1.0.2"
+
+generic-pool@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.9.0.tgz#36f4a678e963f4fdb8707eab050823abc4e8f5e4"
+  integrity sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -5561,6 +5605,18 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+redis@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.5.1.tgz#f5a818970bb2dc5d60540bab41308640604c7d33"
+  integrity sha512-oxXSoIqMJCQVBTfxP6BNTCtDMyh9G6Vi5wjdPdV/sRKkufyZslDqCScSGcOr6XGR/reAWZefz7E4leM31RgdBA==
+  dependencies:
+    "@redis/bloom" "1.1.0"
+    "@redis/client" "1.4.2"
+    "@redis/graph" "1.1.0"
+    "@redis/json" "1.0.4"
+    "@redis/search" "1.1.0"
+    "@redis/time-series" "1.0.4"
+
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
@@ -6728,15 +6784,15 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yallist@4.0.0, yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yallist@^2.0.0, yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"


### PR DESCRIPTION
Description:
Part of #322. Add redis to our project so we can later add [bullmq](https://github.com/taskforcesh/bullmq).


Test plan:
1. After pulling, first run `make reset-dev`
2. After all containers are up, inside the project directory run `yarn docker c` to enter the redis command line.
3. Run `KEYS *`. It should be empty.

 Now, we are going to try to modify the redis cache from within our Next.JS project:
1. Create a file `test.patch` inside the project directory with the following content:
```
diff --git a/pages/api/dashboard/index.ts b/pages/api/dashboard/index.ts
index 6953f9d..f03287f 100644
--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -5,6 +5,7 @@ import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 import { Prisma } from '@prisma/client'
 import moment, { DurationInputArg2 } from 'moment'
 import { setSession } from 'utils/setSession'
+import { redis } from 'redis/clientInstance'

 interface ChartData {
   labels: string[]
@@ -202,6 +203,8 @@ export default async (req: any, res: any): Promise<void> => {
     await setSession(req, res)
     const userId = req.session.userId

+    redis.set('example', 'works')
+
     res.status(200).json(await getUserDashboardData(userId))
   }
 }
```
2. Apply the patch above by running `patch -p1 < test.patch`
3. Acessing the dashboard (http://localhost:3000) now should set the key 'example' to the value 'works'. Verify that by running again `KEYS *` in the redis command line, which should yield `1) "example"`
4. Likewise, `GET example` should return `works`

