### PR TITLE
[Issue #395] feat: show addresses paybuttons on wallet creation

### DIFF
--- a/components/Wallet/WalletForm.tsx
+++ b/components/Wallet/WalletForm.tsx
@@ -156,7 +156,7 @@ export default function WalletForm ({ userAddresses, refreshWalletList, userId }
                     name='name'
                   />
 
-                  <h4>Addresses</h4>
+                  <h4>Select Buttons</h4>
                   <div className={style.buttonlist_ctn}>
                     {userAddresses.map((addr, index) => (
                       <div className={style.input_field} key={`create-addr-${addr.id}`}>
@@ -170,10 +170,10 @@ export default function WalletForm ({ userAddresses, refreshWalletList, userId }
                           onChange={ (e) => handleSelectedAddressesChange(e.target.checked, addr.id) }
                         />
                         <label htmlFor={`addressIdList.${index}`}>
-                            <b>{addr.address}</b>
                           {addr.paybuttons.map((conn) => (
-                            <div>{conn.paybutton.name}</div>
+                            <div className={style.buttonpill}>{conn.paybutton.name}</div>
                           ))}
+                          <div className={style.addresslabel}>{addr.address}</div>
                         </label>
                       </div>
                     ))}

--- a/components/Wallet/WalletForm.tsx
+++ b/components/Wallet/WalletForm.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { WalletPOSTParameters } from 'utils/validators'
-import { PaybuttonWithAddresses } from 'services/paybuttonService'
+import { Address } from '@prisma/client'
 import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 import Image from 'next/image'
 import style from '../Wallet/wallet.module.css'
@@ -11,23 +11,23 @@ import axios from 'axios'
 import { appInfo } from 'config/appInfo'
 
 interface IProps {
-  userPaybuttons: PaybuttonWithAddresses[]
+  userAddresses: Address[]
   refreshWalletList: Function
   userId: string
 }
 
-export default function WalletForm ({ userPaybuttons, refreshWalletList, userId }: IProps): ReactElement {
+export default function WalletForm ({ userAddresses, refreshWalletList, userId }: IProps): ReactElement {
   const { register, handleSubmit, reset } = useForm<WalletPOSTParameters>()
   const [modal, setModal] = useState(false)
   const [isXECDefaultDisabled, setIsXECDefaultDisabled] = useState(true)
   const [isBCHDefaultDisabled, setIsBCHDefaultDisabled] = useState(true)
   const [error, setError] = useState('')
-  const [selectedPaybuttonIdList, setSelectedPaybuttonIdList] = useState([] as number[])
-  const [disabledPaybuttonList, setDisabledPaybuttonList] = useState([] as PaybuttonWithAddresses[])
+  const [selectedAddressIdList, setSelectedAddressIdList] = useState([] as number[])
+  const [disabledAddressList, setDisabledAddressList] = useState([] as Address[])
 
   async function onSubmit (params: WalletPOSTParameters): Promise<void> {
     params.userId = userId
-    params.paybuttonIdList = selectedPaybuttonIdList
+    params.addressIdList = selectedAddressIdList
     try {
       void await axios.post(`${appInfo.websiteDomain}/api/wallet`, params)
       refreshWalletList()
@@ -37,58 +37,58 @@ export default function WalletForm ({ userPaybuttons, refreshWalletList, userId 
     }
   }
 
-  const disableLastWalletPaybuttons = (): void => {
-    let disabledPaybuttons = [] as PaybuttonWithAddresses[]
-    for (const paybutton of userPaybuttons) {
+  const disableLastWalletAddresses = (): void => {
+    let disabledAddresses = [] as Address[]
+    for (const address of userAddresses) {
 
-      const paybuttonHasWallet = paybutton.walletId !== undefined && paybutton.walletId !== null
-      if (paybuttonHasWallet) {
+      const addressHasWallet = address.walletId !== undefined && address.walletId !== null
+      if (addressHasWallet) {
 
-        const paybuttonIsSelected = selectedPaybuttonIdList.includes(paybutton.id)
-        if (!paybuttonIsSelected) {
+        const addressIsSelected = selectedAddressIdList.includes(address.id)
+        if (!addressIsSelected) {
 
-          const otherPaybuttonsOfSameWalletRemaining = userPaybuttons.filter(otherPb => {
-            const otherPaybuttonIsSelected = selectedPaybuttonIdList.includes(otherPb.id)
+          const otherAddressesOfSameWalletRemaining = userAddresses.filter(otherAddr => {
+            const otherAddressIsSelected = selectedAddressIdList.includes(otherAddr.id)
             return (
-              otherPb.walletId === paybutton.walletId
-              && otherPb.id !== paybutton.id
-              && !otherPaybuttonIsSelected
+              otherAddr.walletId === address.walletId
+              && otherAddr.id !== address.id
+              && !otherAddressIsSelected
             )
           })
 
-          if (otherPaybuttonsOfSameWalletRemaining.length === 0) {
-            disabledPaybuttons.push(paybutton)
+          if (otherAddressesOfSameWalletRemaining.length === 0) {
+            disabledAddresses.push(address)
           }
         }
       }
     }
-    setDisabledPaybuttonList(
-      disabledPaybuttons
+    setDisabledAddressList(
+      disabledAddresses
     )
   }
 
-  function handleSelectedPaybuttonsChange(checked: boolean, paybuttonId: number): void {
-    const paybuttonIsSelected = selectedPaybuttonIdList.includes(paybuttonId)
+  function handleSelectedAddressesChange(checked: boolean, addressId: number): void {
+    const paybuttonIsSelected = selectedAddressIdList.includes(addressId)
     if (paybuttonIsSelected && checked === false) {
-      setSelectedPaybuttonIdList(
-        selectedPaybuttonIdList.filter(id => id !== paybuttonId)
+      setSelectedAddressIdList(
+        selectedAddressIdList.filter(id => id !== addressId)
       )
     }
     if (!paybuttonIsSelected && checked === true) {
-      setSelectedPaybuttonIdList(
-        [...selectedPaybuttonIdList, paybuttonId]
+      setSelectedAddressIdList(
+        [...selectedAddressIdList, addressId]
       )
     }
   }
 
   function hasAddressForNetworkId(networkId: number): boolean {
     let ret = false
-    if (selectedPaybuttonIdList === undefined) return false
-    for (const selectedPaybuttonId of selectedPaybuttonIdList) {
-      let paybutton = userPaybuttons.find((pb) => pb.id === selectedPaybuttonId)
+    if (selectedAddressIdList === undefined) return false
+    for (const selectedAddressId of selectedAddressIdList) {
+      let address = userAddresses.find((addr) => addr.id === selectedAddressId)
       if (
-        paybutton !== undefined
-        && paybutton.addresses.some((addr) => addr.address.networkId === networkId)
+        address !== undefined
+        && address.networkId === networkId
       ) {
         ret = true
         break
@@ -117,17 +117,17 @@ export default function WalletForm ({ userPaybuttons, refreshWalletList, userId 
   }
   useEffect(() => {
     disableDefaultInputFields()
-    disableLastWalletPaybuttons()
-  }, [selectedPaybuttonIdList])
+    disableLastWalletAddresses()
+  }, [selectedAddressIdList])
 
   useEffect(() => {
     setModal(false)
     reset()
-  }, [userPaybuttons])
+  }, [userAddresses])
 
   useEffect(() => {
-    setSelectedPaybuttonIdList([])
-    disableLastWalletPaybuttons()
+    setSelectedAddressIdList([])
+    disableLastWalletAddresses()
   }, [modal])
 
   return (
@@ -155,20 +155,20 @@ export default function WalletForm ({ userPaybuttons, refreshWalletList, userId 
                     name='name'
                   />
 
-                  <h4>Paybuttons</h4>
+                  <h4>Addresses</h4>
                   <div className={style.buttonlist_ctn}>
-                    {userPaybuttons.map((pb, index) => (
-                      <div className={style.input_field} key={`create-pb-${pb.id}`}>
+                    {userAddresses.map((addr, index) => (
+                      <div className={style.input_field} key={`create-addr-${addr.id}`}>
                         <input
                           type='checkbox'
-                          value={pb.id}
-                          id={`paybuttonIdList.${index}`}
+                          value={addr.id}
+                          id={`addressIdList.${index}`}
                           disabled={
-                            disabledPaybuttonList.map(pb => pb.id).includes(pb.id)
+                            disabledAddressList.map(addr => addr.id).includes(addr.id)
                           }
-                          onChange={ (e) => handleSelectedPaybuttonsChange(e.target.checked, pb.id) }
+                          onChange={ (e) => handleSelectedAddressesChange(e.target.checked, addr.id) }
                         />
-                        <label htmlFor={`paybuttonIdList.${index}`}>{pb.name}</label>
+                        <label htmlFor={`addressIdList.${index}`}>{addr.address}</label>
                       </div>
                     ))}
                   </div>

--- a/components/Wallet/WalletForm.tsx
+++ b/components/Wallet/WalletForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { WalletPOSTParameters } from 'utils/validators'
+import { AddressWithPaybuttons } from 'services/addressService'
 import { Address } from '@prisma/client'
 import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 import Image from 'next/image'
@@ -11,7 +12,7 @@ import axios from 'axios'
 import { appInfo } from 'config/appInfo'
 
 interface IProps {
-  userAddresses: Address[]
+  userAddresses: AddressWithPaybuttons[]
   refreshWalletList: Function
   userId: string
 }
@@ -145,7 +146,7 @@ export default function WalletForm ({ userAddresses, refreshWalletList, userId }
             <div className={style_pb.form_ctn_inner}>
               <h4>Create New Wallet</h4>
               <div className={style_pb.form_ctn}>
-                <p>Wallets must have a unique name and contain at least one button. Each button can only be linked to one wallet at a time.</p>
+                <p>Wallets must have a unique name and contain at least one address. Each address can only be linked to one wallet at a time.</p>
                 <form onSubmit={handleSubmit(onSubmit)} method='post'>
                   <label htmlFor='name'>Wallet Name</label>
                   <input
@@ -168,7 +169,12 @@ export default function WalletForm ({ userAddresses, refreshWalletList, userId }
                           }
                           onChange={ (e) => handleSelectedAddressesChange(e.target.checked, addr.id) }
                         />
-                        <label htmlFor={`addressIdList.${index}`}>{addr.address}</label>
+                        <label htmlFor={`addressIdList.${index}`}>
+                            <b>{addr.address}</b>
+                          {addr.paybuttons.map((conn) => (
+                            <div>{conn.paybutton.name}</div>
+                          ))}
+                        </label>
                       </div>
                     ))}
                   </div>

--- a/components/Wallet/wallet.module.css
+++ b/components/Wallet/wallet.module.css
@@ -134,11 +134,35 @@
 .input_field {
   display: flex;
   align-items: center;
+  margin-bottom: 10px;
 }
 
 .input_field input[disabled] + label {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+body .input_field input {
+  align-self: flex-start;
+  margin-top: 4px !important;
+}
+
+.buttonpill {
+  background-color: var(--primary-bg-color);
+  padding: 2px 20px;
+  margin-right: 5px;
+  border-radius: 100px;
+  display: inline-block;
+  font-size: 14px;
+  word-break: keep-all;
+  box-sizing: border-box;
+  transition: all ease-in-out 200ms;
+  margin-bottom: 5px;
+}
+
+.addresslabel {
+  font-size: 12px;
+  margin-left: 5px;
 }
 
 .makedefault_ctn label,

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -12,6 +12,7 @@ export const RESPONSE_MESSAGES = {
   WALLET_NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Wallet name already exists.' },
   ADDRESSES_NOT_PROVIDED_400: { statusCode: 400, message: "'addresses' not provided." },
   BUTTON_IDS_NOT_PROVIDED_400: { statusCode: 400, message: 'Paybuttons were not provided.' },
+  ADDRESS_IDS_NOT_PROVIDED_400: { statusCode: 400, message: 'Addresses were not provided.' },
   TRANSACTION_ID_NOT_PROVIDED_400: { statusCode: 400, message: "'transactionId' not provided." },
   INVALID_NETWORK_SLUG_400: { statusCode: 400, message: 'Invalid network slug.' },
   INVALID_NETWORK_ID_400: { statusCode: 400, message: 'Invalid network id.' },

--- a/pages/api/addresses/index.ts
+++ b/pages/api/addresses/index.ts
@@ -6,10 +6,11 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
   if (req.method === 'GET') {
     const query = req.query
     const userId: string | string[] | undefined = query.userId
+    const includePaybuttons = req.query.includePaybuttons === '1'
     try {
       if (userId === '' || userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
       if (Array.isArray(userId)) throw new Error(RESPONSE_MESSAGES.MULTIPLE_USER_IDS_PROVIDED_400.message)
-      const addressList = await addressService.fetchAllUserAddresses(userId)
+      const addressList = await addressService.fetchAllUserAddresses(userId, false, includePaybuttons)
       res.status(200).json(addressList)
     } catch (err: any) {
       switch (err.message) {

--- a/pages/api/addresses/index.ts
+++ b/pages/api/addresses/index.ts
@@ -1,0 +1,27 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import * as addressService from 'services/addressService'
+import { RESPONSE_MESSAGES } from 'constants/index'
+
+export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+  if (req.method === 'GET') {
+    const query = req.query
+    const userId: string | string[] | undefined = query.userId
+    try {
+      if (userId === '' || userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
+      if (Array.isArray(userId)) throw new Error(RESPONSE_MESSAGES.MULTIPLE_USER_IDS_PROVIDED_400.message)
+      const addressList = await addressService.fetchAllUserAddresses(userId)
+      res.status(200).json(addressList)
+    } catch (err: any) {
+      switch (err.message) {
+        case RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400)
+          break
+        case RESPONSE_MESSAGES.MULTIPLE_USER_IDS_PROVIDED_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.MULTIPLE_USER_IDS_PROVIDED_400)
+          break
+        default:
+          res.status(500).json({ statusCode: 500, message: err.message })
+      }
+    }
+  }
+}

--- a/pages/api/wallet/index.ts
+++ b/pages/api/wallet/index.ts
@@ -15,8 +15,8 @@ export default async (req: any, res: any): Promise<void> => {
         case RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message:
           res.status(400).json(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400)
           break
-        case RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message:
-          res.status(404).json(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404)
+        case RESPONSE_MESSAGES.NO_ADDRESS_FOUND_404.message:
+          res.status(404).json(RESPONSE_MESSAGES.NO_ADDRESS_FOUND_404)
           break
         case RESPONSE_MESSAGES.ADDRESS_ALREADY_BELONGS_TO_WALLET_400.message:
           res.status(400).json(RESPONSE_MESSAGES.ADDRESS_ALREADY_BELONGS_TO_WALLET_400)
@@ -30,8 +30,8 @@ export default async (req: any, res: any): Promise<void> => {
         case RESPONSE_MESSAGES.WALLET_NAME_ALREADY_EXISTS_400.message:
           res.status(400).json(RESPONSE_MESSAGES.WALLET_NAME_ALREADY_EXISTS_400)
           break
-        case RESPONSE_MESSAGES.BUTTON_IDS_NOT_PROVIDED_400.message:
-          res.status(400).json(RESPONSE_MESSAGES.BUTTON_IDS_NOT_PROVIDED_400)
+        case RESPONSE_MESSAGES.ADDRESS_IDS_NOT_PROVIDED_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.ADDRESS_IDS_NOT_PROVIDED_400)
           break
         case RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400.message:
           res.status(400).json(RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400)

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -9,6 +9,7 @@ import WalletCard from 'components/Wallet/WalletCard'
 import WalletForm from 'components/Wallet/WalletForm'
 import { WalletWithPaymentInfo } from 'services/walletService'
 import { PaybuttonWithAddresses } from 'services/paybuttonService'
+import { Address } from '@prisma/client'
 
 const ThirdPartyEmailPasswordAuthNoSSR = dynamic(
   new Promise((resolve, reject) =>
@@ -45,6 +46,7 @@ interface WalletsProps {
 interface WalletsState {
   walletsWithPaymentInfo: WalletWithPaymentInfo[]
   userPaybuttons: PaybuttonWithAddresses[]
+  userAddresses: Address[]
 }
 
 export default function Wallets ({ userId }: WalletsProps): React.ReactElement {
@@ -60,7 +62,8 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
     super(props)
     this.state = {
       walletsWithPaymentInfo: [],
-      userPaybuttons: []
+      userPaybuttons: [],
+      userAddresses: []
     }
   }
 
@@ -75,6 +78,9 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
     const paybuttonsResponse = await fetch(`/api/paybuttons?userId=${this.props.userId}`, {
       method: 'GET'
     })
+    const addressesResponse = await fetch(`/api/addresses?userId=${this.props.userId}`, {
+      method: 'GET'
+    })
     if (walletsResponse.status === 200) {
       this.setState({
         walletsWithPaymentInfo: await walletsResponse.json()
@@ -83,6 +89,11 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
     if (paybuttonsResponse.status === 200) {
       this.setState({
         userPaybuttons: await paybuttonsResponse.json()
+      })
+    }
+    if (paybuttonsResponse.status === 200) {
+      this.setState({
+        userAddresses: await addressesResponse.json()
       })
     }
   }
@@ -120,7 +131,7 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
           />
         }
         )}
-        <WalletForm userPaybuttons={this.state.userPaybuttons} refreshWalletList={this.refreshWalletList} userId={this.props.userId}/>
+        <WalletForm userAddresses={this.state.userAddresses} refreshWalletList={this.refreshWalletList} userId={this.props.userId}/>
         </div>
       </>
     )

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -78,7 +78,7 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
     const paybuttonsResponse = await fetch(`/api/paybuttons?userId=${this.props.userId}`, {
       method: 'GET'
     })
-    const addressesResponse = await fetch(`/api/addresses?userId=${this.props.userId}`, {
+    const addressesResponse = await fetch(`/api/addresses?userId=${this.props.userId}&includePaybuttons=1`, {
       method: 'GET'
     })
     if (walletsResponse.status === 200) {

--- a/services/addressService.ts
+++ b/services/addressService.ts
@@ -90,20 +90,6 @@ export async function fetchAddressesInList (prefixedAddressList: string[]): Prom
   })
 }
 
-export async function fetchAddressArrayByIds (addressIdList: number[]): Promise<Address[]> {
-  const addressArray = await prisma.address.findMany({
-    where: {
-      id: {
-        in: addressIdList
-      }
-    }
-  })
-  if (addressIdList.length !== addressArray.length) {
-    throw new Error(RESPONSE_MESSAGES.NO_ADDRESS_FOUND_404.message)
-  }
-  return addressArray
-}
-
 export async function upsertAddress (addressString: string, walletId?: number, includeTransactions = false): Promise<AddressWithTransactions> {
   const prefix = addressString.split(':')[0].toLowerCase()
   const network = await getNetworkFromSlug(prefix)

--- a/services/addressService.ts
+++ b/services/addressService.ts
@@ -29,10 +29,21 @@ export async function fetchAddressBySubstring (substring: string): Promise<Addre
 const addressWithTransactions = Prisma.validator<Prisma.AddressArgs>()({
   include: { transactions: true }
 })
-
 type AddressWithTransactions = Prisma.AddressGetPayload<typeof addressWithTransactions>
 
-export async function fetchAllUserAddresses (userId: string, includeTransactions = false): Promise<AddressWithTransactions[]> {
+const includePaybuttonsNested = {
+  paybuttons: {
+    include: {
+      paybutton: true
+    }
+  }
+}
+const addressWithPaybuttons = Prisma.validator<Prisma.AddressArgs>()({
+  include: includePaybuttonsNested
+})
+export type AddressWithPaybuttons = Prisma.AddressGetPayload<typeof addressWithPaybuttons>
+
+export async function fetchAllUserAddresses (userId: string, includeTransactions = false, includePaybuttons = false): Promise<AddressWithTransactions[]> {
   return await prisma.address.findMany({
     where: {
       paybuttons: {
@@ -44,7 +55,8 @@ export async function fetchAllUserAddresses (userId: string, includeTransactions
       }
     },
     include: {
-      transactions: includeTransactions
+      transactions: includeTransactions,
+      paybuttons: includePaybuttons ? includePaybuttonsNested.paybuttons : false
     }
   })
 }

--- a/services/addressService.ts
+++ b/services/addressService.ts
@@ -90,6 +90,20 @@ export async function fetchAddressesInList (prefixedAddressList: string[]): Prom
   })
 }
 
+export async function fetchAddressArrayByIds (addressIdList: number[]): Promise<Address[]> {
+  const addressArray = await prisma.address.findMany({
+    where: {
+      id: {
+        in: addressIdList
+      }
+    }
+  })
+  if (addressIdList.length !== addressArray.length) {
+    throw new Error(RESPONSE_MESSAGES.NO_ADDRESS_FOUND_404.message)
+  }
+  return addressArray
+}
+
 export async function upsertAddress (addressString: string, walletId?: number, includeTransactions = false): Promise<AddressWithTransactions> {
   const prefix = addressString.split(':')[0].toLowerCase()
   const network = await getNetworkFromSlug(prefix)

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -70,7 +70,7 @@ describe('Create services', () => {
     createWalletInput: {
       userId: 'mocked-uid',
       name: 'mockedWallet-name',
-      paybuttonIdList: [1]
+      addressIdList: [1]
     }
   }
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -26,9 +26,9 @@ export const clearPaybuttonsAndAddresses = async (): Promise<void> => {
 
 const addressRandexp = new RandExp(SUPPORTED_ADDRESS_PATTERN)
 
-export const createWalletForUser = async (userId: string, paybuttonIdList: number[]): Promise<WalletWithAddressesAndPaybuttons> => {
+export const createWalletForUser = async (userId: string, addressIdList: number[]): Promise<WalletWithAddressesAndPaybuttons> => {
   const name = Math.random().toString(36).slice(2)
-  return await createWallet({ userId, name, paybuttonIdList })
+  return await createWallet({ userId, name, addressIdList })
 }
 
 export const createPaybuttonForUser = async (userId: string, addressList?: string[], walletId?: number): Promise<PaybuttonWithAddresses> => {

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -72,6 +72,10 @@ export const parseError = function (error: Error): Error {
           error.message.includes('prisma.paybutton.update')
         ) {
           return new Error(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message)
+        } else if (
+          error.message.includes('prisma.address.update')
+        ) {
+          return new Error(RESPONSE_MESSAGES.NO_ADDRESS_FOUND_404.message)
         }
         break
     }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -91,7 +91,7 @@ export const parsePaybuttonPOSTRequest = function (params: PaybuttonPOSTParamete
   if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
   if (params.addresses === '' || params.addresses === undefined) throw new Error(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
-  let walletId: number | undefined = Number(params.walletId)
+  const walletId: number | undefined = Number(params.walletId)
   if (params.walletId === '' || params.walletId === undefined) {
     throw new Error(RESPONSE_MESSAGES.WALLET_ID_NOT_PROVIDED_400.message)
   }
@@ -112,7 +112,7 @@ export interface WalletPOSTParameters {
   name?: string
   isXECDefault?: boolean
   isBCHDefault?: boolean
-  paybuttonIdList: number[]
+  addressIdList: number[]
 }
 
 export interface PaybuttonPATCHParameters {
@@ -131,12 +131,12 @@ export interface WalletPATCHParameters {
 export const parseWalletPOSTRequest = function (params: WalletPOSTParameters): CreateWalletInput {
   if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
-  if (params.paybuttonIdList === undefined || params.paybuttonIdList.length === 0) throw new Error(RESPONSE_MESSAGES.BUTTON_IDS_NOT_PROVIDED_400.message)
-  params.paybuttonIdList = params.paybuttonIdList.map((id: string | number) => Number(id))
+  if (params.addressIdList === undefined || params.addressIdList.length === 0) throw new Error(RESPONSE_MESSAGES.ADDRESS_IDS_NOT_PROVIDED_400.message)
+  params.addressIdList = params.addressIdList.map((id: string | number) => Number(id))
   return {
     userId: params.userId,
     name: params.name,
-    paybuttonIdList: params.paybuttonIdList,
+    addressIdList: params.addressIdList,
     isXECDefault: params.isXECDefault,
     isBCHDefault: params.isBCHDefault
   }


### PR DESCRIPTION
Description:
Also displays the buttons to which the addresses are related, upon creating a wallet.

Test plan:
Try to create a wallet, there should appears the addresses with their related buttons.

Depends on:
- [ ] #396