### PR TITLE
feat: don't parse address when upserting it

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   parserOptions: {
     project: './tsconfig.json'
   },
+  ignorePatterns: ["node_modules/"],
   rules: {
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/triple-slash-reference': 'off'

--- a/services/addressService.ts
+++ b/services/addressService.ts
@@ -2,7 +2,6 @@ import { Prisma, Address } from '@prisma/client'
 import prisma from 'prisma/clientInstance'
 import { RESPONSE_MESSAGES } from 'constants/index'
 import { fetchAddressTransactions } from 'services/transactionService'
-import { parseAddress } from 'utils/validators'
 import { getNetworkFromSlug } from 'services/networkService'
 
 const addressFullType = Prisma.validator<Prisma.AddressArgs>()({
@@ -92,15 +91,14 @@ export async function fetchAddressesInList (prefixedAddressList: string[]): Prom
 }
 
 export async function upsertAddress (addressString: string): Promise<AddressWithTransactions> {
-  const prefixedAddress = parseAddress(addressString)
-  const prefix = prefixedAddress.split(':')[0].toLowerCase()
+  const prefix = addressString.split(':')[0].toLowerCase()
   const network = await getNetworkFromSlug(prefix)
   return await prisma.address.upsert({
     where: {
-      address: prefixedAddress
+      address: addressString
     },
     create: {
-      address: prefixedAddress.toLowerCase(),
+      address: addressString.toLowerCase(),
       networkId: Number(network.id)
     },
     update: {},

--- a/tests/unittests/addressService.test.ts
+++ b/tests/unittests/addressService.test.ts
@@ -38,14 +38,6 @@ describe('Find by substring', () => {
 })
 
 describe('Create by substring', () => {
-  it('Fail to create address with invalid address', async () => {
-    prismaMock.address.upsert.mockResolvedValue(mockedBCHAddress)
-    prisma.address.upsert = prismaMock.address.upsert
-
-    await expect(addressService.upsertAddress('mock')).rejects.toThrow(
-      RESPONSE_MESSAGES.INVALID_ADDRESS_400.message
-    )
-  })
   it('Create single address', async () => {
     prismaMock.address.upsert.mockResolvedValue(mockedBCHAddress)
     prisma.address.upsert = prismaMock.address.upsert


### PR DESCRIPTION
Description:
Tough it sounds logical to always parse the address before upserting, I don't think this should be done on the `upsertAddress` service.

- Everywhere in the code where we call this function (which on master is actually only on `pages/api/address/transactions/sync/[address].ts:37`), we do it after parsing the address already.
- When implementing another feature that would use this service to upsert addresses before when creating a paybutton, I've found out that a lot of tests would fail, because now the addresses were being parsed everytime a paybutton was being created, even though that's not the desired behavior on the tests, because we don't use real addresses there. 
- The function is intended to upsert some address, so it really should do only that.

Of course addresses should be parsed before being upserted, but I think this should be done separately; or else we will end up doing it reduntantly, since every endpoint already calls a e.g. `parse[...]POSTRequest` that will do this type of parsing.

Test plan:
Nothing should change.