### PR TITLE
[Issue  #443] fix: initial txs sync

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -108,3 +108,5 @@ export const NETWORK_BLOCKCHAIN_CLIENTS: KeyValueT<BLOCKCHAIN_CLIENT_OPTIONS> = 
 }
 
 export const CHRONIK_CLIENT_URL = 'https://chronik.be.cash/xec'
+
+export const UPSERT_TRANSACTION_PRICES_ON_DB_TIMEOUT = 15000

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -12,11 +12,9 @@ import { subscribeTransactions } from 'services/blockchainService'
 
 const syncAndSubscribeAddressList = async (addressList: Address[]): Promise<void> => {
   // sync addresses
-  await Promise.all(
-    addressList.map(async (addr) => {
-      await transactionService.syncTransactionsAndPricesForAddress(addr.address)
-    })
-  )
+  for (const addr of addressList) {
+    await transactionService.syncTransactionsAndPricesForAddress(addr.address)
+  }
   // subscribe addresses
   addressList.map(async (addr) => {
     await subscribeTransactions(

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -12,9 +12,11 @@ import { subscribeTransactions } from 'services/blockchainService'
 
 const syncAndSubscribeAddressList = async (addressList: Address[]): Promise<void> => {
   // sync addresses
-  for (const addr of addressList) {
-    await transactionService.syncTransactionsAndPricesForAddress(addr.address)
-  }
+  await Promise.all(
+    addressList.map(async (addr) => {
+      await transactionService.syncTransactionsAndPricesForAddress(addr.address)
+    })
+  )
   // subscribe addresses
   addressList.map(async (addr) => {
     await subscribeTransactions(

--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 import { appInfo } from 'config/appInfo'
 import { Prisma, Price } from '@prisma/client'
 import prisma from 'prisma/clientInstance'
-import { NETWORK_IDS, HUMAN_READABLE_DATE_FORMAT, PRICE_API_TIMEOUT, PRICE_API_MAX_RETRIES, PRICE_API_DATE_FORMAT, RESPONSE_MESSAGES, NETWORK_TICKERS, XEC_NETWORK_ID, BCH_NETWORK_ID, USD_QUOTE_ID, CAD_QUOTE_ID, N_OF_QUOTES } from 'constants/index'
+import { NETWORK_IDS, HUMAN_READABLE_DATE_FORMAT, PRICE_API_TIMEOUT, PRICE_API_MAX_RETRIES, PRICE_API_DATE_FORMAT, RESPONSE_MESSAGES, NETWORK_TICKERS, XEC_NETWORK_ID, BCH_NETWORK_ID, USD_QUOTE_ID, CAD_QUOTE_ID, N_OF_QUOTES, UPSERT_TRANSACTION_PRICES_ON_DB_TIMEOUT } from 'constants/index'
 import { validatePriceAPIUrlAndToken, validateNetworkTicker } from 'utils/validators'
 import moment from 'moment'
 
@@ -317,7 +317,11 @@ export async function createTransactionPrices (params: CreatePricesFromTransacti
       },
       update: {}
     })
-  })
+  },
+  {
+    timeout: UPSERT_TRANSACTION_PRICES_ON_DB_TIMEOUT
+  }
+  )
 }
 
 export async function syncTransactionPriceValues (params: SyncTransactionPricesInput): Promise<QuoteValues | undefined> {


### PR DESCRIPTION
Description:
Solves #433.
Turns out that sometimes DB transactions for setting the transaction prices were taking longer than 5s, which is the prisma default. This increases the timeout to 15s.

Test plan:
Run `yarn docker jr` to rerun the jobs, and check with `yarn docker jw` if no errors happened and all addresses were synced fine.

Remarks:
Since we already have a robust pipeline for setting all past prices, we shouldn't even be upserting these transactions prices. For that, I created issue #447