### PR TITLE
fix: take .env into account when running jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "dotenv -e .env.development next dev",
     "build": "next build && tsc --project tsconfig.json",
-    "initJobs": "dotenv -e .env.development -e .env.local -- tsx jobs/initJobs.ts",
+    "initJobs": "dotenv -e .env.development -e .env -c -- tsx jobs/initJobs.ts",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "prod": "npm run build && NODE_ENV=production pm2 start dist/index.js",
     "test": "dotenv -e .env.test -- ts-node -O '{\"module\":\"commonjs\"}' node_modules/jest/bin/jest.js",


### PR DESCRIPTION
**Description:**
Env variables can now be put both on `.env` and `.env.local`. `.env.local` overrides `.env`.

**Test plan:**
Experiment with having the
```
GRPC_BCH_NODE_URL=
GRPC_XEC_NODE_URL=
PRICE_API_URL=
```
environment variables on `.env` and/or `.env.local` and see if both are being taken into account and if the aforementioned hierarchy is being preserved; by checking `jobs/out.log` and seeing if it works normally or breaks.