### PR TITLE
[Issue #154] feat: edit wallet show errors

### DIFF
--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -20,6 +20,7 @@ interface IProps {
 export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletList }: IProps): ReactElement {
   const { register, handleSubmit, reset } = useForm<WalletPATCHParameters>()
   const [modal, setModal] = useState(false)
+  const [error, setError] = useState('')
 
   useEffect(() => {
     setModal(false)
@@ -30,8 +31,13 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
     if (params.name === '' || params.name === undefined) {
       params.name = wallet.name
     }
-    void await axios.patch(`${appInfo.websiteDomain}/api/wallet/${wallet.id}`, params)
-    refreshWalletList()
+    try {
+      void await axios.patch(`${appInfo.websiteDomain}/api/wallet/${wallet.id}`, params)
+      refreshWalletList()
+      setError('')
+    } catch (err: any) {
+      setError(err.response.data.message)
+    }
   }
 
   return (
@@ -104,6 +110,7 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
                   <button onClick={() => { setModal(false); reset() }} className={style_pb.cancel_btn}>Cancel</button>
                 </div>
               </form>
+                    {error !== '' && <div className={style_pb.error_message}>{error}</div>}
             </div>
           </div>
         </div>)

--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement, useState, useEffect } from 'react'
-import { Paybutton } from '@prisma/client'
+import { PaybuttonWithAddresses } from 'services/paybuttonService'
 import { useForm } from 'react-hook-form'
 import { WalletPATCHParameters } from 'utils/validators'
 import Image from 'next/image'
-import style from '../Paybutton/paybutton.module.css'
-import s from '../Wallet/wallet.module.css'
+import style from '../Wallet/wallet.module.css'
+import style_pb from '../Paybutton/paybutton.module.css'
 import EditIcon from 'assets/edit-icon.png'
 import { WalletWithAddressesAndPaybuttons } from 'services/walletService'
 import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
@@ -13,7 +13,7 @@ import { appInfo } from 'config/appInfo'
 
 interface IProps {
   wallet: WalletWithAddressesAndPaybuttons
-  userPaybuttons: Paybutton[]
+  userPaybuttons: PaybuttonWithAddresses[]
   refreshWalletList: Function
 }
 
@@ -36,16 +36,16 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
 
   return (
     <>
-      <div className={s.edit_button} onClick={() => setModal(true)}>
+      <div className={style.edit_button} onClick={() => setModal(true)}>
         <Image src={EditIcon} alt='edit' />
       </div>
 
   {modal
     ? (
-        <div className={style.form_ctn_outer}>
-          <div className={style.form_ctn_inner}>
+        <div className={style_pb.form_ctn_outer}>
+          <div className={style_pb.form_ctn_inner}>
             <h4>Edit {wallet.name}</h4>
-            <div className={style.form_ctn}>
+            <div className={style_pb.form_ctn}>
               <form onSubmit={(e) => { void handleSubmit(onSubmit)(e) }} method='post'>
                 <label htmlFor='name'>Wallet Name</label>
                 <input
@@ -55,8 +55,8 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
                     name='name'
                     placeholder={wallet.name}
                 />
-                <div className={s.makedefault_ctn} key={wallet.id}>
-                  <div className={s.input_field}>
+                <div className={style.makedefault_ctn} key={`edit-wallet-${wallet.id}`}>
+                  <div className={style.input_field}>
                     <input
                         {...register('isXECDefault')}
                         defaultChecked={wallet.userProfile?.isXECDefault === true}
@@ -67,9 +67,9 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
                           wallet.userProfile?.isXECDefault === true
                         }
                     />
-                    <label htmlFor='xec-default' className={s.makedefault_margin}>Make Default XEC Wallet</label>
+                    <label htmlFor='xec-default' className={style.makedefault_margin}>Make Default XEC Wallet</label>
                   </div>
-                  <div className={s.input_field}>
+                  <div className={style.input_field}>
                     <input
                         {...register('isBCHDefault')}
                         defaultChecked={wallet.userProfile?.isBCHDefault === true}
@@ -80,14 +80,14 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
                           wallet.userProfile?.isBCHDefault === true
                         }
                     />
-                    <label htmlFor='bch-default' className={s.makedefault_margin}>Make Default BCH Wallet</label>
+                    <label htmlFor='bch-default' className={style.makedefault_margin}>Make Default BCH Wallet</label>
                   </div>
                 </div>
 
       <h4>Paybuttons</h4>
-      <div className={s.buttonlist_ctn}>
+      <div className={style.buttonlist_ctn}>
       {userPaybuttons.map((pb, index) => (
-        <div className={s.input_field} key={`pb-${pb.id}`}>
+        <div className={style.input_field} key={`edit-pb-${pb.id}`}>
           <input {...register('paybuttonIdList')}
           type='checkbox'
           value={pb.id}
@@ -99,9 +99,9 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
       ))}
       </div>
 
-                <div className={style.btn_row}>
+                <div className={style_pb.btn_row}>
                   <button type='submit'>Submit</button>
-                  <button onClick={() => { setModal(false); reset() }} className={style.cancel_btn}>Cancel</button>
+                  <button onClick={() => { setModal(false); reset() }} className={style_pb.cancel_btn}>Cancel</button>
                 </div>
               </form>
             </div>

--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -46,24 +46,24 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
         <Image src={EditIcon} alt='edit' />
       </div>
 
-  {modal
-    ? (
-        <div className={style_pb.form_ctn_outer}>
-          <div className={style_pb.form_ctn_inner}>
-            <h4>Edit {wallet.name}</h4>
-            <div className={style_pb.form_ctn}>
-              <form onSubmit={(e) => { void handleSubmit(onSubmit)(e) }} method='post'>
-                <label htmlFor='name'>Wallet Name</label>
-                <input
+      {modal
+        ? (
+          <div className={style_pb.form_ctn_outer}>
+            <div className={style_pb.form_ctn_inner}>
+              <h4>Edit {wallet.name}</h4>
+              <div className={style_pb.form_ctn}>
+                <form onSubmit={(e) => { void handleSubmit(onSubmit)(e) }} method='post'>
+                  <label htmlFor='name'>Wallet Name</label>
+                  <input
                     {...register('name')}
                     type='text'
                     id='name'
                     name='name'
                     placeholder={wallet.name}
-                />
-                <div className={style.makedefault_ctn} key={`edit-wallet-${wallet.id}`}>
-                  <div className={style.input_field}>
-                    <input
+                  />
+                  <div className={style.makedefault_ctn} key={`edit-wallet-${wallet.id}`}>
+                    <div className={style.input_field}>
+                      <input
                         {...register('isXECDefault')}
                         defaultChecked={wallet.userProfile?.isXECDefault === true}
                         type="checkbox"
@@ -72,11 +72,11 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
                           wallet.addresses.every((addr) => addr.networkId !== XEC_NETWORK_ID) ||
                           wallet.userProfile?.isXECDefault === true
                         }
-                    />
-                    <label htmlFor='xec-default' className={style.makedefault_margin}>Make Default XEC Wallet</label>
-                  </div>
-                  <div className={style.input_field}>
-                    <input
+                      />
+                      <label htmlFor='xec-default' className={style.makedefault_margin}>Make Default XEC Wallet</label>
+                    </div>
+                    <div className={style.input_field}>
+                      <input
                         {...register('isBCHDefault')}
                         defaultChecked={wallet.userProfile?.isBCHDefault === true}
                         type="checkbox"
@@ -85,36 +85,35 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
                           wallet.addresses.every((addr) => addr.networkId !== BCH_NETWORK_ID) ||
                           wallet.userProfile?.isBCHDefault === true
                         }
-                    />
-                    <label htmlFor='bch-default' className={style.makedefault_margin}>Make Default BCH Wallet</label>
+                      />
+                      <label htmlFor='bch-default' className={style.makedefault_margin}>Make Default BCH Wallet</label>
+                    </div>
                   </div>
-                </div>
 
-      <h4>Paybuttons</h4>
-      <div className={style.buttonlist_ctn}>
-      {userPaybuttons.map((pb, index) => (
-        <div className={style.input_field} key={`edit-pb-${pb.id}`}>
-          <input {...register('paybuttonIdList')}
-          type='checkbox'
-          value={pb.id}
-          id={`paybuttonIdList.${index}`}
-          defaultChecked={pb.walletId === wallet.id}
-          />
-          <label htmlFor={`paybuttonIdList.${index}`}>{pb.name}</label>
-        </div>
-      ))}
-      </div>
-
-                <div className={style_pb.btn_row}>
-                  <button type='submit'>Submit</button>
-                  <button onClick={() => { setModal(false); reset() }} className={style_pb.cancel_btn}>Cancel</button>
-                </div>
-              </form>
+                  <h4>Paybuttons</h4>
+                  <div className={style.buttonlist_ctn}>
+                    {userPaybuttons.map((pb, index) => (
+                      <div className={style.input_field} key={`edit-pb-${pb.id}`}>
+                        <input {...register('paybuttonIdList')}
+                          type='checkbox'
+                          value={pb.id}
+                          id={`paybuttonIdList.${index}`}
+                          defaultChecked={pb.walletId === wallet.id}
+                        />
+                        <label htmlFor={`paybuttonIdList.${index}`}>{pb.name}</label>
+                      </div>
+                    ))}
+                  </div>
+                  <div className={style_pb.btn_row}>
                     {error !== '' && <div className={style_pb.error_message}>{error}</div>}
+                    <button type='submit'>Submit</button>
+                    <button onClick={() => { setModal(false); reset() }} className={style_pb.cancel_btn}>Cancel</button>
+                  </div>
+                </form>
+              </div>
             </div>
-          </div>
-        </div>)
-    : null}
+          </div>)
+        : null}
     </>
   )
 }

