### PR TITLE
[Issue #380] fix: confirmed transactions being upserted as unconfirmed

### DIFF
--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -184,7 +184,7 @@ export async function syncTransactionsForAddress (addressString: string): Promis
     newTransactionsCount = nextConfirmedTransactions.length // Unconfirmed transactions are NOT taken into account when skipping with nbSkip
     seenTransactionsCount += newTransactionsCount
 
-    let newInsertedTransactions = await upsertManyTransactionsForAddress(nextConfirmedTransactions, address)
+    let newInsertedTransactions = await upsertManyTransactionsForAddress(nextConfirmedTransactions, address, true)
     newInsertedTransactions = [
       ...newInsertedTransactions,
       ...(await upsertManyTransactionsForAddress(nextUnconfirmedTransactions, address, false))


### PR DESCRIPTION
Description:
Solves #380.

Test plan:
After spinning up the containers, add some address (with transactions) using the frontend or `curl http://localhost:3000/address/transactions/sync/[address]`, open the db container with `yarn docker db` and see if the added transactions are there with `confirmed=1` with `select * from Transactions;`