### PR TITLE
[Issue #248] feat: dedicated redis db to bullmq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 
 jobs/out.log
 /prisma/seeds/prices.csv
+redis/dump.rdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,5 +55,5 @@ services:
       - 6379:6379
     volumes:
       - ./redis:/data/redis:z
-    # dump the dataset each 20 seconds if there was at least 1 change
-    command: sh -c "umask 000 && redis-server /data/redis/redis.conf --loglevel warning"
+      - ./scripts:/data/scripts
+    command: sh ./scripts/redis-start.sh

--- a/jobs/initJobs.ts
+++ b/jobs/initJobs.ts
@@ -1,6 +1,6 @@
 import { XEC_NETWORK_ID, BCH_NETWORK_ID, CURRENT_PRICE_SYNC_DELAY } from 'constants/index'
 import { Queue, FlowProducer } from 'bullmq'
-import { redis } from 'redis/clientInstance'
+import { redisBullMQ } from 'redis/clientInstance'
 import {
   syncAllAddressTransactionsForNetworkWorker,
   syncPricesWorker,
@@ -9,16 +9,16 @@ import {
 
 const main = async (): Promise<void> => {
   // sync all db addresses transactions
-  const initTransactionsSync = new Queue('initTransactionsSync', { connection: redis })
+  const initTransactionsSync = new Queue('initTransactionsSync', { connection: redisBullMQ })
 
   // sync current prices
-  const pricesSync = new Queue('pricesSync', { connection: redis })
+  const pricesSync = new Queue('pricesSync', { connection: redisBullMQ })
 
   // try to sync new addresses periodically
-  const newAddressesSync = new Queue('newAddressesSync', { connection: redis })
+  const newAddressesSync = new Queue('newAddressesSync', { connection: redisBullMQ })
 
   // create flow
-  const flowProducer = new FlowProducer({ connection: redis })
+  const flowProducer = new FlowProducer({ connection: redisBullMQ })
 
   await flowProducer.add({
     name: 'syncUnsyncedAddresses',

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -1,6 +1,6 @@
 import { Worker, Job, Queue } from 'bullmq'
 import { Address } from '@prisma/client'
-import { redis } from 'redis/clientInstance'
+import { redisBullMQ } from 'redis/clientInstance'
 import { SYNC_NEW_ADDRESSES_DELAY, DEFAULT_WORKER_LOCK_DURATION } from 'constants/index'
 
 import * as transactionService from 'services/transactionService'
@@ -51,7 +51,7 @@ export const syncAllAddressTransactionsForNetworkWorker = async (queueName: stri
     queueName,
     syncAllAddressTransactionsForNetworkJob,
     {
-      connection: redis,
+      connection: redisBullMQ,
       lockDuration: DEFAULT_WORKER_LOCK_DURATION
     }
   )
@@ -83,7 +83,7 @@ export const syncPricesWorker = async (queueName: string): Promise<void> => {
       }
     },
     {
-      connection: redis,
+      connection: redisBullMQ,
       lockDuration: DEFAULT_WORKER_LOCK_DURATION
     }
   )
@@ -117,7 +117,7 @@ export const syncUnsyncedAddressesWorker = async (queue: Queue): Promise<void> =
       )
     },
     {
-      connection: redis,
+      connection: redisBullMQ,
       lockDuration: DEFAULT_WORKER_LOCK_DURATION
     }
   )

--- a/redis/clientInstance.ts
+++ b/redis/clientInstance.ts
@@ -5,4 +5,10 @@ export const redis = new IORedis(appInfo.redisURL, {
   maxRetriesPerRequest: null
 })
 
+export const redisBullMQ = new IORedis(appInfo.redisURL, {
+  maxRetriesPerRequest: null,
+  db: 1
+})
+
 redis.on('error', (err) => console.log('Redis Client Error', err))
+redisBullMQ.on('error', (err) => console.log('Redis BullMQ Client Error', err))

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -1,2 +1,8 @@
+databases 2
+
 dir redis/
-save ""
+dbfilename dump.rdb
+
+save 600 1
+save 60 10
+save 6 100

--- a/scripts/docker-exec-shortcuts.sh
+++ b/scripts/docker-exec-shortcuts.sh
@@ -46,10 +46,11 @@ case "$command" in
         ;;
     "jobsstop" | "js")
         eval "$base_command_node" tmux kill-session -t initJobs && echo Jobs stoped. || echo No jobs running.
+        yarn docker cbr && echo Cleaned jobs cache.
         ;;
     "jobsrestart" | "jr")
-        eval "$base_command_node" tmux kill-session -t initJobs && echo Jobs stoped, restarting... || echo No jobs running, starting...
-        yarn docker cbr
+        yarn docker js
+        echo "Starting jobs..."
         eval "$base_command_node" sh ./scripts/init-jobs.sh
         ;;
     "yarn" | "y")

--- a/scripts/docker-exec-shortcuts.sh
+++ b/scripts/docker-exec-shortcuts.sh
@@ -49,7 +49,7 @@ case "$command" in
         ;;
     "jobsrestart" | "jr")
         eval "$base_command_node" tmux kill-session -t initJobs && echo Jobs stoped, restarting... || echo No jobs running, starting...
-        yarn docker cr
+        yarn docker cbr
         eval "$base_command_node" sh ./scripts/init-jobs.sh
         ;;
     "yarn" | "y")
@@ -85,6 +85,9 @@ case "$command" in
     "cache" | "c")
         eval "$base_command_cache" redis-cli
         ;;
+    "cachebullmqreset" | "cbr")
+        eval "$base_command_cache" redis-cli -n 1 FLUSHDB
+        ;;
     "cachereset" | "cr")
         eval "$base_command_cache" redis-cli FLUSHALL
         ;;
@@ -117,6 +120,7 @@ case "$command" in
         echo "  c, cache                    [$cache_container_name]   enter the redis command-line interface"
         echo "  cs, cacheshell              [$node_container_name]     enter the redis container"
         echo "  cr, cachereset              [$node_container_name]     clear the redis cache"
+        echo "  cbr, cachebullmqreset       [$node_container_name]     clear the bullMQ redis database"
         echo "  jw, jobswatch               [$node_container_name]     watch jobs logs"
         echo "  js, jobsstop                [$node_container_name]     stop jobs"
         echo "  jr, jobsrestart             [$node_container_name]     restart jobs"

--- a/scripts/redis-start.sh
+++ b/scripts/redis-start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+umask 000 || exit 1
+redis-cli -n 1 FLUSHDB || echo "No redis database of index 1 (BullMQ database) to flush"
+redis-server /data/redis/redis.conf --loglevel warning || exit 1


### PR DESCRIPTION
Description
---
Create a dedicated redis DB to bullMQ. This way, when caching the dashboard data, they don't get mixed up.

Test plan
---
1. Reset the containers with `make reset-dev`.
2. See if the jobs are being normally executed with `yd jw` or peeking into the `jobs/out.log` file
3. Reset the jobs with `yd jr` and make sure they all run again.

Also, you can enter the redis command-line with `yd c`, then:
1. Running `KEYS *` should return nothing,
2. Running `SELECT 1` and `KEYS *` should return the keys related to bullmq.

Depends on
---
- [x] #459 