### PR TITLE
3  [Issue #420] feat: do not show other users paybuttons on wallet

### DIFF
--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -20,7 +20,7 @@ export default function EditWalletForm ({ wallet, userAddresses, refreshWalletLi
   const { register, handleSubmit, reset } = useForm<WalletPATCHParameters>()
   const [modal, setModal] = useState(false)
   const [error, setError] = useState('')
-  const thisWalletAddressIdList = userAddresses.filter(addr => addr.walletId === wallet.id).map(addr => addr.id)
+  const thisWalletAddressIdList = wallet.userAddresses.map((addr) => addr.addressId)
 
   const [selectedAddressIdList, setSelectedAddressIdList] = useState([] as number[])
 
@@ -92,7 +92,7 @@ export default function EditWalletForm ({ wallet, userAddresses, refreshWalletLi
                           type='checkbox'
                           value={addr.id}
                           id={`addressIdList.${index}`}
-                          defaultChecked={addr.walletId === wallet.id}
+                          defaultChecked={thisWalletAddressIdList.includes(addr.id)}
                           onChange={ (e) => handleSelectedAddressesChange(e.target.checked, addr.id) }
                         />
                         <label htmlFor={`addressIdList.${index}`}>

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -8,7 +8,6 @@ import { GetServerSideProps } from 'next'
 import WalletCard from 'components/Wallet/WalletCard'
 import WalletForm from 'components/Wallet/WalletForm'
 import { WalletWithPaymentInfo } from 'services/walletService'
-import { PaybuttonWithAddresses } from 'services/paybuttonService'
 import { AddressWithPaybuttons } from 'services/addressService'
 
 const ThirdPartyEmailPasswordAuthNoSSR = dynamic(
@@ -45,7 +44,6 @@ interface WalletsProps {
 
 interface WalletsState {
   walletsWithPaymentInfo: WalletWithPaymentInfo[]
-  userPaybuttons: PaybuttonWithAddresses[]
   userAddresses: AddressWithPaybuttons[]
 }
 
@@ -62,7 +60,6 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
     super(props)
     this.state = {
       walletsWithPaymentInfo: [],
-      userPaybuttons: [],
       userAddresses: []
     }
   }
@@ -75,9 +72,6 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
     const walletsResponse = await fetch(`/api/wallets?userId=${this.props.userId}`, {
       method: 'GET'
     })
-    const paybuttonsResponse = await fetch(`/api/paybuttons?userId=${this.props.userId}`, {
-      method: 'GET'
-    })
     const addressesResponse = await fetch(`/api/addresses?userId=${this.props.userId}&includePaybuttons=1`, {
       method: 'GET'
     })
@@ -86,12 +80,7 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
         walletsWithPaymentInfo: await walletsResponse.json()
       })
     }
-    if (paybuttonsResponse.status === 200) {
-      this.setState({
-        userPaybuttons: await paybuttonsResponse.json()
-      })
-    }
-    if (paybuttonsResponse.status === 200) {
+    if (addressesResponse.status === 200) {
       this.setState({
         userAddresses: await addressesResponse.json()
       })
@@ -127,7 +116,6 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
             wallet={walletWithPaymentInfo.wallet}
             paymentInfo={walletWithPaymentInfo.paymentInfo}
             userAddresses={this.state.userAddresses}
-            userPaybuttons={this.state.userPaybuttons}
             refreshWalletList={this.refreshWalletList}
             key={walletWithPaymentInfo.wallet.name}
           />

--- a/services/addressService.ts
+++ b/services/addressService.ts
@@ -57,6 +57,15 @@ export async function addressExistsBySubstring (substring: string): Promise<bool
 }
 
 export async function fetchAllUserAddresses (userId: string, includeTransactions = false, includePaybuttons = false): Promise<AddressWithTransactions[]> {
+  let userPaybuttons
+  if (includePaybuttons) {
+    userPaybuttons = includePaybuttonsNested.paybuttons as Prisma.AddressesOnButtonsFindManyArgs
+    userPaybuttons.where = {
+      paybutton: {
+        providerUserId: userId
+      }
+    }
+  }
   return await prisma.address.findMany({
     where: {
       paybuttons: {
@@ -69,7 +78,7 @@ export async function fetchAllUserAddresses (userId: string, includeTransactions
     },
     include: {
       transactions: includeTransactions,
-      paybuttons: includePaybuttons ? includePaybuttonsNested.paybuttons : false
+      paybuttons: includePaybuttons ? userPaybuttons : false
     }
   })
 }

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -406,14 +406,16 @@ export const mockedWalletList = [
     createdAt: new Date('2022-09-30T18:01:32.456Z'),
     updatedAt: new Date('2022-09-30T18:01:32.456Z'),
     name: 'mockedWallet',
-    providerUserId: 'mocked-uid'
+    providerUserId: 'mocked-uid',
+    userAddresses: []
   },
   {
     id: 2,
     createdAt: new Date('2022-09-30T18:01:32.456Z'),
     updatedAt: new Date('2022-09-30T18:01:32.456Z'),
     name: 'mockedWallet2',
-    providerUserId: 'mocked-uid'
+    providerUserId: 'mocked-uid',
+    userAddresses: []
   }
 ]
 


### PR DESCRIPTION
Description:
Solves #420.

Test plan:

1. Log into `dev@paybutton.org` on a browser window and into `dev2@paybutton.org` on a private window.
2. Take any of the addresses that `dev` is using on one of their paybuttons and create a paybutton with it for `dev2`
3. Go to the wallets view on both users. On master (considering this PR dependencies were met) something like this would be seen:

(on the left `dev2`, on the right `dev`)
![image](https://user-images.githubusercontent.com/21281174/224991340-f7b1e0d1-5647-42ea-84e5-8032d8026afd.png)

On this branch, this should be fixed:
![image](https://user-images.githubusercontent.com/21281174/224991799-849ed4ec-456c-4b48-9e5f-6225195d79ff.png)



Depends on:
- [x] #430 