### PR TITLE
 [Issue #264] feat: use UUID on userProfile 

### DIFF
--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -75,7 +75,7 @@ CREATE TABLE `Wallet` (
 
 -- CreateTable
 CREATE TABLE `UserProfile` (
-    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `id` VARCHAR(191) NOT NULL DEFAULT (uuid()),
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
     `userId` VARCHAR(255) NOT NULL,
@@ -87,7 +87,7 @@ CREATE TABLE `UserProfile` (
 -- CreateTable
 CREATE TABLE `WalletsOnUserProfile` (
     `walletId` VARCHAR(191) NOT NULL,
-    `userProfileId` INTEGER NOT NULL,
+    `userProfileId` VARCHAR(191) NOT NULL,
     `isXECDefault` BOOLEAN NULL,
     `isBCHDefault` BOOLEAN NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
@@ -139,7 +139,7 @@ CREATE TABLE `Quote` (
 -- CreateTable
 CREATE TABLE `AddressesOnUserProfiles` (
     `addressId` INTEGER NOT NULL,
-    `userProfileId` INTEGER NOT NULL,
+    `userProfileId` VARCHAR(191) NOT NULL,
     `walletId` VARCHAR(191) NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,7 +124,7 @@ model PricesOnTransactions {
 
 model AddressesOnUserProfiles {
   addressId     Int
-  userProfileId Int
+  userProfileId String
   walletId      String?
   createdAt     DateTime     @default(now())
   updatedAt     DateTime     @updatedAt
@@ -137,7 +137,7 @@ model AddressesOnUserProfiles {
 
 model WalletsOnUserProfile {
   walletId      String      @unique
-  userProfileId Int
+  userProfileId String
   isXECDefault  Boolean?
   isBCHDefault  Boolean?
   createdAt     DateTime    @default(now())
@@ -151,7 +151,7 @@ model WalletsOnUserProfile {
 }
 
 model UserProfile {
-  id        Int                    @id @default(autoincrement())
+  id        String                 @id @default(dbgenerated("(uuid())"))
   createdAt DateTime               @default(now())
   updatedAt DateTime               @updatedAt
   userId    String                 @unique @db.VarChar(255)

--- a/prisma/seeds/addressUserConnectors.ts
+++ b/prisma/seeds/addressUserConnectors.ts
@@ -2,21 +2,21 @@ export const addressUserConnectors = [
   {
     walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
     addressId: 1,
-    userProfileId: 1
+    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25'
   },
   {
     walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
     addressId: 2,
-    userProfileId: 1
+    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25'
   },
   {
     walletId: '408093c4-2eff-4b35-a0c5-c369220ca236',
     addressId: 3,
-    userProfileId: 1
+    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25'
   },
   {
     walletId: 'ed9b656f-3fb0-4563-af9a-e6ad536c609d',
     addressId: 4,
-    userProfileId: 1
+    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25'
   }
 ]

--- a/prisma/seeds/devUser.ts
+++ b/prisma/seeds/devUser.ts
@@ -12,13 +12,13 @@ export const createDevUserRawQueryList = [
 
 export const userProfiles = [
   {
-    id: 1,
+    id: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25',
     userId: 'dev-uid',
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
-    id: 2,
+    id: '2f51c061-9c5a-48b9-8212-98a8a6c079df',
     userId: 'dev2-uid',
     createdAt: new Date(),
     updatedAt: new Date()

--- a/prisma/seeds/walletUserConnectors.ts
+++ b/prisma/seeds/walletUserConnectors.ts
@@ -1,27 +1,27 @@
 export const walletUserConnectors = [
   {
     walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
-    userProfileId: 1,
+    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25',
     isBCHDefault: true,
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
     walletId: '408093c4-2eff-4b35-a0c5-c369220ca236',
-    userProfileId: 1,
+    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25',
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
     walletId: 'ed9b656f-3fb0-4563-af9a-e6ad536c609d',
-    userProfileId: 1,
+    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25',
     isXECDefault: true,
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
     walletId: 'db14e515-ede8-4949-b20a-a450f9171f77',
-    userProfileId: 2,
+    userProfileId: '2f51c061-9c5a-48b9-8212-98a8a6c079df',
     isXECDefault: true,
     isBCHDefault: true,
     createdAt: new Date(),

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -341,7 +341,7 @@ export async function getWalletBalance (wallet: WalletWithAddressesWithPaybutton
   return ret
 }
 
-export async function getUserDefaultWalletForNetworkId (userProfileId: number, networkId: number): Promise<WalletWithAddressesWithPaybuttons> {
+export async function getUserDefaultWalletForNetworkId (userProfileId: string, networkId: number): Promise<WalletWithAddressesWithPaybuttons> {
   let userWalletProfile: WalletsOnUserProfile | null
   if (networkId === BCH_NETWORK_ID) {
     userWalletProfile = await prisma.walletsOnUserProfile.findUnique({

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -510,7 +510,7 @@ describe('POST /api/wallets/', () => {
     expect(responseData.userProfile).toStrictEqual({
       isXECDefault: null,
       isBCHDefault: null,
-      userProfileId: 3
+      userProfileId: expect.any(String)
     })
     void expect(countWallets()).resolves.toBe(1)
   })
@@ -567,7 +567,7 @@ describe('POST /api/wallets/', () => {
     expect(responseData.userProfile).toStrictEqual({
       isXECDefault: null,
       isBCHDefault: null,
-      userProfileId: 3
+      userProfileId: expect.any(String)
     })
     expect(responseData.userAddresses).toEqual(
       expect.arrayContaining([expectedAddressObject])
@@ -589,7 +589,7 @@ describe('POST /api/wallets/', () => {
     expect(responseData.userProfile).toStrictEqual({
       isXECDefault: null,
       isBCHDefault: null,
-      userProfileId: 3
+      userProfileId: expect.any(String)
     })
     expect(responseData.userAddresses).toEqual(
       expect.arrayContaining([expectedAddressObject])

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -65,7 +65,7 @@ export const mockedXECAddress = {
 
 export const mockedAddressesOnUserProfile = {
   addressId: 1,
-  userProfileId: 1,
+  userProfileId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
   walletId: '570fbb7e-fc7f-4096-8541-e68405cf9b56',
   createdAt: new Date('2022-05-27T15:18:42.000Z'),
   updatedAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -204,12 +204,12 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
   userProfile: {
     isXECDefault: null,
     isBCHDefault: null,
-    userProfileId: 1
+    userProfileId: 'ddde6236-bde3-425f-b0fc-13a007cc584b'
   },
   userAddresses: [
     {
       addressId: 1,
-      userProfileId: 1,
+      userProfileId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
       walletId: '570fbb7e-fc7f-4096-8541-e68405cf9b56',
       createdAt: new Date('2022-05-27T15:18:42.000Z'),
       updatedAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -254,7 +254,7 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
     },
     {
       addressId: 2,
-      userProfileId: 1,
+      userProfileId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
       walletId: '0da1977f-d65b-43a7-a7c8-b2a1f01da7a0',
       createdAt: new Date('2022-05-27T15:18:42.000Z'),
       updatedAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -321,7 +321,7 @@ export const mockedWalletList = [
 
 export const mockedWalletsOnUserProfile = {
   walletId: '1f79bbe4-1c56-48af-b703-b22efd629104',
-  userProfileId: 1,
+  userProfileId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
   isXECDefault: null,
   isBCHDefault: null,
   createdAt: new Date('2022-05-27T15:18:42.000Z'),


### PR DESCRIPTION
Description:
Part of #264. Uses UUID on `UserProfile` instead of autoincrementing ids.

Test plan:
Run `make reset-dev`. Nothing should effectively change.


Depends on:
- [x] #452 