### PR TITLE
chore: allow dynamic dev WEBSITE_DOMAIN

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,7 +18,7 @@ const {
     const base_url = process.env.BASE_URL || 'paybutton.io'
     const env = {
       APP_URL: (() => {
-        if (isDev) return 'http://localhost:3000'
+        if (isDev) return process.env.WEBSITE_DOMAIN ?? 'http://localhost:3000'
         if (isProd) {
           return branch === 'master' ? `https://${base_url}` : `https://${branch.replaceAll('/', '-')}.${base_url}`
         }

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "custom-server-typescript",
   "version": "1.0.0",
   "scripts": {
-    "dev": "dotenv -e .env.development next dev",
+    "dev": "dotenv -e .env.development -c development next dev",
     "build": "next build && tsc --project tsconfig.json",
     "initJobs": "dotenv -e .env.development -e .env -c -- tsx jobs/initJobs.ts",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "prod": "npm run build && NODE_ENV=production pm2 start dist/index.js",
     "test": "dotenv -e .env.test -- ts-node -O '{\"module\":\"commonjs\"}' node_modules/jest/bin/jest.js",
     "pretest": "dotenv -e .env.test -- prisma migrate reset --force",
-    "prisma": "dotenv -e .env.development -- prisma",
+    "prisma": "dotenv -e .env.development -c development -- prisma",
     "docker": "./scripts/docker-exec-shortcuts.sh",
     "ci:integration:test": "yarn pretest && dotenv -e .env.test -- ts-node -O '{\"module\":\"commonjs\"}' node_modules/jest/bin/jest.js tests/integration-tests --forceExit"
   },


### PR DESCRIPTION
**Description:**
I have a server which is much faster than the notebook from where I am currently working, but in order to use it remotely is necessary to change some environment variables.

For me not to be forced to keep unstaged changes, I can change this env variables by putting them on `.env.development.local`, which is `.gitignore`d.

This PR makes so that `.env.development` is actually taken into account.

**Test plan:**
Nothing should change on running it locally.