### PR TITLE
[Issue #363, #364] fix: Redis not persistent & Exit start script with error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@ yarn-error.log*
 # vercel
 .vercel
 
-redis/dump.rdb
 jobs/out.log

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ dev:
 	docker-compose up --build -d
 
 stop-dev:
-	docker-compose down && rm redis/dump.rdb
+	docker-compose down
 
 reset-dev:
 	make stop-dev && make dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,4 +56,4 @@ services:
     volumes:
       - ./redis:/data/redis:z
     # dump the dataset each 20 seconds if there was at least 1 change
-    command: sh -c "umask 000 && redis-server /data/redis/redis.conf --save 20 1 --loglevel warning"
+    command: sh -c "umask 000 && redis-server /data/redis/redis.conf --loglevel warning"

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -1,1 +1,2 @@
 dir redis/
+save ""

--- a/scripts/paybutton-server-start.sh
+++ b/scripts/paybutton-server-start.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-yarn || exit
-yarn prisma migrate dev || exit
-yarn prisma db seed || exit
-date "+start date: %Y-%m-%d %H:%M:%S" > jobs/out.log || exit
-tmux new-session -d -s "initJobs" 'yarn initJobs 2>&1 | tee -a jobs/out.log' || exit
-yarn dev || exit
+yarn || exit 1
+yarn prisma migrate dev || exit 1
+yarn prisma db seed || exit 1
+date "+start date: %Y-%m-%d %H:%M:%S" > jobs/out.log || exit 1
+tmux new-session -d -s "initJobs" 'yarn initJobs 2>&1 | tee -a jobs/out.log' || exit 1
+yarn dev || exit 1


### PR DESCRIPTION
Description:
Solves #363 and #364.

Test plan:
After checking out on this branch, manually delete the `redis/dumb.rdb` since this is not gonna be done automatically by `make stop-dev` now. Then reset the containers and everything should work normally.