### PR TITLE
fix: add openssl1.1-compat to alpine node container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:lts-alpine
-RUN apk add --no-cache python3 make g++
+RUN apk add --no-cache python3 make g++ openssl1.1-compat
 USER node
 WORKDIR /home/node/src/
 ENV PATH /home/node/src/node_modules/.bin:$PATH


### PR DESCRIPTION
Fixes the:
```
Error: Unable to require('/home/node/src/node_modules/@prisma/engines/libquery_engine-linux-musl.so.node')
Error loading shared library libssl.so.1.1: No such file or directory (needed by .../node_modules/prisma/libquery_engine-linux-musl.so.node)
```
 error.