### PR TITLE
refactor: exit if any command fails without `set -e`

### DIFF
--- a/config/backendConfig.ts
+++ b/config/backendConfig.ts
@@ -4,7 +4,7 @@ import { appInfo } from './appInfo'
 import { TypeInput } from 'supertokens-node/types'
 import * as addressService from 'services/addressService'
 import * as walletService from 'services/walletService'
-import { syncTransactions } from 'services/transactionService'
+import { syncTransactionsAndPricesForAddress } from 'services/transactionService'
 import { syncCurrentPrices } from 'services/priceService'
 
 const getSocialLoginProviders = (): array => {
@@ -103,7 +103,7 @@ export const backendConfig = (): TypeInput => {
                 if (response.status === 'OK') {
                   // post sign in logic goes here
                   (await addressService.fetchAllUserAddresses(response.user.id)).forEach((addr) => {
-                    void syncTransactions(addr.address)
+                    void syncTransactionsAndPricesForAddress(addr.address)
                   })
                   void syncCurrentPrices()
                   return response

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "3000:3000"
     volumes:
       - .:/home/node/src
-    command: ./scripts/paybutton-server-start.sh
+    command: sh ./scripts/paybutton-server-start.sh
   db:
     container_name: paybutton-db
     image: mariadb

--- a/scripts/paybutton-server-start.sh
+++ b/scripts/paybutton-server-start.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
-set -e
 
-yarn
-yarn prisma migrate dev
-yarn prisma db seed
-yarn dev
+yarn || exit
+yarn prisma migrate dev || exit
+yarn prisma db seed || exit
+yarn dev || exit


### PR DESCRIPTION
Description:
`set -e` to exit the script if any of the lines failed was causing problems on some builds. I  rewrote it to acheive the same behavior without `set -e`.

Test plan:
If your build was working, it should continue working. If not, due to some `set: line 2: illegal option -` error, now it should work.