### PR TITLE
[Issue #390] test: avoid .only statements on tests from being committed

### DIFF
--- a/.github/workflows/pull-request-lint-and-test.yml
+++ b/.github/workflows/pull-request-lint-and-test.yml
@@ -14,6 +14,8 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: yarn
+      - name: Check no tests are run with `.only`
+        run: make no-isolated-tests
       - name: Lint and check format
         run: make lint-master
       - name: Run unit tests

--- a/.github/workflows/pull-request-lint-and-test.yml
+++ b/.github/workflows/pull-request-lint-and-test.yml
@@ -12,10 +12,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Check no tests will be run with `.only`
+        run: make no-isolated-tests
       - name: Install dependencies
         run: yarn
-      - name: Check no tests are run with `.only`
-        run: make no-isolated-tests
       - name: Lint and check format
         run: make lint-master
       - name: Run unit tests

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ check-logs-users:
 lint:
 	yarn eslint .
 
+no-isolated-tests:
+	grep -rEq '(describe|it)\.only' tests/* && exit 1
+
 lint-master:
 	$(git_diff_to_master)
 	yarn eslint --stdin --stdin-filename DIFF

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 	yarn eslint .
 
 no-isolated-tests:
-	grep -rEq '(describe|it)\.only' tests/* && exit 1
+	grep -rEn '(describe|it)\.only' tests/* && exit 1 || echo No isolated tests.
 
 lint-master:
 	$(git_diff_to_master)

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -57,7 +57,7 @@ describe('POST /api/paybutton/', () => {
     }
   }
 
-  it('Create a paybutton with two addresses', async () => {
+  it.only('Create a paybutton with two addresses', async () => {
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)
     const responseData = res._getJSONData()
     expect(res.statusCode).toBe(200)

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -57,7 +57,7 @@ describe('POST /api/paybutton/', () => {
     }
   }
 
-  it.only('Create a paybutton with two addresses', async () => {
+  it('Create a paybutton with two addresses', async () => {
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)
     const responseData = res._getJSONData()
     expect(res.statusCode).toBe(200)

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -232,7 +232,7 @@ describe('Update services', () => {
   })
 })
 
-describe('Set wallet paybuttons', () => {
+describe.only('Set wallet paybuttons', () => {
   beforeEach(() => {
     prismaMockPaybuttonAndAddressUpdate()
   })

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -232,7 +232,7 @@ describe('Update services', () => {
   })
 })
 
-describe.only('Set wallet paybuttons', () => {
+describe('Set wallet paybuttons', () => {
   beforeEach(() => {
     prismaMockPaybuttonAndAddressUpdate()
   })


### PR DESCRIPTION
**Description:**
Solves #390.
There was a `describe.only` on the code, that was mistakenly commited by me on January. This would make so that most of the `walletService` tests didn't run.

I've removed it & made so that the unittests git action also checks for `describe.only`s and `it.only`s across the tests folder, failing the action in case they're found.

**Test plan:**
Can only be tested by pushing a branch which contains such `.only` statements to github, [here](https://github.com/PayButton/paybutton-server/actions/runs/4133291387/jobs/7143017250) is an example of me testing it before.