### PR TITLE
[Issue #349] feat: subscribe addresses to unconfirmed txs

### DIFF
--- a/components/Transaction/AddressTransactions.tsx
+++ b/components/Transaction/AddressTransactions.tsx
@@ -18,6 +18,13 @@ export default ({ addressTransactions }: IProps): FunctionComponent => {
   const columns = useMemo(
     () => [
       {
+        Header: 'Confirmed',
+        accessor: 'confirmed',
+        Cell: (cellProps) => {
+          return <div className='table-date'>{cellProps.cell.value === true ? 'yes' : 'no'}</div>
+        }
+      },
+      {
         Header: 'Date',
         accessor: 'timestamp',
         Cell: (cellProps) => {
@@ -51,7 +58,7 @@ export default ({ addressTransactions }: IProps): FunctionComponent => {
         Cell: (cellProps) => {
           const url = cellProps.cell.row.values.address.networkId === 1 ? 'https://explorer.e.cash/tx/' : 'https://blockchair.com/bitcoin-cash/transaction/'
           return (
-            <a href={url + cellProps.cell.value} target="_blank" rel="noopener noreferrer" className="table-eye-ctn">
+            <a href={url.concat(cellProps.cell.value)} target="_blank" rel="noopener noreferrer" className="table-eye-ctn">
               <div className="table-eye">
                 <Image src={EyeIcon} alt='View on explorer' />
               </div>

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -22,6 +22,7 @@ const syncAndSubscribeAddressList = async (addressList: Address[]): Promise<void
     await grpcService.subscribeTransactions(
       [addr.address],
       async (txn: Transaction.AsObject) => { await transactionService.upsertTransaction(txn, addr) },
+      async (txn: Transaction.AsObject) => { await transactionService.upsertTransaction(txn, addr, false) },
       getAddressPrefix(addr.address)
     )
   })

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -21,7 +21,7 @@ const syncAndSubscribeAddressList = async (addressList: Address[]): Promise<void
   addressList.map(async (addr) => {
     await grpcService.subscribeTransactions(
       [addr.address],
-      async (txn: Transaction.AsObject) => { await transactionService.upsertTransaction(txn, addr) },
+      async (txn: Transaction.AsObject) => { await transactionService.upsertTransaction(txn, addr, true) },
       async (txn: Transaction.AsObject) => { await transactionService.upsertTransaction(txn, addr, false) },
       getAddressPrefix(addr.address)
     )

--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -58,7 +58,7 @@ CREATE TABLE `Transaction` (
     `amount` DECIMAL(24, 8) NOT NULL,
     `timestamp` INTEGER NOT NULL,
     `addressId` INTEGER NOT NULL,
-    `confirmed` BOOLEAN NOT NULL DEFAULT TRUE,
+    `confirmed` BOOLEAN NOT NULL DEFAULT FALSE,
 
     UNIQUE INDEX `Transaction_hash_key`(`hash`),
     PRIMARY KEY (`id`)

--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -58,6 +58,7 @@ CREATE TABLE `Transaction` (
     `amount` DECIMAL(24, 8) NOT NULL,
     `timestamp` INTEGER NOT NULL,
     `addressId` INTEGER NOT NULL,
+    `confirmed` BOOLEAN NOT NULL DEFAULT TRUE,
 
     UNIQUE INDEX `Transaction_hash_key`(`hash`),
     PRIMARY KEY (`id`)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,7 +68,7 @@ model Transaction {
   id        Int                    @id @default(autoincrement())
   hash      String                 @db.VarChar(255)
   amount    Decimal                @db.Decimal(24, 8)
-  confirmed Boolean                @default(true)
+  confirmed Boolean                @default(false)
   timestamp Int
   addressId Int
   address   Address                @relation(fields: [addressId], references: [id], onDelete: Cascade, onUpdate: Restrict)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,7 @@ model Transaction {
   id        Int                    @id @default(autoincrement())
   hash      String                 @db.VarChar(255)
   amount    Decimal                @db.Decimal(24, 8)
+  confirmed Boolean                @default(true)
   timestamp Int
   addressId Int
   address   Address                @relation(fields: [addressId], references: [id], onDelete: Cascade, onUpdate: Restrict)

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -103,26 +103,60 @@ export const getTransactionDetails = async (
 export const subscribeTransactions = async (
   addresses: string[],
   onTransactionNotification: (txn: Transaction.AsObject) => any,
+  onMempoolTransactionNotification: (txn: Transaction.AsObject) => any,
   networkSlug: string,
 ): Promise<void> => {
   const createTxnStream = async (): Promise<void> => {
     const client = getClientForNetworkSlug(networkSlug)
-    const txnStream = await client.subscribeTransactions({
-      //includeMempoolAcceptance: true,
+    const confirmedStream = await client.subscribeTransactions({
+      includeMempoolAcceptance: false,
       includeBlockAcceptance: true,
-      //includeSerializedTxn: false,
+      addresses: addresses,
+    });
+    const unconfirmedStream = await client.subscribeTransactions({
+      includeMempoolAcceptance: true,
+      includeBlockAcceptance: false,
       addresses: addresses,
     });
 
-    txnStream.on('end', async (error: any) => {
-      console.log('stream ended', error);
+    let nowDateString = (new Date()).toISOString()
+
+    // output for end, error or close of stream
+    void confirmedStream.on('end', async () => {
+      console.log(`${nowDateString}: addresses ${addresses.join(', ')} confirmed stream ended`);
+    });
+    void confirmedStream.on('close', async () => {
+      console.log(`${nowDateString}: addresses ${addresses.join(', ')} confirmed stream closed`);
+    });
+    void confirmedStream.on('error', async (error: any) => {
+      console.log(`${nowDateString}: addresses ${addresses.join(', ')} confirmed stream error`, error);
+    });
+    void unconfirmedStream.on('end', async () => {
+      console.log(`${nowDateString}: addresses ${addresses.join(', ')} unconfirmed stream ended`);
+    });
+    void unconfirmedStream.on('close', async () => {
+      console.log(`${nowDateString}: addresses ${addresses.join(', ')} unconfirmed stream closed`);
+    });
+    void unconfirmedStream.on('error', async (error: any) => {
+      console.log(`${nowDateString}: addresses ${addresses.join(', ')} unconfirmed stream error`, error);
     });
 
-    txnStream.on('data', async (data: TransactionNotification) => {
-      let txn = data.getConfirmedTransaction()!;
-      onTransactionNotification(txn.toObject());
+    // output for data stream
+    void confirmedStream.on('data', async (data: TransactionNotification) => {
+      let objectTxn = data.getConfirmedTransaction()!.toObject();
+      console.log(`${nowDateString}: got confirmed txn`, objectTxn);
+      onTransactionNotification(objectTxn);
     });
-    console.log(`txn data stream established.`);
+    void unconfirmedStream.on('data', async (data: TransactionNotification) => {
+      let unconfirmedTxn = data.getUnconfirmedTransaction()!;
+      let timestamp = unconfirmedTxn.getAddedTime()
+      let objectTxn = unconfirmedTxn.getTransaction()!.toObject();
+      objectTxn.timestamp = timestamp
+      console.log(`${nowDateString}: got unconfirmed txn`, objectTxn);
+      onMempoolTransactionNotification(objectTxn);
+    });
+
+    console.log(`${nowDateString}: txn data stream established for addresses ${addresses.join(', ')}.`);
   };
   await createTxnStream();
 };

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -108,7 +108,7 @@ export async function base64HashToHex (base64Hash: string): Promise<string> {
   )
 }
 
-export async function upsertTransaction (transaction: Transaction.AsObject, address: Address): Promise<TransactionWithAddressAndPrices | undefined> {
+export async function upsertTransaction (transaction: Transaction.AsObject, address: Address, confirmed=true): Promise<TransactionWithAddressAndPrices | undefined> {
   const receivedAmount = await getTransactionAmount(transaction, address.address)
   if (receivedAmount === new Prisma.Decimal(0)) { // out transactions
     return
@@ -118,7 +118,8 @@ export async function upsertTransaction (transaction: Transaction.AsObject, addr
     hash,
     amount: receivedAmount,
     addressId: address.id,
-    timestamp: transaction.timestamp
+    timestamp: transaction.timestamp,
+    confirmed: confirmed
   }
   return await prisma.transaction.upsert({
     where: {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -108,7 +108,7 @@ export async function base64HashToHex (base64Hash: string): Promise<string> {
   )
 }
 
-export async function upsertTransaction (transaction: Transaction.AsObject, address: Address, confirmed=true): Promise<TransactionWithAddressAndPrices | undefined> {
+export async function upsertTransaction (transaction: Transaction.AsObject, address: Address, confirmed = false): Promise<TransactionWithAddressAndPrices | undefined> {
   const receivedAmount = await getTransactionAmount(transaction, address.address)
   if (receivedAmount === new Prisma.Decimal(0)) { // out transactions
     return
@@ -119,7 +119,7 @@ export async function upsertTransaction (transaction: Transaction.AsObject, addr
     amount: receivedAmount,
     addressId: address.id,
     timestamp: transaction.timestamp,
-    confirmed: confirmed
+    confirmed
   }
   return await prisma.transaction.upsert({
     where: {
@@ -134,11 +134,11 @@ export async function upsertTransaction (transaction: Transaction.AsObject, addr
   })
 }
 
-export async function upsertManyTransactionsForAddress (transactions: Transaction.AsObject[], address: Address): Promise<TransactionWithAddressAndPrices[]> {
+export async function upsertManyTransactionsForAddress (transactions: Transaction.AsObject[], address: Address, confirmed = false): Promise<TransactionWithAddressAndPrices[]> {
   const ret = await prisma.$transaction(async (_) => {
     const insertedTransactions: Array<TransactionWithAddressAndPrices | undefined> = await Promise.all(
       transactions.map(async (transaction) => {
-        return await upsertTransaction(transaction, address)
+        return await upsertTransaction(transaction, address, confirmed)
       })
     )
     return insertedTransactions

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -233,6 +233,7 @@ export const mockedTransaction = {
   id: 1,
   hash: 'Yh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
   addressId: 1,
+  confirmed: true,
   address: {
     id: 1,
     address: 'mockedaddress0nkush83z76az28900c7tj5vpc8f',
@@ -252,6 +253,7 @@ export const mockedTransactionList = [
   {
     id: 1,
     hash: 'Yh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
+    confirmed: true,
     addressId: 1,
     amount: new Prisma.Decimal('4.31247724'),
     timestamp: 1657130467
@@ -259,6 +261,7 @@ export const mockedTransactionList = [
   {
     id: 2,
     hash: 'hh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
+    confirmed: true,
     addressId: 1,
     amount: new Prisma.Decimal('1.5'),
     timestamp: 1657130467
@@ -266,6 +269,7 @@ export const mockedTransactionList = [
   {
     id: 3,
     hash: '5h5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
+    confirmed: true,
     addressId: 1,
     amount: new Prisma.Decimal('0.2'),
     timestamp: 1657130467

--- a/tests/unittests/transactionService.test.ts
+++ b/tests/unittests/transactionService.test.ts
@@ -12,7 +12,8 @@ describe('Create services', () => {
 
     const result = await transactionService.upsertTransaction(
       mockedGrpc.transaction1.toObject(),
-      mockedBCHAddress
+      mockedBCHAddress,
+      true
     )
     expect(result).toEqual(mockedTransaction)
   })


### PR DESCRIPTION
Description:
Part of #349. Subscribes addresses also to unconfirmed transactions, so that they are synced as soon as they get into the mempool. For now, I decided showing if they are confirmed or not; will remove that in the PR that removes from the DB transactions that become invalid.

Test plan:
Same as #345, but now waiting for unconfirmed txs. Also, more detailed output now will be visible by running `yarn docker jobs` or examining the file `jobs/out.log`.

Depends on:
- [x] #345 