### PR TITLE
[Issue #395] feat: remodel address to wallet on wallet card

### DIFF
--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -7,12 +7,12 @@ import Image from 'next/image'
 import style from '../Wallet/wallet.module.css'
 import style_pb from '../Paybutton/paybutton.module.css'
 import EditIcon from 'assets/edit-icon.png'
-import { WalletWithAddressesAndPaybuttons } from 'services/walletService'
+import { WalletWithAddressesWithPaybuttons } from 'services/walletService'
 import axios from 'axios'
 import { appInfo } from 'config/appInfo'
 
 interface IProps {
-  wallet: WalletWithAddressesAndPaybuttons
+  wallet: WalletWithAddressesWithPaybuttons
   userPaybuttons: PaybuttonWithAddresses[]
   refreshWalletList: Function
 }

--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -19,6 +19,14 @@ interface IProps {
 
 const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userPaybuttons, refreshWalletList }: IProps) => {
   const networks = wallet.addresses.map((addr) => addr.networkId)
+  const differentPaybuttons = wallet.addresses.map(addr =>
+    addr.paybuttons.map(conn => conn.paybutton)
+  ).reduce(
+    (accumulator, pbList) => accumulator.concat(pbList),
+    []
+  ).filter(
+    (pb, index, self) => index === self.findIndex(p => p.id === pb.id)
+  )
   return (
     <div className={style.wallet_card}>
       <div className={style.wallet_card_header_ctn}>
@@ -61,10 +69,8 @@ const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userPaybutt
         <div className={style.info_item}>
           <h6>Buttons</h6>
           <div className={style.buttons_list_ctn}>
-            {wallet.addresses.map(addr =>
-              addr.paybuttons.map(conn =>
-              <Link href={`/button/${conn.paybutton.id}`}>{conn.paybutton.name}</Link>
-              )
+            {differentPaybuttons.map(pb =>
+              <Link href={`/button/${pb.id}`}>{pb.name}</Link>
             )}
           </div>
         </div>

--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -6,18 +6,20 @@ import Image from 'next/image'
 import XECIcon from 'assets/xec-logo.png'
 import BCHIcon from 'assets/bch-logo.png'
 import EditWalletForm from './EditWalletForm'
-import { WalletWithAddressesAndPaybuttons, WalletPaymentInfo } from 'services/walletService'
+import { WalletWithAddressesWithPaybuttons, WalletPaymentInfo } from 'services/walletService'
 import { PaybuttonWithAddresses } from 'services/paybuttonService'
+import { AddressWithPaybuttons } from 'services/addressService'
 import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 
 interface IProps {
-  wallet: WalletWithAddressesAndPaybuttons
+  wallet: WalletWithAddressesWithPaybuttons
   paymentInfo: WalletPaymentInfo
+  userAddresses: AddressWithPaybuttons[]
   userPaybuttons: PaybuttonWithAddresses[]
   refreshWalletList: Function
 }
 
-const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userPaybuttons, refreshWalletList }: IProps) => {
+const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userPaybuttons, userAddresses, refreshWalletList }: IProps) => {
   const networks = wallet.addresses.map((addr) => addr.networkId)
   return (
     <div className={style.wallet_card}>
@@ -61,8 +63,10 @@ const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userPaybutt
         <div className={style.info_item}>
           <h6>Buttons</h6>
           <div className={style.buttons_list_ctn}>
-            {wallet.paybuttons.map(button =>
-                <Link href={`/button/${button.id}`}>{button.name}</Link>
+            {wallet.addresses.map(addr =>
+              addr.paybuttons.map(conn =>
+              <Link href={`/button/${conn.paybutton.id}`}>{conn.paybutton.name}</Link>
+              )
             )}
           </div>
         </div>

--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -8,18 +8,16 @@ import BCHIcon from 'assets/bch-logo.png'
 import EditWalletForm from './EditWalletForm'
 import { WalletWithAddressesWithPaybuttons, WalletPaymentInfo } from 'services/walletService'
 import { PaybuttonWithAddresses } from 'services/paybuttonService'
-import { AddressWithPaybuttons } from 'services/addressService'
 import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 
 interface IProps {
   wallet: WalletWithAddressesWithPaybuttons
   paymentInfo: WalletPaymentInfo
-  userAddresses: AddressWithPaybuttons[]
   userPaybuttons: PaybuttonWithAddresses[]
   refreshWalletList: Function
 }
 
-const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userPaybuttons, userAddresses, refreshWalletList }: IProps) => {
+const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userPaybuttons, refreshWalletList }: IProps) => {
   const networks = wallet.addresses.map((addr) => addr.networkId)
   return (
     <div className={style.wallet_card}>

--- a/components/Wallet/WalletForm.tsx
+++ b/components/Wallet/WalletForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { WalletPOSTParameters } from 'utils/validators'
+import { AddressWithPaybuttons } from 'services/addressService'
 import { Address } from '@prisma/client'
 import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 import Image from 'next/image'
@@ -11,7 +12,7 @@ import axios from 'axios'
 import { appInfo } from 'config/appInfo'
 
 interface IProps {
-  userAddresses: Address[]
+  userAddresses: AddressWithPaybuttons[]
   refreshWalletList: Function
   userId: string
 }
@@ -145,7 +146,7 @@ export default function WalletForm ({ userAddresses, refreshWalletList, userId }
             <div className={style_pb.form_ctn_inner}>
               <h4>Create New Wallet</h4>
               <div className={style_pb.form_ctn}>
-                <p>Wallets must have a unique name and contain at least one button. Each button can only be linked to one wallet at a time.</p>
+                <p>Wallets must have a unique name and contain at least one address. Each address can only be linked to one wallet at a time.</p>
                 <form onSubmit={handleSubmit(onSubmit)} method='post'>
                   <label htmlFor='name'>Wallet Name</label>
                   <input
@@ -168,7 +169,12 @@ export default function WalletForm ({ userAddresses, refreshWalletList, userId }
                           }
                           onChange={ (e) => handleSelectedAddressesChange(e.target.checked, addr.id) }
                         />
-                        <label htmlFor={`addressIdList.${index}`}>{addr.address}</label>
+                        <label htmlFor={`addressIdList.${index}`}>
+                          {addr.address}
+                          {addr.paybuttons.map((conn) => (
+                            <div>{conn.paybutton.name}</div>
+                          ))}
+                        </label>
                       </div>
                     ))}
                   </div>

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -9,7 +9,7 @@ import WalletCard from 'components/Wallet/WalletCard'
 import WalletForm from 'components/Wallet/WalletForm'
 import { WalletWithPaymentInfo } from 'services/walletService'
 import { PaybuttonWithAddresses } from 'services/paybuttonService'
-import { Address } from '@prisma/client'
+import { AddressWithPaybuttons } from 'services/addressService'
 
 const ThirdPartyEmailPasswordAuthNoSSR = dynamic(
   new Promise((resolve, reject) =>
@@ -46,7 +46,7 @@ interface WalletsProps {
 interface WalletsState {
   walletsWithPaymentInfo: WalletWithPaymentInfo[]
   userPaybuttons: PaybuttonWithAddresses[]
-  userAddresses: Address[]
+  userAddresses: AddressWithPaybuttons[]
 }
 
 export default function Wallets ({ userId }: WalletsProps): React.ReactElement {
@@ -126,6 +126,7 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
           return <WalletCard
             wallet={walletWithPaymentInfo.wallet}
             paymentInfo={walletWithPaymentInfo.paymentInfo}
+            userAddresses={this.state.userAddresses}
             userPaybuttons={this.state.userPaybuttons}
             refreshWalletList={this.refreshWalletList}
           />

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -78,7 +78,7 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
     const paybuttonsResponse = await fetch(`/api/paybuttons?userId=${this.props.userId}`, {
       method: 'GET'
     })
-    const addressesResponse = await fetch(`/api/addresses?userId=${this.props.userId}`, {
+    const addressesResponse = await fetch(`/api/addresses?userId=${this.props.userId}&includePaybuttons=1`, {
       method: 'GET'
     })
     if (walletsResponse.status === 200) {

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -21,7 +21,7 @@ export interface UpdateWalletInput {
   userId: string
 }
 
-const includeAddressesAndPaybuttons = {
+const includeAddressesAndPaybuttons = { // DEPRECATED
   userProfile: {
     select: {
       userProfileId: true,
@@ -38,10 +38,33 @@ const includeAddressesAndPaybuttons = {
     }
   }
 }
-
-const walletWithAddressesAndPaybuttons = Prisma.validator<Prisma.WalletArgs>()(
+const walletWithAddressesAndPaybuttons = Prisma.validator<Prisma.WalletArgs>()( // DEPRECATED
   { include: includeAddressesAndPaybuttons }
 )
+export type WalletWithAddressesAndPaybuttons = Prisma.WalletGetPayload<typeof walletWithAddressesAndPaybuttons> // DEPRECATED
+
+const includeAddressesWithPaybuttons = {
+  userProfile: {
+    select: {
+      userProfileId: true,
+      isXECDefault: true,
+      isBCHDefault: true
+    }
+  },
+  addresses: {
+    include: {
+      paybuttons: {
+        include: {
+          paybutton: true
+        }
+      }
+    }
+  }
+}
+const walletWithAddressesWithPaybuttons = Prisma.validator<Prisma.WalletArgs>()({
+  include: includeAddressesWithPaybuttons
+})
+export type WalletWithAddressesWithPaybuttons = Prisma.WalletGetPayload<typeof walletWithAddressesWithPaybuttons>
 
 export const getDefaultForNetworkIds = (isXECDefault: boolean | undefined, isBCHDefault: boolean | undefined): number[] => {
   const defaultForNetworkIds: number[] = []
@@ -63,8 +86,6 @@ export const walletHasAddressForNetwork = (wallet: WalletWithAddressesAndPaybutt
   }
   return true
 }
-
-export type WalletWithAddressesAndPaybuttons = Prisma.WalletGetPayload<typeof walletWithAddressesAndPaybuttons>
 
 async function removePaybuttonsFromWallet (
   prisma: Prisma.TransactionClient,
@@ -370,11 +391,11 @@ export interface WalletPaymentInfo {
 }
 
 export interface WalletWithPaymentInfo {
-  wallet: WalletWithAddressesAndPaybuttons
+  wallet: WalletWithAddressesWithPaybuttons
   paymentInfo: WalletPaymentInfo
 }
 
-export async function getWalletBalance (wallet: WalletWithAddressesAndPaybuttons): Promise<WalletPaymentInfo> {
+export async function getWalletBalance (wallet: WalletWithAddressesWithPaybuttons): Promise<WalletPaymentInfo> {
   const ret: WalletPaymentInfo = {
     XECBalance: new Prisma.Decimal(0),
     BCHBalance: new Prisma.Decimal(0),
@@ -393,9 +414,9 @@ export async function getWalletBalance (wallet: WalletWithAddressesAndPaybuttons
   return ret
 }
 
-export async function fetchWalletArrayByUserId (userId: string): Promise<WalletWithAddressesAndPaybuttons[]> {
+export async function fetchWalletArrayByUserId (userId: string): Promise<WalletWithAddressesWithPaybuttons[]> {
   return await prisma.wallet.findMany({
     where: { providerUserId: userId },
-    include: includeAddressesAndPaybuttons
+    include: includeAddressesWithPaybuttons
   })
 }

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -662,23 +662,23 @@ describe('GET /api/wallets/', () => {
     expect(responseData.length).toBe(1)
     expect(responseData[0].wallet.addresses).toEqual(
       expect.arrayContaining([
-        {
+        expect.objectContaining({
           address: expect.any(String),
           networkId: expect.any(Number),
           id: expect.any(Number)
-        },
-        {
+        }),
+        expect.objectContaining({
           address: expect.any(String),
           networkId: expect.any(Number),
           id: expect.any(Number)
-        }
+        })
       ])
     )
     expect(responseData[0]).toHaveProperty('wallet')
     expect(responseData[0]).toHaveProperty('paymentInfo')
     expect(responseData[0].wallet).toHaveProperty('providerUserId', 'test-other-u-id')
     expect(responseData[0].wallet).toHaveProperty('name')
-    expect(responseData[0].wallet).toHaveProperty('paybuttons')
+    expect(responseData[0].wallet).toHaveProperty('addresses')
     expect(responseData[0].wallet).toHaveProperty('userProfile')
     expect(responseData[0].paymentInfo).toHaveProperty('XECBalance')
     expect(responseData[0].paymentInfo).toHaveProperty('BCHBalance')

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -146,6 +146,16 @@ export const mockedPaybuttonList = [
   mockedPaybutton
 ]
 
+export const mockedBCHAddressWithPaybutton = { ...mockedBCHAddress } as any
+mockedBCHAddressWithPaybutton.paybuttons = [
+  {
+    paybutton: mockedPaybuttonList[2]
+  },
+  {
+    address: mockedPaybuttonList[3]
+  }
+]
+
 // Wallet
 export const mockedWallet: WalletWithAddressesAndPaybuttons = {
   id: 1,

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -4,7 +4,15 @@ import * as walletService from 'services/walletService'
 import * as addressService from 'services/addressService'
 import { prismaMock } from 'prisma/mockedClient'
 import { RESPONSE_MESSAGES, XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
-import { mockedWallet, mockedWalletList, mockedPaybuttonList, mockedPaybutton, mockedNetwork, mockedBCHAddress, mockedAddressList } from '../mockedObjects'
+import {
+  mockedWallet,
+  mockedWalletList,
+  mockedPaybuttonList,
+  mockedPaybutton,
+  mockedNetwork,
+  mockedAddressList,
+  mockedBCHAddressWithPaybutton
+} from '../mockedObjects'
 
 const prismaMockPaybuttonAndAddressUpdate = (): void => {
   prismaMock.paybutton.update.mockImplementation((_) => {
@@ -44,11 +52,10 @@ describe('Fetch services', () => {
         paymentCount: 3
       }
     })
-    const params: walletService.WalletWithAddressesAndPaybuttons = {
+    const params: walletService.WalletWithAddressesWithPaybuttons = {
       ...mockedWallet,
       userProfile: null,
-      addresses: [mockedBCHAddress],
-      paybuttons: []
+      addresses: [mockedBCHAddressWithPaybutton]
     }
     const result = await walletService.getWalletBalance(params)
     expect(result).toHaveProperty('XECBalance', new Prisma.Decimal('0'))


### PR DESCRIPTION
Description:
Shows the paybuttons that belongs to a wallet by inferring them from the wallet addresses.

Test plan:
Go on to create a new wallet, select some address to it. See if all wallets now are correctly inferring their paybuttons.

Remarks:
- Now, editing a wallet will produce unexpected results. This will be later addressed in another PR.

Depends on:
- [x] #398 

