### PR TITLE
refactor: rename interfaces to uppercase

### DIFF
--- a/components/Paybutton/EditButtonForm.tsx
+++ b/components/Paybutton/EditButtonForm.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { PaybuttonWithAddresses } from 'services/paybuttonService'
 import { useForm } from 'react-hook-form'
-import { paybuttonPOSTParameters, paybuttonPATCHParameters } from 'utils/validators'
+import { PaybuttonPOSTParameters, PaybuttonPATCHParameters } from 'utils/validators'
 import Image from 'next/image'
 import style from '../Paybutton/paybutton.module.css'
 import s from '../Wallet/wallet.module.css'
@@ -19,7 +19,7 @@ interface IProps {
 }
 
 export default function EditButtonForm ({ paybutton, error, onDelete, refreshPaybutton }: IProps): ReactElement {
-  const { register, handleSubmit, reset } = useForm<paybuttonPOSTParameters>()
+  const { register, handleSubmit, reset } = useForm<PaybuttonPOSTParameters>()
   const [modal, setModal] = useState(false)
   const [deleteModal, setDeleteModal] = useState(false)
 
@@ -28,7 +28,7 @@ export default function EditButtonForm ({ paybutton, error, onDelete, refreshPay
     reset()
   }, [paybutton])
 
-  async function onSubmit (params: paybuttonPATCHParameters): Promise<void> {
+  async function onSubmit (params: PaybuttonPATCHParameters): Promise<void> {
     if (params.name === '' || params.name === undefined) {
       params.name = paybutton.name
     }

--- a/components/Paybutton/PaybuttonForm.tsx
+++ b/components/Paybutton/PaybuttonForm.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
-import { paybuttonPOSTParameters } from 'utils/validators'
+import { PaybuttonPOSTParameters } from 'utils/validators'
 import Image from 'next/image'
 import style from './paybutton.module.css'
 import Plus from 'assets/plus.png'
@@ -12,7 +12,7 @@ interface IProps {
 }
 
 export default function PaybuttonForm ({ onSubmit, paybuttons, error }: IProps): ReactElement {
-  const { register, handleSubmit, reset } = useForm<paybuttonPOSTParameters>()
+  const { register, handleSubmit, reset } = useForm<PaybuttonPOSTParameters>()
   const [modal, setModal] = useState(false)
 
   useEffect(() => {

--- a/pages/buttons/index.tsx
+++ b/pages/buttons/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ThirdPartyEmailPassword from 'supertokens-auth-react/recipe/thirdpartyemailpassword'
 import { PaybuttonList, PaybuttonForm } from 'components/Paybutton'
 import { PaybuttonWithAddresses } from 'services/paybuttonService'
-import { paybuttonPOSTParameters } from 'utils/validators'
+import { PaybuttonPOSTParameters } from 'utils/validators'
 import dynamic from 'next/dynamic'
 import supertokensNode from 'supertokens-node'
 import * as SuperTokensConfig from '../../config/backendConfig'
@@ -76,7 +76,7 @@ class ProtectedPage extends React.Component<PaybuttonsProps, PaybuttonsState> {
     }
   }
 
-  async onSubmit (values: paybuttonPOSTParameters): Promise<void> {
+  async onSubmit (values: PaybuttonPOSTParameters): Promise<void> {
     const res = await fetch('/api/paybutton', {
       method: 'POST',
       headers: {

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -147,7 +147,7 @@ describe('parseButtonData', () => {
 })
 
 describe('parsePaybuttonPOSTRequest', () => {
-  const data: v.paybuttonPOSTParameters = {
+  const data: v.PaybuttonPOSTParameters = {
     userId: undefined,
     name: 'somename',
     buttonData: undefined,
@@ -183,7 +183,7 @@ describe('parsePaybuttonPOSTRequest', () => {
 })
 
 describe('parsePaybuttonPATCHRequest', () => {
-  const data: v.paybuttonPOSTParameters = {
+  const data: v.PaybuttonPOSTParameters = {
     name: 'somename',
     addresses: undefined
   }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -79,14 +79,14 @@ export const parseError = function (error: Error): Error {
   return error
 }
 
-export interface paybuttonPOSTParameters {
+export interface PaybuttonPOSTParameters {
   userId?: string
   name?: string
   buttonData?: string
   addresses?: string
 }
 
-export const parsePaybuttonPOSTRequest = function (params: paybuttonPOSTParameters): CreatePaybuttonInput {
+export const parsePaybuttonPOSTRequest = function (params: PaybuttonPOSTParameters): CreatePaybuttonInput {
   if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
   if (params.addresses === '' || params.addresses === undefined) throw new Error(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)


### PR DESCRIPTION
Description:
Interfaces should have uppercase names, this refactor simply renames `paybuttonPOSTParameters` -> `PaybuttonPOSTParameters` and `paybuttonPATCHParameters` -> `PaybuttonPATCHParameters`.

Test plan:
N/A