### PR TITLE
[Issue #353] fix: require userId to update wallet

### DIFF
--- a/pages/api/wallet/[id].ts
+++ b/pages/api/wallet/[id].ts
@@ -25,8 +25,9 @@ export default async (
   } else if (req.method === 'PATCH') {
     await setSession(req, res)
     try {
-      const values = req.body
-      const updateWalletInput = parseWalletPATCHRequest(values)
+      const params = req.body
+      params.userId = req.session.userId
+      const updateWalletInput = parseWalletPATCHRequest(params)
       const wallet = await walletService.updateWallet(Number(walletId), updateWalletInput)
       res.status(200).json(wallet)
     } catch (err: any) {

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -16,6 +16,7 @@ export interface UpdateWalletInput {
   isXECDefault?: boolean
   isBCHDefault?: boolean
   paybuttonIdList: number[]
+  userId: string
 }
 
 const includeAddressesAndPaybuttons = {
@@ -244,6 +245,9 @@ export async function updateWallet (walletId: number, params: UpdateWalletInput)
 
   // enforce that added paybuttons & addresses don't already belong to a wallet
   paybuttonList.forEach((pb) => {
+    if (pb.providerUserId !== params.userId) {
+      throw new Error(RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400.message)
+    }
     if (pb.walletId !== null && pb.walletId !== walletId) {
       throw new Error(RESPONSE_MESSAGES.PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400.message)
     }

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -110,14 +110,7 @@ describe('Update services', () => {
   interface Data {
     updateWalletInput: walletService.UpdateWalletInput
   }
-  let data: Data = {
-    updateWalletInput: {
-      name: '',
-      isXECDefault: undefined,
-      isBCHDefault: undefined,
-      paybuttonIdList: [1]
-    }
-  }
+  let data: Data
 
   beforeEach(() => {
     data = {
@@ -125,7 +118,8 @@ describe('Update services', () => {
         name: 'mockedWallet',
         isXECDefault: undefined,
         isBCHDefault: undefined,
-        paybuttonIdList: [1]
+        paybuttonIdList: [1],
+        userId: 'mocked-uid'
       }
     }
     prismaMock.wallet.update.mockResolvedValue(mockedWallet)

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -109,6 +109,7 @@ export interface PaybuttonPATCHParameters {
 
 export interface WalletPATCHParameters {
   name: string
+  userId?: string
   isXECDefault?: boolean
   isBCHDefault?: boolean
   paybuttonIdList: number[]
@@ -126,11 +127,13 @@ export const parseWalletPOSTRequest = function (params: WalletPOSTParameters): C
 }
 
 export const parseWalletPATCHRequest = function (params: WalletPATCHParameters): UpdateWalletInput {
+  if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
   if (params.paybuttonIdList === undefined || params.paybuttonIdList.length === 0) throw new Error(RESPONSE_MESSAGES.BUTTON_IDS_NOT_PROVIDED_400.message)
   params.paybuttonIdList = params.paybuttonIdList.map((id: string | number) => Number(id))
   return {
     name: params.name,
+    userId: params.userId,
     paybuttonIdList: params.paybuttonIdList,
     isXECDefault: params.isXECDefault,
     isBCHDefault: params.isBCHDefault


### PR DESCRIPTION
Description:
Solve #353. Update user method requires `userId`, which will be get from session. Now users are not allowed to craft a request that would allow them to edit a wallet with other users' buttons.

Test plan:
Covered by tests, editing wallets from the front end should work normally.