### PR TITLE
[Issue #264] feat: use UUID on wallets

### DIFF
--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -40,7 +40,7 @@ export default function EditWalletForm ({ wallet, userAddresses, refreshWalletLi
     }
   }
 
-  async function onDelete (walletId: number): Promise<void> {
+  async function onDelete (walletId: string): Promise<void> {
     const res = await axios.delete<WalletWithAddressesWithPaybuttons>(`${appInfo.websiteDomain}/api/wallet/${walletId}`)
     if (res.status === 200) {
       refreshWalletList()

--- a/pages/api/wallet/[id].ts
+++ b/pages/api/wallet/[id].ts
@@ -28,7 +28,7 @@ export default async (
       const params = req.body
       params.userId = userId
       const updateWalletInput = parseWalletPATCHRequest(params)
-      const wallet = await walletService.updateWallet(Number(walletId), updateWalletInput)
+      const wallet = await walletService.updateWallet(walletId, updateWalletInput)
       res.status(200).json(wallet)
     } catch (err: any) {
       const parsedError = parseError(err)

--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -63,7 +63,7 @@ CREATE TABLE `Transaction` (
 
 -- CreateTable
 CREATE TABLE `Wallet` (
-    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `id` VARCHAR(191) NOT NULL DEFAULT (uuid()),
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
     `name` VARCHAR(255) NOT NULL,
@@ -86,7 +86,7 @@ CREATE TABLE `UserProfile` (
 
 -- CreateTable
 CREATE TABLE `WalletsOnUserProfile` (
-    `walletId` INTEGER NOT NULL,
+    `walletId` VARCHAR(191) NOT NULL,
     `userProfileId` INTEGER NOT NULL,
     `isXECDefault` BOOLEAN NULL,
     `isBCHDefault` BOOLEAN NULL,
@@ -140,7 +140,7 @@ CREATE TABLE `Quote` (
 CREATE TABLE `AddressesOnUserProfiles` (
     `addressId` INTEGER NOT NULL,
     `userProfileId` INTEGER NOT NULL,
-    `walletId` INTEGER NULL,
+    `walletId` VARCHAR(191) NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,7 +75,7 @@ model Transaction {
 }
 
 model Wallet {
-  id             Int                   @id @default(autoincrement())
+  id             String                @id @default(dbgenerated("(uuid())"))
   createdAt      DateTime              @default(now())
   updatedAt      DateTime              @updatedAt
   name           String                @db.VarChar(255)
@@ -125,7 +125,7 @@ model PricesOnTransactions {
 model AddressesOnUserProfiles {
   addressId     Int
   userProfileId Int
-  walletId      Int?
+  walletId      String?
   createdAt     DateTime     @default(now())
   updatedAt     DateTime     @updatedAt
   address       Address      @relation(fields: [addressId], references: [id], onDelete: Cascade)
@@ -136,7 +136,7 @@ model AddressesOnUserProfiles {
 }
 
 model WalletsOnUserProfile {
-  walletId      Int         @unique
+  walletId      String      @unique
   userProfileId Int
   isXECDefault  Boolean?
   isBCHDefault  Boolean?

--- a/prisma/seeds/addressUserConnectors.ts
+++ b/prisma/seeds/addressUserConnectors.ts
@@ -1,21 +1,21 @@
 export const addressUserConnectors = [
   {
-    walletId: 1,
+    walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
     addressId: 1,
     userProfileId: 1
   },
   {
-    walletId: 1,
+    walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
     addressId: 2,
     userProfileId: 1
   },
   {
-    walletId: 2,
+    walletId: '408093c4-2eff-4b35-a0c5-c369220ca236',
     addressId: 3,
     userProfileId: 1
   },
   {
-    walletId: 3,
+    walletId: 'ed9b656f-3fb0-4563-af9a-e6ad536c609d',
     addressId: 4,
     userProfileId: 1
   }

--- a/prisma/seeds/walletUserConnectors.ts
+++ b/prisma/seeds/walletUserConnectors.ts
@@ -1,26 +1,26 @@
 export const walletUserConnectors = [
   {
-    walletId: 1,
+    walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
     userProfileId: 1,
     isBCHDefault: true,
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
-    walletId: 2,
+    walletId: '408093c4-2eff-4b35-a0c5-c369220ca236',
     userProfileId: 1,
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
-    walletId: 3,
+    walletId: 'ed9b656f-3fb0-4563-af9a-e6ad536c609d',
     userProfileId: 1,
     isXECDefault: true,
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
-    walletId: 4,
+    walletId: 'db14e515-ede8-4949-b20a-a450f9171f77',
     userProfileId: 2,
     isXECDefault: true,
     isBCHDefault: true,

--- a/prisma/seeds/wallets.ts
+++ b/prisma/seeds/wallets.ts
@@ -1,27 +1,27 @@
 export const wallets = [
   {
-    id: 1,
+    id: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
     createdAt: new Date(),
     updatedAt: new Date(),
     name: 'My Wallet',
     providerUserId: 'dev-uid'
   },
   {
-    id: 2,
+    id: '408093c4-2eff-4b35-a0c5-c369220ca236',
     createdAt: new Date(),
     updatedAt: new Date(),
     name: 'Foo Wallet',
     providerUserId: 'dev-uid'
   },
   {
-    id: 3,
+    id: 'ed9b656f-3fb0-4563-af9a-e6ad536c609d',
     createdAt: new Date(),
     updatedAt: new Date(),
     name: 'Bar Wallet',
     providerUserId: 'dev-uid'
   },
   {
-    id: 4,
+    id: 'db14e515-ede8-4949-b20a-a450f9171f77',
     createdAt: new Date(),
     updatedAt: new Date(),
     name: 'Default Wallet',

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -12,7 +12,7 @@ export interface UpdatePaybuttonInput {
 
 export interface CreatePaybuttonInput {
   userId: string
-  walletId?: number
+  walletId?: string
   name: string
   buttonData: string
   prefixedAddressList: string[]

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -21,7 +21,7 @@ export interface UpdateWalletInput {
 
 export interface DeleteWalletInput {
   userId: string
-  walletId: number | string
+  walletId: string
 }
 
 const includeAddressesWithPaybuttons = {
@@ -188,7 +188,7 @@ export async function createDefaultWalletForUser (userId: string): Promise<Walle
   return wallet
 }
 
-export async function fetchWalletById (walletId: number | string): Promise<WalletWithAddressesWithPaybuttons> {
+export async function fetchWalletById (walletId: string): Promise<WalletWithAddressesWithPaybuttons> {
   const wallet = await prisma.wallet.findUnique({
     where: { id: Number(walletId) },
     include: includeAddressesWithPaybuttons

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -147,7 +147,7 @@ export async function setAddressListForWallet (
 
 export async function createWallet (values: CreateWalletInput): Promise<WalletWithAddressesWithPaybuttons> {
   const defaultForNetworkIds = getDefaultForNetworkIds(values.isXECDefault, values.isBCHDefault)
-  const newWalletId: number = await prisma.$transaction(async (prisma) => {
+  const newWalletId: string = await prisma.$transaction(async (prisma) => {
     const w = await prisma.wallet.create({
       data: {
         providerUserId: values.userId,
@@ -190,7 +190,7 @@ export async function createDefaultWalletForUser (userId: string): Promise<Walle
 
 export async function fetchWalletById (walletId: string): Promise<WalletWithAddressesWithPaybuttons> {
   const wallet = await prisma.wallet.findUnique({
-    where: { id: Number(walletId) },
+    where: { id: walletId },
     include: includeAddressesWithPaybuttons
   })
   if (wallet === null) {
@@ -282,7 +282,7 @@ export async function setDefaultWallet (wallet: WalletWithAddressesWithPaybutton
   return wallet
 }
 
-export async function updateWallet (walletId: number, params: UpdateWalletInput): Promise<WalletWithAddressesWithPaybuttons> {
+export async function updateWallet (walletId: string, params: UpdateWalletInput): Promise<WalletWithAddressesWithPaybuttons> {
   const wallet = await fetchWalletById(walletId)
 
   if (wallet.userProfile === null) {
@@ -379,7 +379,7 @@ export async function moveAddressesToDefaultWallet (wallet: WalletWithAddressesW
   const BCHDefaultWallet = await getUserDefaultWalletForNetworkId(wallet.userProfile?.userProfileId, BCH_NETWORK_ID)
   for (const addr of wallet.userAddresses) {
     // Get id of default wallet to move
-    let defaultWalletId: number
+    let defaultWalletId: string
     if (addr.address.networkId === BCH_NETWORK_ID) {
       defaultWalletId = BCHDefaultWallet.id
     } else if (addr.address.networkId === XEC_NETWORK_ID) {
@@ -414,7 +414,7 @@ export async function deleteWallet (params: DeleteWalletInput): Promise<WalletWi
     await moveAddressesToDefaultWallet(wallet)
     const w = await prisma.wallet.delete({
       where: {
-        id: Number(params.walletId)
+        id: params.walletId
       },
       include: includeAddressesWithPaybuttons
     })

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -55,7 +55,7 @@ describe('POST /api/paybutton/', () => {
       addresses: `${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`,
       name: 'test-paybutton',
       buttonData: '{"somefield":"somevalue"}',
-      walletId: '1'
+      walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978'
     }
   }
 
@@ -88,7 +88,7 @@ describe('POST /api/paybutton/', () => {
   it('Create a paybutton empty JSON for buttonData', async () => {
     baseRequestOptions.body = {
       name: 'test-paybutton-no-button-data',
-      walletId: '1',
+      walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
       addresses: `ectest:${exampleAddresses.ectest}`
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)
@@ -125,7 +125,7 @@ describe('POST /api/paybutton/', () => {
     baseRequestOptions.body = {
       userId: 'test-u-id',
       name: 'test-paybutton',
-      walletId: '1',
+      walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
       addresses: `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonEndpoint)
@@ -696,7 +696,7 @@ describe('GET /api/wallets/', () => {
 
 describe('GET /api/wallet/[id]', () => {
   // Create 4 wallets
-  let createdWalletsIds: number[]
+  let createdWalletsIds: string[]
   beforeAll(async () => {
     await clearPaybuttonsAndAddresses()
     await clearWallets()
@@ -730,9 +730,8 @@ describe('GET /api/wallet/[id]', () => {
     }
   })
 
-  it('Not find wallet for next id', async () => {
-    const nextId = createdWalletsIds[createdWalletsIds.length - 1] + 1
-    if (baseRequestOptions.query != null) baseRequestOptions.query.id = nextId
+  it('Not find wallet for unknown id', async () => {
+    if (baseRequestOptions.query != null) baseRequestOptions.query.id = 'mockeduuid-does-not-exist'
     const res = await testEndpoint(baseRequestOptions, walletIdEndpoint)
     expect(res.statusCode).toBe(404)
     const responseData = res._getJSONData()
@@ -1003,7 +1002,7 @@ describe('DELETE /api/wallet/[id]', () => {
   })
 
   it('Fail for inexistent wallet', async () => {
-    if (baseRequestOptions.query != null) baseRequestOptions.query.id = 129837129873
+    if (baseRequestOptions.query != null) baseRequestOptions.query.id = 'mockeduuid-does-not-exist'
     const res = await testEndpoint(baseRequestOptions, walletIdEndpoint)
     const responseData = res._getJSONData()
     expect(res.statusCode).toBe(404)

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -66,7 +66,7 @@ export const mockedXECAddress = {
 export const mockedAddressesOnUserProfile = {
   addressId: 1,
   userProfileId: 1,
-  walletId: 8,
+  walletId: '570fbb7e-fc7f-4096-8541-e68405cf9b56',
   createdAt: new Date('2022-05-27T15:18:42.000Z'),
   updatedAt: new Date('2022-05-27T15:18:42.000Z'),
   address: {
@@ -196,7 +196,7 @@ mockedBCHAddressWithPaybutton.paybuttons = [
 
 // Wallet
 export const mockedWallet: WalletWithAddressesWithPaybuttons = {
-  id: 1,
+  id: '0da1977f-d65b-43a7-a7c8-b2a1f01da7a0',
   createdAt: new Date('2022-09-30T18:01:32.456Z'),
   updatedAt: new Date('2022-09-30T18:01:32.456Z'),
   name: 'mockedWallet',
@@ -210,7 +210,7 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
     {
       addressId: 1,
       userProfileId: 1,
-      walletId: 8,
+      walletId: '570fbb7e-fc7f-4096-8541-e68405cf9b56',
       createdAt: new Date('2022-05-27T15:18:42.000Z'),
       updatedAt: new Date('2022-05-27T15:18:42.000Z'),
       address: {
@@ -255,7 +255,7 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
     {
       addressId: 2,
       userProfileId: 1,
-      walletId: 1,
+      walletId: '0da1977f-d65b-43a7-a7c8-b2a1f01da7a0',
       createdAt: new Date('2022-05-27T15:18:42.000Z'),
       updatedAt: new Date('2022-05-27T15:18:42.000Z'),
       address: {
@@ -302,7 +302,7 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
 
 export const mockedWalletList = [
   {
-    id: 1,
+    id: '0da1977f-d65b-43a7-a7c8-b2a1f01da7a0',
     createdAt: new Date('2022-09-30T18:01:32.456Z'),
     updatedAt: new Date('2022-09-30T18:01:32.456Z'),
     name: 'mockedWallet',
@@ -310,7 +310,7 @@ export const mockedWalletList = [
     userAddresses: []
   },
   {
-    id: 2,
+    id: '1f79bbe4-1c56-48af-b703-b22efd629104',
     createdAt: new Date('2022-09-30T18:01:32.456Z'),
     updatedAt: new Date('2022-09-30T18:01:32.456Z'),
     name: 'mockedWallet2',
@@ -320,7 +320,7 @@ export const mockedWalletList = [
 ]
 
 export const mockedWalletsOnUserProfile = {
-  walletId: 1,
+  walletId: '1f79bbe4-1c56-48af-b703-b22efd629104',
   userProfileId: 1,
   isXECDefault: null,
   isBCHDefault: null,
@@ -366,7 +366,7 @@ export const mockedTransaction = {
     createdAt: new Date('2022-11-02T15:18:42.000Z'),
     updatedAt: new Date('2022-11-02T15:18:42.000Z'),
     networkId: 1,
-    walletId: 1
+    walletId: '0da1977f-d65b-43a7-a7c8-b2a1f01da7a0'
   },
   amount: new Prisma.Decimal('4.31247724'),
   timestamp: 1657130467,

--- a/tests/unittests/walletService.test.ts
+++ b/tests/unittests/walletService.test.ts
@@ -34,7 +34,7 @@ describe('Fetch services', () => {
     prismaMock.wallet.findUnique.mockResolvedValue(mockedWallet)
     prisma.wallet.findUnique = prismaMock.wallet.findUnique
 
-    const result = await walletService.fetchWalletById(4)
+    const result = await walletService.fetchWalletById(mockedWallet.id)
     expect(result).toEqual(mockedWallet)
   })
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -31,7 +31,7 @@ export const createWalletForUser = async (userId: string, addressIdList: number[
   return await createWallet({ userId, name, addressIdList, isXECDefault, isBCHDefault })
 }
 
-export const createPaybuttonForUser = async (userId: string, addressList?: string[], walletId?: number): Promise<PaybuttonWithAddresses> => {
+export const createPaybuttonForUser = async (userId: string, addressList?: string[], walletId?: string): Promise<PaybuttonWithAddresses> => {
   let prefixedAddressList = [
     'bitcoincash:' + addressRandexp.gen(),
     'ecash:' + addressRandexp.gen()

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -96,7 +96,7 @@ export const parsePaybuttonPOSTRequest = function (params: PaybuttonPOSTParamete
   if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
   if (params.addresses === '' || params.addresses === undefined) throw new Error(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
-  const walletId: number | undefined = Number(params.walletId)
+  const walletId: string | undefined = params.walletId
   if (params.walletId === '' || params.walletId === undefined) {
     throw new Error(RESPONSE_MESSAGES.WALLET_ID_NOT_PROVIDED_400.message)
   }


### PR DESCRIPTION
Description:
Part of #264.Uses UUID on wallets instead of autoincrementing ids.

Test plan:
First run `make reset-dev`. Then all related to wallets should work normally: deleting, creating, modifying, creating a paybutton setting it to a wallet...
