### PR TITLE
[Issue #376] fix: smaller alphine image that still runs on M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:lts
-RUN apt-get update && apt-get -y install tmux
+FROM  --platform=linux/amd64 node:lts-alpine
+RUN apk add --no-cache python3 make g++ tmux openssl1.1-compat
 USER node
 WORKDIR /home/node/src/
 ENV PATH /home/node/src/node_modules/.bin:$PATH


### PR DESCRIPTION
adding the flag --platform=linux/amd64 to the original dockerfile (before last PR: https://github.com/PayButton/paybutton-server/pull/373) works in M1