### PR TITLE
[Issue #395] refactor: remove deprecated WalletWithAddressesAndPaybuttons type

### DIFF
--- a/components/Paybutton/PaybuttonForm.tsx
+++ b/components/Paybutton/PaybuttonForm.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { PaybuttonPOSTParameters } from 'utils/validators'
-import { WalletWithAddressesAndPaybuttons } from 'services/walletService'
+import { WalletWithAddressesWithPaybuttons } from 'services/walletService'
 import Image from 'next/image'
 import style from './paybutton.module.css'
 import Plus from 'assets/plus.png'
@@ -9,7 +9,7 @@ import Plus from 'assets/plus.png'
 interface IProps {
   onSubmit: Function
   paybuttons: []
-  wallets: WalletWithAddressesAndPaybuttons[]
+  wallets: WalletWithAddressesWithPaybuttons[]
   error: String
 }
 

--- a/pages/buttons/index.tsx
+++ b/pages/buttons/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ThirdPartyEmailPassword from 'supertokens-auth-react/recipe/thirdpartyemailpassword'
 import { PaybuttonList, PaybuttonForm } from 'components/Paybutton'
 import { PaybuttonWithAddresses } from 'services/paybuttonService'
-import { WalletWithAddressesAndPaybuttons } from 'services/walletService'
+import { WalletWithAddressesWithPaybuttons } from 'services/walletService'
 import { PaybuttonPOSTParameters } from 'utils/validators'
 import dynamic from 'next/dynamic'
 import supertokensNode from 'supertokens-node'
@@ -44,7 +44,7 @@ interface PaybuttonsProps {
 
 interface PaybuttonsState {
   paybuttons: PaybuttonWithAddresses[]
-  wallets: WalletWithAddressesAndPaybuttons[]
+  wallets: WalletWithAddressesWithPaybuttons[]
   error: String
 }
 

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -20,28 +20,6 @@ export interface UpdateWalletInput {
   userId: string
 }
 
-const includeAddressesAndPaybuttons = { // DEPRECATED
-  userProfile: {
-    select: {
-      userProfileId: true,
-      isXECDefault: true,
-      isBCHDefault: true
-    }
-  },
-  paybuttons: true,
-  addresses: {
-    select: {
-      id: true,
-      address: true,
-      networkId: true
-    }
-  }
-}
-const walletWithAddressesAndPaybuttons = Prisma.validator<Prisma.WalletArgs>()( // DEPRECATED
-  { include: includeAddressesAndPaybuttons }
-)
-export type WalletWithAddressesAndPaybuttons = Prisma.WalletGetPayload<typeof walletWithAddressesAndPaybuttons> // DEPRECATED
-
 const includeAddressesWithPaybuttons = {
   userProfile: {
     select: {


### PR DESCRIPTION
Description:
Part of #395. Changing the type that includes a wallet associated paybuttons (since we are deleting this association) for the type that gets the paybuttons from the wallet addresses.

Test plan:
Only a refactor, nothing should change.