### PR TITLE
[Issue #433] fix: ecash grpc client being recreated

### DIFF
--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -21,22 +21,22 @@ export interface OutputsList {
   slpToken: string | undefined
 }
 
-export class GrpcBlockchainClient implements BlockchainClient {
-  clients: KeyValueT<GrpcClient>
+const grpcBCH = new GrpcClient({ url: process.env.GRPC_BCH_NODE_URL })
 
-  constructor () {
-    this.clients = {
-      bitcoincash: new GrpcClient({ url: process.env.GRPC_BCH_NODE_URL }),
-      ecash: new GrpcClient({ url: process.env.GRPC_XEC_NODE_URL })
-    }
+export const getGrpcClients = (): KeyValueT<GrpcClient> => {
+  return {
+    bitcoincash: grpcBCH,
+    ecash: new GrpcClient({ url: process.env.GRPC_XEC_NODE_URL })
   }
+}
 
+export class GrpcBlockchainClient implements BlockchainClient {
   private getClientForAddress (addressString: string): GrpcClient {
-    return getObjectValueForAddress(addressString, this.clients)
+    return getObjectValueForAddress(addressString, getGrpcClients())
   }
 
   private getClientForNetworkSlug (networkSlug: string): GrpcClient {
-    return getObjectValueForNetworkSlug(networkSlug, this.clients)
+    return getObjectValueForNetworkSlug(networkSlug, getGrpcClients())
   }
 
   public async getBlockchainInfo (networkSlug: string): Promise<BlockchainInfo> {


### PR DESCRIPTION
**Description:**
XEC Grpc client wasn't working, this fixes it.

**Test plan:**
On the `Networks` tab, eCash should show "connected"

Also, the initial transaction syncing should also be working now. It still doesn't quite solves #433 because looks like the initial transactions sync is not being completed because some other job is race conditioning it; so not all transactions will be synced. This will be addressed in another PR