### PR TITLE
[Issue #264] feat: use  UUID on paybuttons

### DIFF
--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -118,7 +118,7 @@ const getAllMonths = function (paymentList: Payment[]): AllMonths {
 
 export interface ButtonDisplayData {
   name: string
-  id: number
+  id: string
 }
 
 interface Payment {

--- a/pages/api/paybutton/[id].ts
+++ b/pages/api/paybutton/[id].ts
@@ -47,7 +47,7 @@ export default async (
     try {
       const values = req.body
       const updatePaybuttonInput = parsePaybuttonPATCHRequest(values)
-      const paybutton = await paybuttonService.updatePaybutton(Number(paybuttonId), updatePaybuttonInput)
+      const paybutton = await paybuttonService.updatePaybutton(paybuttonId, updatePaybuttonInput)
       res.status(200).json(paybutton)
     } catch (err: any) {
       const parsedError = parseError(err)

--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -117,7 +117,7 @@ class ProtectedPage extends React.Component<PaybuttonProps, PaybuttonState> {
     void ThirdPartyEmailPassword.redirectToAuth()
   }
 
-  async onDelete (paybuttonId: number): Promise<void> {
+  async onDelete (paybuttonId: string): Promise<void> {
     const res = await axios.delete<PaybuttonWithAddresses>(`${appInfo.websiteDomain}/api/paybutton/${paybuttonId}`)
     if (res.status === 200) {
       void Router.push(`${appInfo.websiteDomain}/buttons/`)

--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -14,9 +14,8 @@ CREATE TABLE `Address` (
 
 -- CreateTable
 CREATE TABLE `Paybutton` (
-    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `id` VARCHAR(191) NOT NULL DEFAULT (uuid()),
     `name` VARCHAR(255) NOT NULL,
-    `uuid` VARCHAR(191) NOT NULL DEFAULT (uuid()),
     `buttonData` LONGTEXT NOT NULL,
     `providerUserId` VARCHAR(255) NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
@@ -28,7 +27,7 @@ CREATE TABLE `Paybutton` (
 
 -- CreateTable
 CREATE TABLE `AddressesOnButtons` (
-    `paybuttonId` INTEGER NOT NULL,
+    `paybuttonId` VARCHAR(191) NOT NULL,
     `addressId` INTEGER NOT NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,9 +26,8 @@ model Address {
 }
 
 model Paybutton {
-  id             Int                  @id @default(autoincrement())
+  id             String               @id @default(dbgenerated("(uuid())"))
   name           String               @db.VarChar(255)
-  uuid           String               @default(dbgenerated("(uuid())"))
   buttonData     String               @db.LongText
   providerUserId String?              @db.VarChar(255)
   createdAt      DateTime             @default(now())
@@ -39,7 +38,7 @@ model Paybutton {
 }
 
 model AddressesOnButtons {
-  paybuttonId Int
+  paybuttonId String
   addressId   Int
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt

--- a/prisma/seeds/paybuttonAddressConnectors.ts
+++ b/prisma/seeds/paybuttonAddressConnectors.ts
@@ -1,26 +1,26 @@
 export const paybuttonAddressConnectors = [
   {
     addressId: 1,
-    paybuttonId: 1
+    paybuttonId: 'a245152d-397a-4ce6-a669-971ba263182f'
   },
   {
     addressId: 2,
-    paybuttonId: 2
+    paybuttonId: '7a37b914-52fa-4b27-ad52-ddbb79263785'
   },
   {
     addressId: 2,
-    paybuttonId: 3
+    paybuttonId: '21599080-1264-4829-b3cd-205cf1896cf5'
   },
   {
     addressId: 1,
-    paybuttonId: 3
+    paybuttonId: '21599080-1264-4829-b3cd-205cf1896cf5'
   },
   {
     addressId: 3,
-    paybuttonId: 4
+    paybuttonId: '94f0a111-6f92-4eb2-b5c5-d3cc0b044973'
   },
   {
     addressId: 4,
-    paybuttonId: 5
+    paybuttonId: 'ef45a4e7-8ded-4aab-93e8-b1d3e8b4f69d'
   }
 ]

--- a/prisma/seeds/paybuttons.ts
+++ b/prisma/seeds/paybuttons.ts
@@ -1,30 +1,30 @@
 export const paybuttons = [
   {
-    id: 1,
+    id: 'a245152d-397a-4ce6-a669-971ba263182f',
     providerUserId: 'dev-uid',
     name: 'PayButton XEC',
     buttonData: '{"example": "value"}'
   },
   {
-    id: 2,
+    id: '7a37b914-52fa-4b27-ad52-ddbb79263785',
     providerUserId: 'dev-uid',
     name: 'Coin Dance BCH',
     buttonData: '{}'
   },
   {
-    id: 3,
+    id: '21599080-1264-4829-b3cd-205cf1896cf5',
     providerUserId: 'dev-uid',
     name: 'PayButton XEC & Coin Dance BCH',
     buttonData: '{}'
   },
   {
-    id: 4,
+    id: '94f0a111-6f92-4eb2-b5c5-d3cc0b044973',
     providerUserId: 'dev-uid',
     name: 'Foo XEC',
     buttonData: '{}'
   },
   {
-    id: 5,
+    id: 'ef45a4e7-8ded-4aab-93e8-b1d3e8b4f69d',
     providerUserId: 'dev-uid',
     name: 'Bar XEC',
     buttonData: '{}'

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -20,7 +20,7 @@ export interface CreatePaybuttonInput {
 
 export interface DeletePaybuttonInput {
   userId: string
-  paybuttonId: number | string
+  paybuttonId: string
 }
 
 const includeAddresses = {
@@ -97,13 +97,13 @@ export async function deletePaybutton (values: DeletePaybuttonInput): Promise<Pa
   }
   return await prisma.paybutton.delete({
     where: {
-      id: Number(values.paybuttonId)
+      id: values.paybuttonId
     },
     include: includeAddresses
   })
 }
 
-export async function fetchPaybuttonArrayByIds (paybuttonIdList: number[]): Promise<PaybuttonWithAddresses[]> {
+export async function fetchPaybuttonArrayByIds (paybuttonIdList: string[]): Promise<PaybuttonWithAddresses[]> {
   const paybuttonArray = await prisma.paybutton.findMany({
     where: {
       id: {
@@ -118,9 +118,9 @@ export async function fetchPaybuttonArrayByIds (paybuttonIdList: number[]): Prom
   return paybuttonArray
 }
 
-export async function fetchPaybuttonById (paybuttonId: number | string): Promise<PaybuttonWithAddresses | null> {
+export async function fetchPaybuttonById (paybuttonId: string): Promise<PaybuttonWithAddresses | null> {
   return await prisma.paybutton.findUnique({
-    where: { id: Number(paybuttonId) },
+    where: { id: paybuttonId },
     include: includeAddresses
   })
 }
@@ -132,7 +132,7 @@ export async function fetchPaybuttonArrayByUserId (userId: string): Promise<Payb
   })
 }
 
-export async function updatePaybutton (paybuttonId: number, params: UpdatePaybuttonInput): Promise<PaybuttonWithAddresses> {
+export async function updatePaybutton (paybuttonId: string, params: UpdatePaybuttonInput): Promise<PaybuttonWithAddresses> {
   const updateData: Prisma.PaybuttonUpdateInput = {}
   if (params.name !== undefined && params.name !== '') {
     updateData.name = params.name

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -280,7 +280,7 @@ describe('PATCH /api/paybutton/', () => {
     expect(responseData.message).toBe(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message)
   })
   it('Should fail for non non-existent button', async () => {
-    if (baseRequestOptions.query != null) baseRequestOptions.query.id = 9128371987912
+    if (baseRequestOptions.query != null) baseRequestOptions.query.id = 'nonexistent-uuid'
     baseRequestOptions.body = {
       name: 'some-different-name',
       addresses: undefined
@@ -1120,7 +1120,7 @@ describe('DELETE /api/paybutton/[id]', () => {
   })
 
   it('Fail to delete non-existent paybutton', async () => {
-    if (baseRequestOptions.query != null) baseRequestOptions.query.id = 999999
+    if (baseRequestOptions.query != null) baseRequestOptions.query.id = 'nonexistent-uuid'
     const res = await testEndpoint(baseRequestOptions, paybuttonIdEndpoint)
     const responseData = res._getJSONData()
     expect(res.statusCode).toBe(404)

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -66,7 +66,6 @@ describe('POST /api/paybutton/', () => {
     expect(responseData.providerUserId).toBe('test-u-id')
     expect(responseData.name).toBe('test-paybutton')
     expect(responseData.buttonData).toBe('{"somefield":"somevalue"}')
-    expect(responseData.uuid).not.toBeNull()
     expect(responseData.addresses).toEqual(
       expect.arrayContaining([
         {
@@ -225,7 +224,6 @@ describe('PATCH /api/paybutton/', () => {
     expect(res.statusCode).toBe(200)
     expect(responseData.providerUserId).toBe('test-u-id')
     expect(responseData.name).toBe('blablabla')
-    expect(responseData.uuid).not.toBeNull()
     expect(responseData.addresses).toEqual(
       expect.arrayContaining([
         {
@@ -347,7 +345,6 @@ describe('GET /api/paybuttons/', () => {
     expect(responseData[0]).toHaveProperty('providerUserId')
     expect(responseData[0]).toHaveProperty('name')
     expect(responseData[0]).toHaveProperty('buttonData')
-    expect(responseData[0]).toHaveProperty('uuid')
   })
 
   it('Get no paybuttons for unknown user', async () => {
@@ -1071,7 +1068,6 @@ describe('GET /api/paybutton/[id]', () => {
       expect(responseData).toHaveProperty('providerUserId')
       expect(responseData).toHaveProperty('name')
       expect(responseData).toHaveProperty('buttonData')
-      expect(responseData).toHaveProperty('uuid')
     }
   })
 
@@ -1121,7 +1117,6 @@ describe('DELETE /api/paybutton/[id]', () => {
     expect(responseData).toHaveProperty('providerUserId')
     expect(responseData).toHaveProperty('name')
     expect(responseData).toHaveProperty('buttonData')
-    expect(responseData).toHaveProperty('uuid')
   })
 
   it('Fail to delete non-existent paybutton', async () => {

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -1032,7 +1032,7 @@ describe('GET /api/paybutton/[id]', () => {
   // Create 4 paybuttons, 3 for one user and 1 for another.
   const userA = 'test-u-id'
   const userB = 'test-other-u-id'
-  let createdPaybuttonsIds: number[]
+  let createdPaybuttonsIds: string[]
   beforeAll(async () => {
     await clearPaybuttonsAndAddresses()
     createdPaybuttonsIds = []
@@ -1075,9 +1075,8 @@ describe('GET /api/paybutton/[id]', () => {
     }
   })
 
-  it('Not find paybutton for next id', async () => {
-    const nextId = createdPaybuttonsIds[createdPaybuttonsIds.length - 1] + 1
-    if (baseRequestOptions.query != null) baseRequestOptions.query.id = nextId
+  it('Not find paybutton for nonexistent id', async () => {
+    if (baseRequestOptions.query != null) baseRequestOptions.query.id = 'nonexistent-uuid'
     const res = await testEndpoint(baseRequestOptions, paybuttonIdEndpoint)
     expect(res.statusCode).toBe(404)
     const responseData = res._getJSONData()
@@ -1089,7 +1088,7 @@ describe('DELETE /api/paybutton/[id]', () => {
   // Create 4 paybuttons, 3 for one user and 1 for another.
   const userA = 'test-u-id'
   const userB = 'test-other-u-id'
-  let createdPaybuttonsIds: number[]
+  let createdPaybuttonsIds: string[]
   beforeAll(async () => {
     await clearPaybuttonsAndAddresses()
     createdPaybuttonsIds = []

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -11,11 +11,10 @@ import { WalletWithAddressesWithPaybuttons } from 'services/walletService'
 import { USD_QUOTE_ID, CAD_QUOTE_ID, XEC_NETWORK_ID, NETWORK_SLUGS } from 'constants/index'
 
 export const mockedPaybutton: PaybuttonWithAddresses = {
-  id: 4,
+  id: '730bfa24-eb57-11ec-b722-0242ac150002',
   providerUserId: 'mocked-uid',
   name: 'mocked-name',
   buttonData: 'mockedData',
-  uuid: '730bfa24-eb57-11ec-b722-0242ac150002',
   createdAt: new Date('2022-05-27T15:18:42.000Z'),
   updatedAt: new Date('2022-05-27T15:18:42.000Z'),
   addresses: [
@@ -49,7 +48,7 @@ export const mockedBCHAddress = {
   updatedAt: new Date('2022-05-27T15:18:42.000Z'),
   networkId: 2,
   lastSynced: null,
-  paybuttonId: 1,
+  paybuttonId: 'bfe90894-b1f4-11ed-b556-0242ac120003',
   walletId: null
 }
 
@@ -60,7 +59,7 @@ export const mockedXECAddress = {
   updatedAt: new Date('2022-05-27T15:18:42.000Z'),
   lastSynced: null,
   networkId: 1,
-  paybuttonId: 1,
+  paybuttonId: 'bfe90894-b1f4-11ed-b556-0242ac120003',
   walletId: null
 }
 
@@ -79,14 +78,13 @@ export const mockedAddressesOnUserProfile = {
     lastSynced: new Date('2022-05-27T15:18:42.000Z'),
     paybuttons: [
       {
-        paybuttonId: 1,
+        paybuttonId: 'bfe90894-b1f4-11ed-b556-0242ac120003',
         addressId: 1,
         createdAt: new Date('2022-05-27T15:18:42.000Z'),
         updatedAt: new Date('2022-05-27T15:18:42.000Z'),
         paybutton: {
-          id: 1,
+          id: 'bfe90894-b1f4-11ed-b556-0242ac120003',
           name: 'Mocked Paybutton 1',
-          uuid: 'bfe90894-b1f4-11ed-b556-0242ac120003',
           buttonData: '{"example": "value"}',
           providerUserId: 'dev-uid',
           createdAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -94,14 +92,13 @@ export const mockedAddressesOnUserProfile = {
         }
       },
       {
-        paybuttonId: 3,
+        paybuttonId: 'bfe92acd-b1f4-11ed-b556-0242ac120003',
         addressId: 1,
         createdAt: new Date('2022-05-27T15:18:42.000Z'),
         updatedAt: new Date('2022-05-27T15:18:42.000Z'),
         paybutton: {
-          id: 3,
+          id: 'bfe92acd-b1f4-11ed-b556-0242ac120003',
           name: 'Mocked Paybutton 2',
-          uuid: 'bfe92acd-b1f4-11ed-b556-0242ac120003',
           buttonData: '{}',
           providerUserId: 'dev-uid',
           createdAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -153,11 +150,10 @@ export const mockedAddressList = [
 
 export const mockedPaybuttonList = [
   {
-    id: 1,
+    id: '730bfa24-eb57-11ec-b722-0242ac150002',
     providerUserId: 'mocked-uid',
     name: 'mocked-name-1',
     buttonData: 'mockedData',
-    uuid: '730bfa24-eb57-11ec-b722-0242ac150002',
     createdAt: new Date('2022-05-27T15:18:42.000Z'),
     updatedAt: new Date('2022-05-27T15:18:42.000Z'),
     addresses: [
@@ -170,11 +166,10 @@ export const mockedPaybuttonList = [
     ]
   },
   {
-    id: 2,
+    id: '133fb8aa-eb57-11ec-b722-0242ac150002',
     providerUserId: 'mocked-uid',
     name: 'mocked-name-2',
     buttonData: 'mockedData',
-    uuid: '133fb8aa-eb57-11ec-b722-0242ac150002',
     createdAt: new Date('2022-05-27T15:18:42.000Z'),
     updatedAt: new Date('2022-05-27T15:18:42.000Z'),
     addresses: [
@@ -227,14 +222,13 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
         lastSynced: new Date('2022-05-27T15:18:42.000Z'),
         paybuttons: [
           {
-            paybuttonId: 1,
+            paybuttonId: 'bfe90894-b1f4-11ed-b556-0242ac120003',
             addressId: 1,
             createdAt: new Date('2022-05-27T15:18:42.000Z'),
             updatedAt: new Date('2022-05-27T15:18:42.000Z'),
             paybutton: {
-              id: 1,
+              id: 'bfe90894-b1f4-11ed-b556-0242ac120003',
               name: 'Mocked Paybutton 1',
-              uuid: 'bfe90894-b1f4-11ed-b556-0242ac120003',
               buttonData: '{"example": "value"}',
               providerUserId: 'dev-uid',
               createdAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -242,14 +236,13 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
             }
           },
           {
-            paybuttonId: 3,
+            paybuttonId: 'bfe92acd-b1f4-11ed-b556-0242ac120003',
             addressId: 1,
             createdAt: new Date('2022-05-27T15:18:42.000Z'),
             updatedAt: new Date('2022-05-27T15:18:42.000Z'),
             paybutton: {
-              id: 3,
+              id: 'bfe92acd-b1f4-11ed-b556-0242ac120003',
               name: 'Mocked Paybutton 2',
-              uuid: 'bfe92acd-b1f4-11ed-b556-0242ac120003',
               buttonData: '{}',
               providerUserId: 'dev-uid',
               createdAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -274,14 +267,13 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
         lastSynced: new Date('2022-05-27T15:18:42.000Z'),
         paybuttons: [
           {
-            paybuttonId: 2,
+            paybuttonId: 'bfe90b48-b1f4-11ed-b556-0242ac120003',
             addressId: 2,
             createdAt: new Date('2022-05-27T15:18:42.000Z'),
             updatedAt: new Date('2022-05-27T15:18:42.000Z'),
             paybutton: {
-              id: 2,
+              id: 'bfe90b48-b1f4-11ed-b556-0242ac120003',
               name: 'Mocked Paybutton 3',
-              uuid: 'bfe90b48-b1f4-11ed-b556-0242ac120003',
               buttonData: '{}',
               providerUserId: 'dev-uid',
               createdAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -289,14 +281,13 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
             }
           },
           {
-            paybuttonId: 3,
+            paybuttonId: 'bfe92acd-b1f4-11ed-b556-0242ac120003',
             addressId: 2,
             createdAt: new Date('2022-05-27T15:18:42.000Z'),
             updatedAt: new Date('2022-05-27T15:18:42.000Z'),
             paybutton: {
-              id: 3,
+              id: 'bfe92acd-b1f4-11ed-b556-0242ac120003',
               name: 'Mocked Paybutton 4',
-              uuid: 'bfe92acd-b1f4-11ed-b556-0242ac120003',
               buttonData: '{}',
               providerUserId: 'dev-uid',
               createdAt: new Date('2022-05-27T15:18:42.000Z'),

--- a/tests/unittests/paybuttonService.test.ts
+++ b/tests/unittests/paybuttonService.test.ts
@@ -8,7 +8,7 @@ describe('Fetch services', () => {
     prismaMock.paybutton.findUnique.mockResolvedValue(mockedPaybutton)
     prisma.paybutton.findUnique = prismaMock.paybutton.findUnique
 
-    const result = await paybuttonService.fetchPaybuttonById(4)
+    const result = await paybuttonService.fetchPaybuttonById(mockedPaybutton.id)
     expect(result).toEqual(mockedPaybutton)
   })
 
@@ -59,7 +59,7 @@ describe('Delete services', () => {
 
     const deletePaybuttonInput = {
       userId: 'mocked-uid',
-      paybuttonId: 3
+      paybuttonId: 'mocked-uuid'
     }
     const result = await paybuttonService.deletePaybutton(deletePaybuttonInput)
     expect(result).toEqual(mockedPaybutton)
@@ -87,7 +87,7 @@ describe('Update services', () => {
       name: 'mocked-name',
       prefixedAddressList: ['mockednetwork:mockaddress']
     }
-    const result = await paybuttonService.updatePaybutton(1, updatePaybuttonInput)
+    const result = await paybuttonService.updatePaybutton('mocked-uuid', updatePaybuttonInput)
     expect(result).toEqual(mockedPaybutton)
   })
 })


### PR DESCRIPTION
Description:
Part of #264. Paybuttons already had an `uuid` field, this makes so that it is now the `id` field.

Test plan:
All related to paybuttons should work normally: deleting, creating, modifying, the dashboard...

Nothing should change for the end user except for the fact that the paybutton detail URL shows some UUID instead of some integer.