### PR TITLE
[Issue #154] feat: allow for wallet creation to override paybutton wallet belongingness

### DIFF
--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -23,9 +23,10 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
   const [isXECDefaultDisabled, setIsXECDefaultDisabled] = useState(true)
   const [isBCHDefaultDisabled, setIsBCHDefaultDisabled] = useState(true)
   const [error, setError] = useState('')
-  const [selectedPaybuttonIdList, setSelectedPaybuttonIdList] = useState([] as string[])
+  const [selectedPaybuttonIdList, setSelectedPaybuttonIdList] = useState([] as number[])
 
   async function onSubmit (params: WalletPATCHParameters): Promise<void> {
+    params.paybuttonIdList = selectedPaybuttonIdList
     if (params.name === '' || params.name === undefined) {
       params.name = wallet.name
     }
@@ -38,7 +39,7 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
     }
   }
 
-  function handleSelectedPaybuttonsChange (checked: boolean, paybuttonId: string): void {
+  function handleSelectedPaybuttonsChange (checked: boolean, paybuttonId: number): void {
     if (selectedPaybuttonIdList.includes(paybuttonId) && !checked) {
       setSelectedPaybuttonIdList(
         selectedPaybuttonIdList.filter(id => id !== paybuttonId)
@@ -55,7 +56,7 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
     let ret = false
     if (selectedPaybuttonIdList === undefined) return false
     for (const selectedPaybuttonId of selectedPaybuttonIdList) {
-      const paybutton = userPaybuttons.find((pb) => pb.id === Number(selectedPaybuttonId))
+      const paybutton = userPaybuttons.find((pb) => pb.id === selectedPaybuttonId)
       if (paybutton === undefined) {
         continue
       }
@@ -125,7 +126,7 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
                   <div className={style.buttonlist_ctn}>
                     {userPaybuttons.map((pb, index) => (
                       <div className={style.input_field} key={`edit-pb-${pb.id}`}>
-                        <input {...register('paybuttonIdList')}
+                        <input
                           type='checkbox'
                           value={pb.id}
                           id={`paybuttonIdList.${index}`}

--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -130,12 +130,6 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
                           value={pb.id}
                           id={`paybuttonIdList.${index}`}
                           defaultChecked={pb.walletId === wallet.id}
-                          disabled={
-                            (pb.walletId !== null && pb.walletId !== wallet.id) ||
-                            pb.addresses.map((addr) => addr.address.walletId).some((walletId) =>
-                              walletId !== null && walletId !== wallet.id
-                            )
-                          }
                           onChange={ (e) => handleSelectedPaybuttonsChange(e.target.checked, pb.id) }
                         />
                         <label htmlFor={`paybuttonIdList.${index}`}>{pb.name}</label>

--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -23,10 +23,9 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
   const [isXECDefaultDisabled, setIsXECDefaultDisabled] = useState(true)
   const [isBCHDefaultDisabled, setIsBCHDefaultDisabled] = useState(true)
   const [error, setError] = useState('')
-  const [selectedPaybuttonIdList, setSelectedPaybuttonIdList] = useState([] as number[])
+  const [selectedPaybuttonIdList, setSelectedPaybuttonIdList] = useState([] as string[])
 
   async function onSubmit (params: WalletPATCHParameters): Promise<void> {
-    params.paybuttonIdList = selectedPaybuttonIdList
     if (params.name === '' || params.name === undefined) {
       params.name = wallet.name
     }
@@ -39,7 +38,7 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
     }
   }
 
-  function handleSelectedPaybuttonsChange (checked: boolean, paybuttonId: number): void {
+  function handleSelectedPaybuttonsChange (checked: boolean, paybuttonId: string): void {
     if (selectedPaybuttonIdList.includes(paybuttonId) && !checked) {
       setSelectedPaybuttonIdList(
         selectedPaybuttonIdList.filter(id => id !== paybuttonId)
@@ -56,7 +55,7 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
     let ret = false
     if (selectedPaybuttonIdList === undefined) return false
     for (const selectedPaybuttonId of selectedPaybuttonIdList) {
-      const paybutton = userPaybuttons.find((pb) => pb.id === selectedPaybuttonId)
+      const paybutton = userPaybuttons.find((pb) => pb.id === Number(selectedPaybuttonId))
       if (paybutton === undefined) {
         continue
       }
@@ -126,11 +125,17 @@ export default function EditWalletForm ({ wallet, userPaybuttons, refreshWalletL
                   <div className={style.buttonlist_ctn}>
                     {userPaybuttons.map((pb, index) => (
                       <div className={style.input_field} key={`edit-pb-${pb.id}`}>
-                        <input
+                        <input {...register('paybuttonIdList')}
                           type='checkbox'
                           value={pb.id}
                           id={`paybuttonIdList.${index}`}
                           defaultChecked={pb.walletId === wallet.id}
+                          disabled={
+                            (pb.walletId !== null && pb.walletId !== wallet.id) ||
+                            pb.addresses.map((addr) => addr.address.walletId).some((walletId) =>
+                              walletId !== null && walletId !== wallet.id
+                            )
+                          }
                           onChange={ (e) => handleSelectedPaybuttonsChange(e.target.checked, pb.id) }
                         />
                         <label htmlFor={`paybuttonIdList.${index}`}>{pb.name}</label>

--- a/components/Wallet/WalletForm.tsx
+++ b/components/Wallet/WalletForm.tsx
@@ -22,10 +22,11 @@ export default function WalletForm ({ userPaybuttons, refreshWalletList, userId 
   const [isXECDefaultDisabled, setIsXECDefaultDisabled] = useState(true)
   const [isBCHDefaultDisabled, setIsBCHDefaultDisabled] = useState(true)
   const [error, setError] = useState('')
-  const [selectedPaybuttonIdList, setSelectedPaybuttonIdList] = useState([] as string[])
+  const [selectedPaybuttonIdList, setSelectedPaybuttonIdList] = useState([] as number[])
 
   async function onSubmit (params: WalletPOSTParameters): Promise<void> {
     params.userId = userId
+    params.paybuttonIdList = selectedPaybuttonIdList
     try {
       void await axios.post(`${appInfo.websiteDomain}/api/wallet`, params)
       refreshWalletList()
@@ -35,7 +36,7 @@ export default function WalletForm ({ userPaybuttons, refreshWalletList, userId 
     }
   }
 
-  function handleSelectedPaybuttonsChange(checked: boolean, paybuttonId: string): void {
+  function handleSelectedPaybuttonsChange(checked: boolean, paybuttonId: number): void {
     if (selectedPaybuttonIdList.includes(paybuttonId) && checked === false) {
       setSelectedPaybuttonIdList(
         selectedPaybuttonIdList.filter(id => id !== paybuttonId)
@@ -52,7 +53,7 @@ export default function WalletForm ({ userPaybuttons, refreshWalletList, userId 
     let ret = false
     if (selectedPaybuttonIdList === undefined) return false
     for (const selectedPaybuttonId of selectedPaybuttonIdList) {
-      let paybutton = userPaybuttons.find((pb) => pb.id === Number(selectedPaybuttonId))
+      let paybutton = userPaybuttons.find((pb) => pb.id === selectedPaybuttonId)
       if (
         paybutton !== undefined
         && paybutton.addresses.some((addr) => addr.address.networkId === networkId)
@@ -120,7 +121,7 @@ export default function WalletForm ({ userPaybuttons, refreshWalletList, userId 
                   <div className={style.buttonlist_ctn}>
                     {userPaybuttons.map((pb, index) => (
                       <div className={style.input_field} key={`create-pb-${pb.id}`}>
-                        <input {...register('paybuttonIdList')}
+                        <input
                           type='checkbox'
                           value={pb.id}
                           id={`paybuttonIdList.${index}`}

--- a/components/Wallet/WalletForm.tsx
+++ b/components/Wallet/WalletForm.tsx
@@ -124,11 +124,7 @@ export default function WalletForm ({ userPaybuttons, refreshWalletList, userId 
                           type='checkbox'
                           value={pb.id}
                           id={`paybuttonIdList.${index}`}
-                          disabled={
-                            pb.walletId !== null
-                            || pb.addresses.map((addr) => addr.address.walletId).some((id) => id !== null)
-                          }
-                         onChange={ (e) => handleSelectedPaybuttonsChange(e.target.checked, pb.id) }
+                          onChange={ (e) => handleSelectedPaybuttonsChange(e.target.checked, pb.id) }
                         />
                         <label htmlFor={`paybuttonIdList.${index}`}>{pb.name}</label>
                       </div>

--- a/components/Wallet/WalletForm.tsx
+++ b/components/Wallet/WalletForm.tsx
@@ -37,12 +37,13 @@ export default function WalletForm ({ userPaybuttons, refreshWalletList, userId 
   }
 
   function handleSelectedPaybuttonsChange(checked: boolean, paybuttonId: number): void {
-    if (selectedPaybuttonIdList.includes(paybuttonId) && checked === false) {
+    const paybuttonIsSelected = selectedPaybuttonIdList.includes(paybuttonId)
+    if (paybuttonIsSelected && checked === false) {
       setSelectedPaybuttonIdList(
         selectedPaybuttonIdList.filter(id => id !== paybuttonId)
       )
     }
-    if (!selectedPaybuttonIdList.includes(paybuttonId) && checked === true) {
+    if (!paybuttonIsSelected && checked === true) {
       setSelectedPaybuttonIdList(
         [...selectedPaybuttonIdList, paybuttonId]
       )

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -11,7 +11,7 @@ export const RESPONSE_MESSAGES = {
   PAYBUTTON_NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Button name already exists.' },
   WALLET_NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Wallet name already exists.' },
   ADDRESSES_NOT_PROVIDED_400: { statusCode: 400, message: "'addresses' not provided." },
-  BUTTON_IDS_NOT_PROVIDED_400: { statusCode: 400, message: "'paybuttonIdList' not provided." },
+  BUTTON_IDS_NOT_PROVIDED_400: { statusCode: 400, message: 'Paybuttons were not provided.' },
   TRANSACTION_ID_NOT_PROVIDED_400: { statusCode: 400, message: "'transactionId' not provided." },
   INVALID_NETWORK_SLUG_400: { statusCode: 400, message: 'Invalid network slug.' },
   INVALID_NETWORK_ID_400: { statusCode: 400, message: 'Invalid network id.' },

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -7,7 +7,7 @@ import Session from 'supertokens-node/recipe/session'
 import { GetServerSideProps } from 'next'
 import WalletCard from 'components/Wallet/WalletCard'
 import WalletForm from 'components/Wallet/WalletForm'
-import { WalletWithAddressesAndPaybuttons, WalletPaymentInfo } from 'services/walletService'
+import { WalletWithPaymentInfo } from 'services/walletService'
 import { PaybuttonWithAddresses } from 'services/paybuttonService'
 
 const ThirdPartyEmailPasswordAuthNoSSR = dynamic(
@@ -43,7 +43,7 @@ interface WalletsProps {
 }
 
 interface WalletsState {
-  walletsWithPaymentInfo: [{wallet: WalletWithAddressesAndPaybuttons, paymentInfo: WalletPaymentInfo}]
+  walletsWithPaymentInfo: WalletWithPaymentInfo[]
   userPaybuttons: PaybuttonWithAddresses[]
 }
 

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -109,15 +109,6 @@ export async function setPaybuttonListForWallet (
   const updatedWalletPaybuttonList = []
   // add paybuttons from list
   for (const paybutton of paybuttonList) {
-    // enforce that added paybuttons & addresses don't already belong to a wallet
-    if (paybutton.walletId !== null && paybutton.walletId !== wallet.id) {
-      throw new Error(RESPONSE_MESSAGES.PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400.message)
-    }
-    for (const connector of paybutton.addresses) {
-      if (connector.address.walletId !== null && connector.address.walletId !== wallet.id) {
-        throw new Error(RESPONSE_MESSAGES.ADDRESS_ALREADY_BELONGS_TO_WALLET_400.message)
-      }
-    }
     // enforce that wallet & paybutton have the same user provider
     if (paybutton.providerUserId !== wallet.providerUserId) {
       throw new Error(RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400.message)
@@ -329,14 +320,6 @@ export async function updateWallet (walletId: number, params: UpdateWalletInput)
     if (pb.providerUserId !== params.userId) {
       throw new Error(RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400.message)
     }
-    if (pb.walletId !== null && pb.walletId !== walletId) {
-      throw new Error(RESPONSE_MESSAGES.PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400.message)
-    }
-    pb.addresses.forEach((conn) => {
-      if (conn.address.walletId !== null && conn.address.walletId !== walletId) {
-        throw new Error(RESPONSE_MESSAGES.ADDRESS_ALREADY_BELONGS_TO_WALLET_400.message)
-      }
-    })
   })
 
   const defaultForNetworkIds = getDefaultForNetworkIds(params.isXECDefault, params.isBCHDefault)

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -347,6 +347,11 @@ export interface WalletPaymentInfo {
   paymentCount: number
 }
 
+export interface WalletWithPaymentInfo {
+  wallet: WalletWithAddressesAndPaybuttons
+  paymentInfo: WalletPaymentInfo
+}
+
 export async function getWalletBalance (wallet: WalletWithAddressesAndPaybuttons): Promise<WalletPaymentInfo> {
   const ret: WalletPaymentInfo = {
     XECBalance: new Prisma.Decimal(0),

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -468,7 +468,7 @@ describe('POST /api/wallets/', () => {
     expect(responseData.message).toBe(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message)
   })
 
-  it('Succed with paybutton that already belongs to other wallet', async () => {
+  it('Succeed with paybutton that already belongs to other wallet', async () => {
     baseRequestOptions.body = {
       userId: 'test-u-id',
       name: 'test-wallet3',
@@ -494,7 +494,7 @@ describe('POST /api/wallets/', () => {
     )
   })
 
-  it('Succed with address that already belongs to other wallet', async () => {
+  it('Succeed with address that already belongs to other wallet', async () => {
     baseRequestOptions.body = {
       userId: 'test-u-id',
       name: 'test-wallet4',

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -468,30 +468,56 @@ describe('POST /api/wallets/', () => {
     expect(responseData.message).toBe(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message)
   })
 
-  it('Fail with paybutton that already belongs to other wallet', async () => {
+  it('Succed with paybutton that already belongs to other wallet', async () => {
     baseRequestOptions.body = {
       userId: 'test-u-id',
-      name: 'test-wallet2',
+      name: 'test-wallet3',
       paybuttonIdList: [buttonIds[0]]
 
     }
     const res = await testEndpoint(baseRequestOptions, walletEndpoint)
     const responseData = res._getJSONData()
-    expect(res.statusCode).toBe(400)
-    expect(responseData.message).toBe(RESPONSE_MESSAGES.PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400.message)
+    expect(res.statusCode).toBe(200)
+    expect(responseData.providerUserId).toBe('test-u-id')
+    expect(responseData.name).toBe('test-wallet3')
+    expect(responseData.userProfile).toStrictEqual({
+      isXECDefault: null,
+      isBCHDefault: null,
+      userProfileId: 3
+    })
+    expect(responseData.paybuttons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          walletId: responseData.id
+        })
+      ])
+    )
   })
 
-  it('Fail with address that already belongs to other wallet', async () => {
+  it('Succed with address that already belongs to other wallet', async () => {
     baseRequestOptions.body = {
       userId: 'test-u-id',
-      name: 'test-wallet2',
+      name: 'test-wallet4',
       paybuttonIdList: [buttonIds[2]]
 
     }
     const res = await testEndpoint(baseRequestOptions, walletEndpoint)
     const responseData = res._getJSONData()
-    expect(res.statusCode).toBe(400)
-    expect(responseData.message).toBe(RESPONSE_MESSAGES.ADDRESS_ALREADY_BELONGS_TO_WALLET_400.message)
+    expect(res.statusCode).toBe(200)
+    expect(responseData.providerUserId).toBe('test-u-id')
+    expect(responseData.name).toBe('test-wallet4')
+    expect(responseData.userProfile).toStrictEqual({
+      isXECDefault: null,
+      isBCHDefault: null,
+      userProfileId: 3
+    })
+    expect(responseData.paybuttons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          walletId: responseData.id
+        })
+      ])
+    )
   })
 })
 

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -244,23 +244,18 @@ describe.only('Set wallet paybuttons', () => {
     )
     expect(result).toEqual(mockedWallet)
   })
-  it('Fail for paybutton that already belongs to other wallet', async () => {
-    expect.assertions(1)
-    try {
-      await walletService.setPaybuttonListForWallet(
-        prismaMock,
-        [{
-          ...mockedPaybutton,
-          walletId: 999
-        }],
-        mockedWallet
-      )
-    } catch (e: any) {
-      expect(e.message).toMatch(RESPONSE_MESSAGES.PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400.message)
-    }
+  it('Update paybutton that already belongs to other wallet', async () => {
+    const result = await walletService.setPaybuttonListForWallet(
+      prismaMock,
+      [{
+        ...mockedPaybutton,
+        walletId: 999
+      }],
+      mockedWallet
+    )
+    expect(result).toEqual(mockedWallet)
   })
-  it('Fail for paybutton with address that already belongs to other wallet', async () => {
-    expect.assertions(1)
+  it('Update for paybutton with address that already belongs to other wallet', async () => {
     const newPaybuttonAddressesList = [
       {
         address: {
@@ -272,19 +267,15 @@ describe.only('Set wallet paybuttons', () => {
         address: mockedPaybutton.addresses[1].address
       }
     ]
-
-    try {
-      await walletService.setPaybuttonListForWallet(
-        prismaMock,
-        [{
-          ...mockedPaybutton,
-          addresses: newPaybuttonAddressesList
-        }],
-        mockedWallet
-      )
-    } catch (e: any) {
-      expect(e.message).toMatch(RESPONSE_MESSAGES.ADDRESS_ALREADY_BELONGS_TO_WALLET_400.message)
-    }
+    const result = await walletService.setPaybuttonListForWallet(
+      prismaMock,
+      [{
+        ...mockedPaybutton,
+        addresses: newPaybuttonAddressesList
+      }],
+      mockedWallet
+    )
+    expect(result).toEqual(mockedWallet)
   })
   it('Fail for paybutton of different user than wallet', async () => {
     expect.assertions(1)

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -99,28 +99,18 @@ describe('Create services', () => {
     expect(result).toEqual(mockedWallet)
   })
 
-  it('Should failed for already binded paybutton', async () => {
+  it('Should succeed for already binded paybutton', async () => {
     data.paybuttons[0].walletId = 1729
-    expect.assertions(1)
-    try {
-      await walletService.createWallet(data.createWalletInput)
-    } catch (e: any) {
-      expect(e.message).toMatch(RESPONSE_MESSAGES.PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400.message)
-    } finally {
-      data.paybuttons[0].walletId = null
-    }
+    const result = await walletService.createWallet(data.createWalletInput)
+    expect(result).toEqual(mockedWallet)
+    data.paybuttons[0].walletId = null
   })
 
-  it('Should failed for already binded address', async () => {
+  it('Should succeed for already binded address', async () => {
     data.address.walletId = 1729
-    expect.assertions(1)
-    try {
-      await walletService.createWallet(data.createWalletInput)
-    } catch (e: any) {
-      expect(e.message).toMatch(RESPONSE_MESSAGES.ADDRESS_ALREADY_BELONGS_TO_WALLET_400.message)
-    } finally {
-      data.address.walletId = null
-    }
+    const result = await walletService.createWallet(data.createWalletInput)
+    expect(result).toEqual(mockedWallet)
+    data.address.walletId = null
   })
 })
 
@@ -170,32 +160,23 @@ describe('Update services', () => {
     })
   })
 
-  it('Fail for paybutton that is already on another wallet', async () => {
+  it('Succeed for paybutton that is already on another wallet', async () => {
     const otherWalletButton = {
       ...mockedPaybutton,
       walletId: 2
     }
     prismaMock.paybutton.findMany.mockResolvedValue([otherWalletButton])
     prisma.paybutton.findMany = prismaMock.paybutton.findMany
-    expect.assertions(1)
-    try {
-      await walletService.updateWallet(mockedWallet.id, data.updateWalletInput)
-    } catch (e: any) {
-      expect(e.message).toMatch(RESPONSE_MESSAGES.PAYBUTTON_ALREADY_BELONGS_TO_WALLET_400.message)
-    }
+    const result = await walletService.updateWallet(mockedWallet.id, data.updateWalletInput)
+    expect(result).toEqual(mockedWallet)
   })
-  it('Fail for address that is already on another wallet', async () => {
+  it('Succeed for address that is already on another wallet', async () => {
     mockedPaybutton.addresses[0].address.walletId = 999
     prismaMock.paybutton.findMany.mockResolvedValue([mockedPaybutton])
     prisma.paybutton.findMany = prismaMock.paybutton.findMany
-    expect.assertions(1)
-    try {
-      await walletService.updateWallet(mockedWallet.id, data.updateWalletInput)
-    } catch (e: any) {
-      expect(e.message).toMatch(RESPONSE_MESSAGES.ADDRESS_ALREADY_BELONGS_TO_WALLET_400.message)
-    } finally {
-      mockedPaybutton.addresses[0].address.walletId = 1
-    }
+    const result = await walletService.updateWallet(mockedWallet.id, data.updateWalletInput)
+    expect(result).toEqual(mockedWallet)
+    mockedPaybutton.addresses[0].address.walletId = 1
   })
   it('Fail if wallet does not exist', async () => {
     prismaMock.wallet.findUnique.mockResolvedValue(null)

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -124,7 +124,7 @@ export interface WalletPATCHParameters {
 export const parseWalletPOSTRequest = function (params: WalletPOSTParameters): CreateWalletInput {
   if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
-  if (params.paybuttonIdList === undefined) throw new Error(RESPONSE_MESSAGES.BUTTON_IDS_NOT_PROVIDED_400.message)
+  if (params.paybuttonIdList === undefined || params.paybuttonIdList.length === 0) throw new Error(RESPONSE_MESSAGES.BUTTON_IDS_NOT_PROVIDED_400.message)
   params.paybuttonIdList = params.paybuttonIdList.map((id: string | number) => Number(id))
   return {
     userId: params.userId,


### PR DESCRIPTION
**Description**:
Before, upon wallet creation, we would not allow a user to select paybuttons that already belonged to other wallets. Now this is possible, such that the selected paybuttons will be updated so that they belong to the new wallet.

Furthermore, users cannot "consume" other wallets by this process, i.e, create a new wallet that leaves some already existent wallet with no paybuttons.

**Test plan:**
Try to create a wallet, assure that is possible to override other wallets paybuttons', as long as they are left with at least one paybutton.

**Depends on:**
- [x] #386 
- [x] #389