--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react'
-import { Paybutton } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 import style from './wallet.module.css'
 import Link from 'next/link'
 import Image from 'next/image'
@@ -7,16 +7,17 @@ import XECIcon from 'assets/xec-logo.png'
 import BCHIcon from 'assets/bch-logo.png'
 import EditWalletForm from './EditWalletForm'
 import { WalletWithAddressesAndPaybuttons, WalletPaymentInfo } from 'services/walletService'
+import { PaybuttonWithAddresses } from 'services/paybuttonService'
 import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 
 interface IProps {
   wallet: WalletWithAddressesAndPaybuttons
   paymentInfo: WalletPaymentInfo
-  userPaybuttons: Paybutton[]
+  userPaybuttons: PaybuttonWithAddresses[]
   refreshWalletList: Function
 }
 
-export default ({ wallet, paymentInfo, userPaybuttons, refreshWalletList }: IProps): FunctionComponent => {
+const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userPaybuttons, refreshWalletList }: IProps) => {
   const networks = wallet.addresses.map((addr) => addr.networkId)
   return (
     <div className={style.wallet_card}>
@@ -36,13 +37,13 @@ export default ({ wallet, paymentInfo, userPaybuttons, refreshWalletList }: IPro
       </div>
 
       <div className={style.info_ctn}>
-      {paymentInfo.XECBalance > 0 &&
+      {paymentInfo.XECBalance > new Prisma.Decimal(0) &&
         <div className={style.info_item}>
           <h6>XEC Balance</h6>
           <h5>{Number(paymentInfo.XECBalance).toLocaleString()} XEC</h5>
         </div>
       }
-      {paymentInfo.BCHBalance > 0 &&
+      {paymentInfo.BCHBalance > new Prisma.Decimal(0) &&
         <div className={style.info_item}>
           <h6>BCH Balance</h6>
           <h5>{Number(paymentInfo.BCHBalance).toLocaleString()} BCH</h5>
@@ -67,3 +68,5 @@ export default ({ wallet, paymentInfo, userPaybuttons, refreshWalletList }: IPro
     </div>
   )
 }
+
+export default component

--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -32,7 +32,11 @@ const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userPaybutt
         <div className={style.edit_button_ctn}>
           {wallet.userProfile?.isXECDefault === true && <div className={style.default_wallet}>Default XEC Wallet</div>}
           {wallet.userProfile?.isBCHDefault === true && <div className={style.default_wallet}>Default BCH Wallet</div>}
-          <EditWalletForm wallet={wallet} userPaybuttons={userPaybuttons} refreshWalletList={refreshWalletList}/>
+          <EditWalletForm
+            wallet={wallet}
+            userPaybuttons={userPaybuttons}
+            refreshWalletList={refreshWalletList}
+          />
         </div>
       </div>
 

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -4,11 +4,11 @@ import dynamic from 'next/dynamic'
 import supertokensNode from 'supertokens-node'
 import * as SuperTokensConfig from '../../config/backendConfig'
 import Session from 'supertokens-node/recipe/session'
-import { Paybutton } from '@prisma/client'
 import { GetServerSideProps } from 'next'
 import WalletCard from 'components/Wallet/WalletCard'
 import WalletForm from 'components/Wallet/WalletForm'
 import { WalletWithAddressesAndPaybuttons, WalletPaymentInfo } from 'services/walletService'
+import { PaybuttonWithAddresses } from 'services/paybuttonService'
 
 const ThirdPartyEmailPasswordAuthNoSSR = dynamic(
   new Promise((resolve, reject) =>
@@ -44,7 +44,7 @@ interface WalletsProps {
 
 interface WalletsState {
   walletsWithPaymentInfo: [{wallet: WalletWithAddressesAndPaybuttons, paymentInfo: WalletPaymentInfo}]
-  userPaybuttons: Paybutton[]
+  userPaybuttons: PaybuttonWithAddresses[]
 }
 
 export default function Wallets ({ userId }: WalletsProps): React.ReactElement {

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -112,7 +112,12 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
           }
           return a.wallet.name.localeCompare(b.wallet.name)
         }).map(walletWithPaymentInfo => {
-          return <WalletCard wallet={walletWithPaymentInfo.wallet} paymentInfo={walletWithPaymentInfo.paymentInfo} userPaybuttons={this.state.userPaybuttons} refreshWalletList={this.refreshWalletList}/>
+          return <WalletCard
+            wallet={walletWithPaymentInfo.wallet}
+            paymentInfo={walletWithPaymentInfo.paymentInfo}
+            userPaybuttons={this.state.userPaybuttons}
+            refreshWalletList={this.refreshWalletList}
+          />
         }
         )}
         <WalletForm />

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -40,6 +40,20 @@ const walletWithAddressesAndPaybuttons = Prisma.validator<Prisma.WalletArgs>()(
   { include: includeAddressesAndPaybuttons }
 )
 
+const getDefaultForNetworkIds = (isXECDefault: boolean | undefined, isBCHDefault: boolean | undefined): number[] => {
+  const defaultForNetworkIds: number[] = []
+  // set default for XEC
+  if (isXECDefault === true) {
+    defaultForNetworkIds.push(XEC_NETWORK_ID)
+  }
+
+  // set default for BCH
+  if (isBCHDefault === true) {
+    defaultForNetworkIds.push(BCH_NETWORK_ID)
+  }
+  return defaultForNetworkIds
+}
+
 export type WalletWithAddressesAndPaybuttons = Prisma.WalletGetPayload<typeof walletWithAddressesAndPaybuttons>
 
 export async function createWallet (values: CreateWalletInput): Promise<WalletWithAddressesAndPaybuttons> {
@@ -206,13 +220,13 @@ export async function setDefaultWallet (wallet: WalletWithAddressesAndPaybuttons
   return wallet
 }
 
-export async function updateWallet (walletId: number, params: any): Promise<WalletWithAddressesAndPaybuttons> {
+export async function updateWallet (walletId: number, params: UpdateWalletInput): Promise<WalletWithAddressesAndPaybuttons> {
   const wallet = await fetchWalletById(walletId)
   if (wallet === null) {
     throw new Error(RESPONSE_MESSAGES.NO_WALLET_FOUND_404.message)
   }
 
-  const paybuttonList = await paybuttonService.fetchPaybuttonArrayByIds(params.paybuttonIdList.map((id: string) => Number(id)))
+  const paybuttonList = await paybuttonService.fetchPaybuttonArrayByIds(params.paybuttonIdList)
 
   // enforce that added paybuttons & addresses don't already belong to a wallet
   paybuttonList.forEach((pb) => {
@@ -228,16 +242,8 @@ export async function updateWallet (walletId: number, params: any): Promise<Wall
   if (wallet.userProfile === null) {
     throw new Error(RESPONSE_MESSAGES.NO_USER_PROFILE_FOUND_ON_WALLET_404.message)
   }
-  // set default for XEC
-  const defaultForNetworkIds: number[] = []
-  if (params.isXECDefault === true) {
-    defaultForNetworkIds.push(XEC_NETWORK_ID)
-  }
 
-  // set default for BCH
-  if (params.isBCHDefault === true) {
-    defaultForNetworkIds.push(BCH_NETWORK_ID)
-  }
+  const defaultForNetworkIds = getDefaultForNetworkIds(params.isXECDefault, params.isBCHDefault)
 
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
   return await prisma.$transaction(async (prisma) => {

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -40,7 +40,7 @@ const walletWithAddressesAndPaybuttons = Prisma.validator<Prisma.WalletArgs>()(
   { include: includeAddressesAndPaybuttons }
 )
 
-const getDefaultForNetworkIds = (isXECDefault: boolean | undefined, isBCHDefault: boolean | undefined): number[] => {
+export const getDefaultForNetworkIds = (isXECDefault: boolean | undefined, isBCHDefault: boolean | undefined): number[] => {
   const defaultForNetworkIds: number[] = []
   // set default for XEC
   if (isXECDefault === true) {
@@ -54,7 +54,7 @@ const getDefaultForNetworkIds = (isXECDefault: boolean | undefined, isBCHDefault
   return defaultForNetworkIds
 }
 
-const walletHasAddressForNetwork = (wallet: WalletWithAddressesAndPaybuttons, networkId: number): boolean => {
+export const walletHasAddressForNetwork = (wallet: WalletWithAddressesAndPaybuttons, networkId: number): boolean => {
   if (wallet.addresses.every((addr) => addr.networkId !== networkId)) {
     return false
   }

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -3,7 +3,7 @@ import { Prisma, Paybutton, Address } from '@prisma/client'
 import * as walletService from 'services/walletService'
 import * as addressService from 'services/addressService'
 import { prismaMock } from 'prisma/mockedClient'
-import { RESPONSE_MESSAGES } from 'constants/index'
+import { RESPONSE_MESSAGES, XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 import { mockedWallet, mockedWalletList, mockedPaybuttonList, mockedPaybutton, mockedNetwork, mockedBCHAddress } from '../mockedObjects'
 
 describe('Fetch services', () => {
@@ -212,5 +212,60 @@ describe('Update services', () => {
     } catch (e: any) {
       expect(e.message).toMatch(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
     }
+  })
+})
+
+describe('Auxiliary functions', () => {
+  it('gets network default', () => {
+    expect(
+      walletService.getDefaultForNetworkIds(true, true)
+    ).toStrictEqual([1, 2])
+    expect(
+      walletService.getDefaultForNetworkIds(true, false)
+    ).toStrictEqual([1])
+    expect(
+      walletService.getDefaultForNetworkIds(false, true)
+    ).toStrictEqual([2])
+    expect(
+      walletService.getDefaultForNetworkIds(false, false)
+    ).toStrictEqual([])
+  })
+  it('Mocked wallet has address for both networks', () => {
+    expect(
+      walletService.walletHasAddressForNetwork(mockedWallet, XEC_NETWORK_ID)
+    ).toBe(true)
+    expect(
+      walletService.walletHasAddressForNetwork(mockedWallet, XEC_NETWORK_ID)
+    ).toBe(true)
+  })
+  it('Mocked wallet has address only for XEC', () => {
+    const otherWallet = { ...mockedWallet }
+    otherWallet.addresses = otherWallet.addresses.filter((addr) => addr.networkId === XEC_NETWORK_ID)
+    expect(
+      walletService.walletHasAddressForNetwork(otherWallet, XEC_NETWORK_ID)
+    ).toBe(true)
+    expect(
+      walletService.walletHasAddressForNetwork(otherWallet, BCH_NETWORK_ID)
+    ).toBe(false)
+  })
+  it('Mocked wallet has address only for BCH', () => {
+    const otherWallet = { ...mockedWallet }
+    otherWallet.addresses = otherWallet.addresses.filter((addr) => addr.networkId === BCH_NETWORK_ID)
+    expect(
+      walletService.walletHasAddressForNetwork(otherWallet, BCH_NETWORK_ID)
+    ).toBe(true)
+    expect(
+      walletService.walletHasAddressForNetwork(otherWallet, XEC_NETWORK_ID)
+    ).toBe(false)
+  })
+  it('Mocked wallet has no addresses', () => {
+    const otherWallet = { ...mockedWallet }
+    otherWallet.addresses = []
+    expect(
+      walletService.walletHasAddressForNetwork(otherWallet, BCH_NETWORK_ID)
+    ).toBe(false)
+    expect(
+      walletService.walletHasAddressForNetwork(otherWallet, XEC_NETWORK_ID)
+    ).toBe(false)
   })
 })

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -128,6 +128,7 @@ export const parseWalletPOSTRequest = function (params: WalletPOSTParameters): C
 export const parseWalletPATCHRequest = function (params: WalletPATCHParameters): UpdateWalletInput {
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
   if (params.paybuttonIdList === undefined || params.paybuttonIdList.length === 0) throw new Error(RESPONSE_MESSAGES.BUTTON_IDS_NOT_PROVIDED_400.message)
+  params.paybuttonIdList = params.paybuttonIdList.map((id: string | number) => Number(id))
   return {
     name: params.name,
     paybuttonIdList: params.paybuttonIdList,


### PR DESCRIPTION
Description:
Editing wallets on http://localhost:3000/wallets now display errors on the modal, like it was already being done on http://localhost:3000/paybuttons.

Test plan:
Go to http://localhost:3000/wallets and try to modify an wallet in an invalid way, such as leaving it with no paybuttons or setting it as a default for some network which it has no addresses to.

Remarks:
- Fixed problem where was possible (on the backend) to set wallet with no XEC addresses to BCH default and vice e versa;
-  This edit feature still does not allow editing the wallet paybuttons, so that any unexpected behaviors related to it are still expected.