### PR TITLE
fix: use .env.local instead of .env

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "dotenv -e .env.development next dev",
     "build": "next build && tsc --project tsconfig.json",
-    "initJobs": "dotenv -e .env.development -e .env -- tsx jobs/initJobs.ts",
+    "initJobs": "dotenv -e .env.development -e .env.local -- tsx jobs/initJobs.ts",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "prod": "npm run build && NODE_ENV=production pm2 start dist/index.js",
     "test": "dotenv -e .env.test -- ts-node -O '{\"module\":\"commonjs\"}' node_modules/jest/bin/jest.js",


### PR DESCRIPTION
Description:
The repo's default logic is to expect local variables on `.env.local`, not `.env`. The command `yarn initJobs` has been adjusted accordinly.

Test plan:
Nothing should change, except that env vars on `.env.local`   such as `PRICE_API_URL` should now work for `yarn initJobs`.