### PR TITLE
[Issue #264] fix: create transaction input

### DIFF
--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -7,7 +7,7 @@ import * as transactionService from 'services/transactionService'
 import * as priceService from 'services/priceService'
 import * as addressService from 'services/addressService'
 import { GrpcBlockchainClient } from 'services/grpcService'
-import { Transaction as TransactionGrpc } from 'grpc-bchrpc-node'
+import { Transaction } from 'grpc-bchrpc-node'
 import { getAddressPrefix } from 'utils'
 
 const syncAndSubscribeAddressList = async (addressList: Address[]): Promise<void> => {
@@ -23,11 +23,11 @@ const syncAndSubscribeAddressList = async (addressList: Address[]): Promise<void
   addressList.map(async (addr) => {
     await grpc.subscribeTransactions(
       [addr.address],
-      async (txn: TransactionGrpc.AsObject) => {
+      async (txn: Transaction.AsObject) => {
         const transactionPrisma = await grpc.getTransactionFromGrpcTransaction(txn, addr, true)
         await transactionService.upsertTransaction(transactionPrisma, addr)
       },
-      async (txn: TransactionGrpc.AsObject) => {
+      async (txn: Transaction.AsObject) => {
         const transactionPrisma = await grpc.getTransactionFromGrpcTransaction(txn, addr, false)
         await transactionService.upsertTransaction(transactionPrisma, addr)
       },

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -7,7 +7,7 @@ import * as transactionService from 'services/transactionService'
 import * as priceService from 'services/priceService'
 import * as addressService from 'services/addressService'
 import { GrpcBlockchainClient } from 'services/grpcService'
-import { Transaction } from 'grpc-bchrpc-node'
+import { Transaction as TransactionGrpc } from 'grpc-bchrpc-node'
 import { getAddressPrefix } from 'utils'
 
 const syncAndSubscribeAddressList = async (addressList: Address[]): Promise<void> => {
@@ -23,12 +23,12 @@ const syncAndSubscribeAddressList = async (addressList: Address[]): Promise<void
   addressList.map(async (addr) => {
     await grpc.subscribeTransactions(
       [addr.address],
-      async (txn: Transaction.AsObject) => {
-        const transactionPrisma = await grpc.getTransactionPrismaFromTransaction(txn, addr.address, true)
+      async (txn: TransactionGrpc.AsObject) => {
+        const transactionPrisma = await grpc.getTransactionFromGrpcTransaction(txn, addr, true)
         await transactionService.upsertTransaction(transactionPrisma, addr)
       },
-      async (txn: Transaction.AsObject) => {
-        const transactionPrisma = await grpc.getTransactionPrismaFromTransaction(txn, addr.address, false)
+      async (txn: TransactionGrpc.AsObject) => {
+        const transactionPrisma = await grpc.getTransactionFromGrpcTransaction(txn, addr, false)
         await transactionService.upsertTransaction(transactionPrisma, addr)
       },
       getAddressPrefix(addr.address)

--- a/prisma/seeds/prices.ts
+++ b/prisma/seeds/prices.ts
@@ -15,16 +15,16 @@ interface PriceFileData extends KeyValueT<string> {
   priceInUSD: string
 }
 
+const writeFile = promisify(fs.writeFile)
+
 export const PATH_PRICE_CSV_FILE = path.join('prisma', 'seeds', 'prices.csv')
 
-async function writeToFile (fileName: string, content: PriceFileData[]): Promise<void> {
-  const writeFile = promisify(fs.writeFile)
-
+async function writePricesToFile (content: PriceFileData[]): Promise<void> {
   const headers = ['ticker', 'date', 'priceInCAD', 'priceInUSD']
   const rows = content.map(({ ticker, date, priceInCAD, priceInUSD }) => [ticker, date, priceInCAD, priceInUSD])
   const csv = [headers, ...rows].map(row => row.join(',')).join('\n')
 
-  await writeFile(fileName, csv, 'utf8')
+  await writeFile(PATH_PRICE_CSV_FILE, csv, 'utf8')
 }
 
 export async function createPricesFile (): Promise<void> {
@@ -54,7 +54,7 @@ export async function createPricesFile (): Promise<void> {
     if (a.date > b.date) return 1
     return 0
   })
-  await writeToFile(PATH_PRICE_CSV_FILE, prices)
+  await writePricesToFile(prices)
 
   const finish = moment()
   console.log(`\n\nstart: ${start.format('HH:mm:ss')}\nfinish: ${finish.format('HH:mm:ss')}\nduration: ${(finish.diff(start) / 1000).toFixed(2)} seconds`)

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -10,7 +10,7 @@ import {
 import { BlockchainClient, BlockchainInfo, BlockInfo, GetAddressTransactionsParameters } from './blockchainService'
 import { getObjectValueForNetworkSlug, getObjectValueForAddress, satoshisToUnit, pubkeyToAddress, removeAddressPrefix } from '../utils/index'
 import { BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N, KeyValueT, RESPONSE_MESSAGES, XEC_NETWORK_ID, XEC_TIMESTAMP_THRESHOLD } from '../constants/index'
-import { Address, Prisma, Transaction } from '@prisma/client'
+import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { fetchAddressBySubstring } from './addressService'
 import { TransactionWithAddressAndPrices, upsertManyTransactionsForAddress } from './transactionService'
@@ -102,13 +102,12 @@ export class GrpcBlockchainClient implements BlockchainClient {
   }
 
   // WIP: this should be private in the future
-  public async getTransactionFromGrpcTransaction (transaction: GrpcTransaction.AsObject, address: Address, confirmed: boolean): Promise<Transaction> {
+  public async getTransactionFromGrpcTransaction (transaction: GrpcTransaction.AsObject, address: Address, confirmed: boolean): Promise<Prisma.TransactionUncheckedCreateInput> {
     return {
       hash: transaction.hash as string,
       amount: await this.getTransactionAmount(transaction, address.address),
       timestamp: transaction.timestamp,
       addressId: address.id,
-      id: 0,
       confirmed
     }
   }

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -102,12 +102,12 @@ export class GrpcBlockchainClient implements BlockchainClient {
   }
 
   // WIP: this should be private in the future
-  public async getTransactionFromGrpcTransaction (transaction: GrpcTransaction.AsObject, addressString: Address, confirmed: boolean): Promise<Transaction> {
+  public async getTransactionFromGrpcTransaction (transaction: GrpcTransaction.AsObject, address: Address, confirmed: boolean): Promise<Transaction> {
     return {
       hash: transaction.hash as string,
-      amount: await this.getTransactionAmount(transaction, addressString),
+      amount: await this.getTransactionAmount(transaction, address.address),
       timestamp: transaction.timestamp,
-      addressId: 0,
+      addressId: address.id,
       id: 0,
       confirmed
     }

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -1,5 +1,5 @@
 import prisma from 'prisma/clientInstance'
-import { Prisma, Address, Transaction } from '@prisma/client'
+import { Prisma, Address } from '@prisma/client'
 import { syncTransactionsAndPricesForAddress, GetAddressTransactionsParameters } from 'services/blockchainService'
 import { parseAddress } from 'utils/validators'
 import { fetchAddressBySubstring, updateLastSynced } from 'services/addressService'
@@ -72,7 +72,7 @@ export async function base64HashToHex (base64Hash: string): Promise<string> {
   )
 }
 
-export async function upsertTransaction (transaction: Transaction, address: Address): Promise<TransactionWithAddressAndPrices | undefined> {
+export async function upsertTransaction (transaction: Prisma.TransactionUncheckedCreateInput, address: Address): Promise<TransactionWithAddressAndPrices | undefined> {
   if (transaction.amount === new Prisma.Decimal(0)) { // out transactions
     return
   }
@@ -97,7 +97,7 @@ export async function upsertTransaction (transaction: Transaction, address: Addr
   })
 }
 
-export async function upsertManyTransactionsForAddress (transactions: Transaction[], address: Address): Promise<TransactionWithAddressAndPrices[]> {
+export async function upsertManyTransactionsForAddress (transactions: Prisma.TransactionUncheckedCreateInput[], address: Address): Promise<TransactionWithAddressAndPrices[]> {
   const ret = await prisma.$transaction(async (_) => {
     const insertedTransactions: Array<TransactionWithAddressAndPrices | undefined> = await Promise.all(
       transactions.map(async (transaction) => {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -1,5 +1,5 @@
 import prisma from 'prisma/clientInstance'
-import { Prisma, Address, Transaction as TransactionPrisma } from '@prisma/client'
+import { Prisma, Address, Transaction } from '@prisma/client'
 import { syncTransactionsAndPricesForAddress, GetAddressTransactionsParameters } from 'services/blockchainService'
 import { parseAddress } from 'utils/validators'
 import { fetchAddressBySubstring, updateLastSynced } from 'services/addressService'
@@ -72,7 +72,7 @@ export async function base64HashToHex (base64Hash: string): Promise<string> {
   )
 }
 
-export async function upsertTransaction (transaction: TransactionPrisma, address: Address): Promise<TransactionWithAddressAndPrices | undefined> {
+export async function upsertTransaction (transaction: Transaction, address: Address): Promise<TransactionWithAddressAndPrices | undefined> {
   if (transaction.amount === new Prisma.Decimal(0)) { // out transactions
     return
   }
@@ -97,7 +97,7 @@ export async function upsertTransaction (transaction: TransactionPrisma, address
   })
 }
 
-export async function upsertManyTransactionsForAddress (transactions: TransactionPrisma[], address: Address): Promise<TransactionWithAddressAndPrices[]> {
+export async function upsertManyTransactionsForAddress (transactions: Transaction[], address: Address): Promise<TransactionWithAddressAndPrices[]> {
   const ret = await prisma.$transaction(async (_) => {
     const insertedTransactions: Array<TransactionWithAddressAndPrices | undefined> = await Promise.all(
       transactions.map(async (transaction) => {


### PR DESCRIPTION
Description
---
Some functions that deal with the creation of `Transaction` objects were being expected to receive the type of a `Transaction`, as a row inserted in the database as input. This is not accurate because that type contains an `id` field, that we don't know yet.

Besides that, the `addressId` was set to be a hardcoded 0, which I don't understand why but don't think is correct, since we are going to connect that transaction with some address upon its creation.

Test plan
---
For what I observed, the initial sync of transactions in master is broken again, only for XEC though. Makes this hard to test for improvements right now.

Remarks
---
Associated to # 264 because this is necessary for both the Transaction & Address remodeling of increment number ids to UUIDs.