### PR TITLE
[Issue #395] feat: remodel address to wallet on wallet creation dependencies

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -12,6 +12,7 @@ export const RESPONSE_MESSAGES = {
   WALLET_NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Wallet name already exists.' },
   ADDRESSES_NOT_PROVIDED_400: { statusCode: 400, message: "'addresses' not provided." },
   BUTTON_IDS_NOT_PROVIDED_400: { statusCode: 400, message: 'Paybuttons were not provided.' },
+  ADDRESS_IDS_NOT_PROVIDED_400: { statusCode: 400, message: 'Addresses were not provided.' },
   TRANSACTION_ID_NOT_PROVIDED_400: { statusCode: 400, message: "'transactionId' not provided." },
   INVALID_NETWORK_SLUG_400: { statusCode: 400, message: 'Invalid network slug.' },
   INVALID_NETWORK_ID_400: { statusCode: 400, message: 'Invalid network id.' },

--- a/pages/api/addresses/index.ts
+++ b/pages/api/addresses/index.ts
@@ -1,0 +1,27 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import * as addressService from 'services/addressService'
+import { RESPONSE_MESSAGES } from 'constants/index'
+
+export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+  if (req.method === 'GET') {
+    const query = req.query
+    const userId: string | string[] | undefined = query.userId
+    try {
+      if (userId === '' || userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
+      if (Array.isArray(userId)) throw new Error(RESPONSE_MESSAGES.MULTIPLE_USER_IDS_PROVIDED_400.message)
+      const addressList = await addressService.fetchAllUserAddresses(userId)
+      res.status(200).json(addressList)
+    } catch (err: any) {
+      switch (err.message) {
+        case RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400)
+          break
+        case RESPONSE_MESSAGES.MULTIPLE_USER_IDS_PROVIDED_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.MULTIPLE_USER_IDS_PROVIDED_400)
+          break
+        default:
+          res.status(500).json({ statusCode: 500, message: err.message })
+      }
+    }
+  }
+}


### PR DESCRIPTION
Description:
Some changes required by #396. Basically:
- API endpoint to fetch all of some user addresses & tests for it,
- A error message constant to say that the user has not selected any address

Test plan:
`curl http://localhost:3000/addresses?userId='dev-uid'`  should return all addresses of the main dev user.