### PR TITLE
bigger base image that has the necessary packages to run on M1 also

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:lts-alpine
-RUN apk add --no-cache python3 make g++ tmux openssl1.1-compat
+FROM node:lts
+RUN apt-get update && apt-get -y install tmux
 USER node
 WORKDIR /home/node/src/
 ENV PATH /home/node/src/node_modules/.bin:$PATH


### PR DESCRIPTION
Please delete `node_modules` folder and docker images before testing everything with `make dev`.

I used a bigger starting docker image that runs in M1 in the end. Also, I believe it has some of the packages that were manually installed afterwards, I removed them.