### PR TITLE
[Issue #248] refactor: update payments cache deps

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -42,7 +42,8 @@ export const RESPONSE_MESSAGES = {
   NO_BLOCKCHAIN_CLIENT_INSTANTIATED_400: { statusCode: 400, message: 'Blockchain client was not instantiated.' },
   DEFAULT_WALLET_CANNOT_BE_DELETED_400: { statusCode: 400, message: 'A default wallet cannot be deleted.' },
   USER_PROFILE_NOT_FOUND_400: { statusCode: 400, message: 'User profile not found.' },
-  CACHED_PAYMENT_NOT_FOUND_404: { statusCode: 404, message: 'Cached payment not found.' }
+  CACHED_PAYMENT_NOT_FOUND_404: { statusCode: 404, message: 'Cached payment not found.' },
+  NO_ADDRESS_FOUND_FOR_TRANSACTION_404: { statusCode: 404, message: 'No address found for transaction.' }
 }
 
 export interface KeyValueT<T> {

--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -5,7 +5,7 @@ import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 import { Prisma } from '@prisma/client'
 import moment, { DurationInputArg2 } from 'moment'
 import { setSession } from 'utils/setSession'
-import { ChartData, PeriodData, DashboardData, Payment, cachePayments, userHasCachedPayments, getCachedPayments } from 'redis/dashboardCache'
+import { ChartData, PeriodData, DashboardData, Payment, cachePayments, userHasCachedPayments, getCachedPayments, getPaymentsFromTransactionsAndButtons } from 'redis/dashboardCache'
 
 interface AllMonths {
   months: number
@@ -99,48 +99,12 @@ const generatePaymentList = async (userId: string, buttons: paybuttonService.Pay
   const XECTransactions = await transactionService.fetchAddressListTransactions(XECAddressIds)
   const BCHTransactions = await transactionService.fetchAddressListTransactions(BCHAddressIds)
 
-  const paymentList: Payment[] = []
-  for (const t of BCHTransactions) {
-    const BCHValue = (await transactionService.getTransactionValue(t)).usd
-    paymentList.push({
-      timestamp: t.timestamp,
-      value: BCHValue,
-      networkId: t.address.networkId,
-      hash: t.hash,
-      buttonDisplayDataList: buttons.filter(button => button.addresses.some(add => add.address.id === t.addressId)).map(
-        (b) => {
-          return {
-            name: b.name,
-            id: b.id
-          }
-        }
-      )
-
-    })
-  }
-  for (const t of XECTransactions) {
-    const XECValue = (await transactionService.getTransactionValue(t)).usd
-    paymentList.push({
-      timestamp: t.timestamp,
-      value: XECValue,
-      networkId: t.address.networkId,
-      hash: t.hash,
-      buttonDisplayDataList: buttons.filter(button => button.addresses.some(add => add.address.id === t.addressId)).map(
-        (b) => {
-          return {
-            name: b.name,
-            id: b.id
-          }
-        }
-      )
-    })
-  }
-
-  const ret = paymentList.filter((p) => p.value > new Prisma.Decimal(0))
+  let paymentList = await getPaymentsFromTransactionsAndButtons(BCHTransactions, buttons)
+  paymentList = paymentList.concat(await getPaymentsFromTransactionsAndButtons(XECTransactions, buttons))
   // save on cache
-  await cachePayments(userId, ret)
+  await cachePayments(userId, paymentList)
 
-  return ret
+  return paymentList
 }
 
 const getPaymentList = async (userId: string, buttons: paybuttonService.PaybuttonWithAddresses[]): Promise<Payment[]> => {

--- a/pages/api/dashboard/index.ts
+++ b/pages/api/dashboard/index.ts
@@ -5,7 +5,7 @@ import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 import { Prisma } from '@prisma/client'
 import moment, { DurationInputArg2 } from 'moment'
 import { setSession } from 'utils/setSession'
-import { ChartData, PeriodData, DashboardData, Payment, cachePayments, userHasCachedPayments, getCachedPayments, getPaymentsFromTransactionsAndButtons } from 'redis/dashboardCache'
+import { ChartData, PeriodData, DashboardData, Payment, cachePayments, userHasCachedPayments, getCachedPayments, getPaymentsFromTransactionsAndAddresses } from 'redis/dashboardCache'
 
 interface AllMonths {
   months: number
@@ -99,8 +99,8 @@ const generatePaymentList = async (userId: string): Promise<Payment[]> => {
   const XECTransactions = await transactionService.fetchAddressListTransactions(XECAddressIds)
   const BCHTransactions = await transactionService.fetchAddressListTransactions(BCHAddressIds)
 
-  let paymentList = await getPaymentsFromTransactionsAndButtons(BCHTransactions, addresses)
-  paymentList = paymentList.concat(await getPaymentsFromTransactionsAndButtons(XECTransactions, addresses))
+  let paymentList = await getPaymentsFromTransactionsAndAddresses(BCHTransactions, addresses)
+  paymentList = paymentList.concat(await getPaymentsFromTransactionsAndAddresses(XECTransactions, addresses))
   // save on cache
   await cachePayments(userId, paymentList)
 

--- a/redis/dashboardCache.ts
+++ b/redis/dashboardCache.ts
@@ -63,12 +63,12 @@ const getCachedWeekKeys = async (userId: string): Promise<string[]> => {
 export const getPaymentsFromTransactionsAndAddresses = async (transactionList: TransactionWithAddressAndPrices[], addresses: AddressWithPaybuttons[]): Promise<Payment[]> => {
   const paymentList: Payment[] = []
   for (const t of transactionList) {
-    const XECValue = (await getTransactionValue(t)).usd
+    const value = (await getTransactionValue(t)).usd
     const txAddress = addresses.find(addr => addr.id === t.addressId)
     if (txAddress === undefined) throw new Error(RESPONSE_MESSAGES.NO_ADDRESS_FOUND_FOR_TRANSACTION_404.message)
     paymentList.push({
       timestamp: t.timestamp,
-      value: XECValue,
+      value,
       networkId: t.address.networkId,
       hash: t.hash,
       buttonDisplayDataList: txAddress.paybuttons.map(

--- a/redis/dashboardCache.ts
+++ b/redis/dashboardCache.ts
@@ -60,7 +60,7 @@ const getCachedWeekKeys = async (userId: string): Promise<string[]> => {
   return await redis.keys(`${userId}:payment:*`)
 }
 
-export const getPaymentsFromTransactionsAndButtons = async (transactionList: TransactionWithAddressAndPrices[], addresses: AddressWithPaybuttons[]): Promise<Payment[]> => {
+export const getPaymentsFromTransactionsAndAddresses = async (transactionList: TransactionWithAddressAndPrices[], addresses: AddressWithPaybuttons[]): Promise<Payment[]> => {
   const paymentList: Payment[] = []
   for (const t of transactionList) {
     const XECValue = (await getTransactionValue(t)).usd

--- a/scripts/docker-exec-shortcuts.sh
+++ b/scripts/docker-exec-shortcuts.sh
@@ -86,6 +86,9 @@ case "$command" in
     "cache" | "c")
         eval "$base_command_cache" redis-cli
         ;;
+    "cachemainreset" | "cmr")
+        eval "$base_command_cache" redis-cli -n 0 FLUSHDB
+        ;;
     "cachebullmqreset" | "cbr")
         eval "$base_command_cache" redis-cli -n 1 FLUSHDB
         ;;
@@ -120,7 +123,8 @@ case "$command" in
         echo "  pg, prismagenerate          [$node_container_name]     run \`prisma generate\` to generate client from scheme"
         echo "  c, cache                    [$cache_container_name]   enter the redis command-line interface"
         echo "  cs, cacheshell              [$node_container_name]     enter the redis container"
-        echo "  cr, cachereset              [$node_container_name]     clear the redis cache"
+        echo "  cr, cachereset              [$node_container_name]     clear the whole redis cache"
+        echo "  cmr, cachemainreset         [$node_container_name]     clear the main redis cache"
         echo "  cbr, cachebullmqreset       [$node_container_name]     clear the bullMQ redis database"
         echo "  jw, jobswatch               [$node_container_name]     watch jobs logs"
         echo "  js, jobsstop                [$node_container_name]     stop jobs"

--- a/services/addressService.ts
+++ b/services/addressService.ts
@@ -4,14 +4,15 @@ import { RESPONSE_MESSAGES } from 'constants/index'
 import { fetchAddressTransactions } from 'services/transactionService'
 import { getNetworkFromSlug } from 'services/networkService'
 
-const addressFullType = Prisma.validator<Prisma.AddressArgs>()({
+const addressWithTransactionAndNetwork = Prisma.validator<Prisma.AddressArgs>()({
   include: { transactions: true, network: true }
 })
-type AddressWithTransactionsAndNetwork = Prisma.AddressGetPayload<typeof addressFullType>
+type AddressWithTransactionsAndNetwork = Prisma.AddressGetPayload<typeof addressWithTransactionAndNetwork>
 
 const addressWithTransactions = Prisma.validator<Prisma.AddressArgs>()({
   include: { transactions: true }
 })
+
 type AddressWithTransactions = Prisma.AddressGetPayload<typeof addressWithTransactions>
 
 export const includePaybuttonsNested = {
@@ -43,6 +44,12 @@ export function includeUserPaybuttonsNested (userId: string): Prisma.AddressIncl
 
 export type AddressWithPaybuttons = Prisma.AddressGetPayload<typeof addressWithPaybuttons>
 
+const addressWithTransactionsAndPaybuttons = Prisma.validator<Prisma.AddressArgs>()({
+  include: { transactions: true, paybuttons: includePaybuttonsNested.paybuttons }
+})
+
+export type AddressWithTransactionsAndPaybuttons = Prisma.AddressGetPayload<typeof addressWithTransactionsAndPaybuttons>
+
 export async function fetchAddressBySubstring (substring: string): Promise<AddressWithTransactionsAndNetwork> {
   const results = await prisma.address.findMany({
     where: {
@@ -73,7 +80,11 @@ export async function addressExistsBySubstring (substring: string): Promise<bool
   return true
 }
 
-export async function fetchAllUserAddresses (userId: string, includeTransactions = false, includePaybuttons = false): Promise<AddressWithTransactions[]> {
+export async function fetchAllUserAddresses (userId: string, includeTransactions = false, includePaybuttons = false): Promise<
+Address[]
+| AddressWithTransactions[]
+| AddressWithPaybuttons[]
+| AddressWithTransactionsAndPaybuttons[]> {
   return await prisma.address.findMany({
     where: {
       paybuttons: {


### PR DESCRIPTION
Description
---
Refactors dashboard code in order to make updating the `Payment`s cache possible.

Test plan
---
The dashboard & payments views should work just as they did in master. Reset the cache with `yd cmr` to make sure it's building also works.
