### PR TITLE
Feat/411 5 1 get utxos and get balance

### DIFF
--- a/services/blockchainService.ts
+++ b/services/blockchainService.ts
@@ -4,8 +4,7 @@ import { getObjectValueForAddress, getObjectValueForNetworkSlug } from '../utils
 import { RESPONSE_MESSAGES, KeyValueT, NETWORK_BLOCKCHAIN_CLIENTS, BLOCKCHAIN_CLIENT_OPTIONS } from '../constants/index'
 import {
   Transaction,
-  GetTransactionResponse,
-  GetAddressUnspentOutputsResponse
+  GetTransactionResponse
 } from 'grpc-bchrpc-node'
 import { TransactionWithAddressAndPrices } from './transactionService'
 
@@ -27,7 +26,6 @@ export interface GetAddressTransactionsParameters {
 export interface BlockchainClient {
   getBalance: (address: string) => Promise<number>
   syncTransactionsAndPricesForAddress: (parameters: GetAddressTransactionsParameters) => Promise<TransactionWithAddressAndPrices[]>
-  getUtxos: (address: string) => Promise<GetAddressUnspentOutputsResponse.AsObject>
   getBlockchainInfo: (networkSlug: string) => Promise<BlockchainInfo>
   getBlockInfo: (networkSlug: string, height: number) => Promise<BlockInfo>
   getTransactionDetails: (hash: string, networkSlug: string) => Promise<GetTransactionResponse.AsObject>
@@ -63,10 +61,6 @@ export async function getBalance (address: string): Promise<number> {
 
 export async function syncTransactionsAndPricesForAddress (parameters: GetAddressTransactionsParameters): Promise<TransactionWithAddressAndPrices[]> {
   return await getObjectValueForAddress(parameters.addressString, BLOCKCHAIN_CLIENTS).syncTransactionsAndPricesForAddress(parameters)
-}
-
-export async function getUtxos (address: string): Promise<GetAddressUnspentOutputsResponse.AsObject> {
-  return await getObjectValueForAddress(address, BLOCKCHAIN_CLIENTS).getUtxos(address)
 }
 
 export async function getBlockchainInfo (networkSlug: string): Promise<BlockchainInfo> {

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -90,7 +90,8 @@ export class ChronikBlockchainClient implements BlockchainClient {
       const { type, hash160 } = toHash160(address.address)
       let transactions = (await this.chronik.script(type, hash160).history(page, pageSize)).txs
 
-      // remove transactions older than the networks
+      // filter out transactions that happened before a certain date set in constants/index,
+      //   this date is understood as the beginning and we don't look past it
       transactions = transactions.filter(this.txThesholdFilter(address))
 
       if (transactions.length === 0) break

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -1,8 +1,8 @@
-import { ChronikClient, ScriptType, Tx } from 'chronik-client'
+import { ChronikClient, ScriptType, Tx, Utxo } from 'chronik-client'
 import { encode, decode } from 'ecashaddrjs'
 import bs58 from 'bs58'
 import { BlockchainClient, BlockchainInfo, BlockInfo, GetAddressTransactionsParameters } from './blockchainService'
-import { GetAddressUnspentOutputsResponse, GetTransactionResponse, Transaction } from 'grpc-bchrpc-node'
+import { GetTransactionResponse, Transaction } from 'grpc-bchrpc-node'
 import { NETWORK_SLUGS, RESPONSE_MESSAGES, CHRONIK_CLIENT_URL, XEC_TIMESTAMP_THRESHOLD, XEC_NETWORK_ID, BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N } from 'constants/index'
 import { TransactionWithAddressAndPrices, upsertManyTransactionsForAddress } from './transactionService'
 import { Address, Prisma } from '@prisma/client'
@@ -119,8 +119,15 @@ export class ChronikBlockchainClient implements BlockchainClient {
     return insertedTransactions
   }
 
-  async getUtxos (address: string): Promise<GetAddressUnspentOutputsResponse.AsObject> {
-    throw new Error('Method not implemented.')
+  private async getUtxos (address: string): Promise<Utxo[]> {
+    const { type, hash160 } = toHash160(address)
+    const scriptsUtxos = await this.chronik.script(type, hash160).utxos()
+    return scriptsUtxos.reduce<Utxo[]>((acc, scriptUtxos) => [...acc, ...scriptUtxos.utxos], [])
+  }
+
+  public async getBalance (address: string): Promise<number> {
+    const utxos = await this.getUtxos(address)
+    return utxos.reduce((acc, utxo) => acc + parseInt(utxo.value), 0)
   }
 
   async getTransactionDetails (hash: string, networkSlug: string): Promise<GetTransactionResponse.AsObject> {
@@ -129,19 +136,6 @@ export class ChronikBlockchainClient implements BlockchainClient {
 
   async subscribeTransactions (addresses: string[], onTransactionNotification: (txn: Transaction.AsObject) => any, onMempoolTransactionNotification: (txn: Transaction.AsObject) => any, networkSlug: string): Promise<void> {
     throw new Error('Method not implemented.')
-  }
-
-  public async getBalance (address: string): Promise<number> {
-    const { type, hash160 } = toHash160(address)
-    const utxos = await this.chronik.script(type, hash160).utxos()
-
-    let totalSatoshis = 0
-    // we should always get only one element since we have only one hash above
-    if (utxos.length > 0) {
-      for (const u of utxos[0].utxos) { totalSatoshis += parseInt(u.value) }
-    }
-
-    return totalSatoshis
   }
 }
 

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -157,21 +157,15 @@ export class GrpcBlockchainClient implements BlockchainClient {
     return insertedTransactions
   };
 
-  public async getUtxos (address: string): Promise<GetAddressUnspentOutputsResponse.AsObject> {
+  private async getUtxos (address: string): Promise<GetAddressUnspentOutputsResponse.AsObject> {
     const client = this.getClientForAddress(address)
     const res = (await client.getAddressUtxos({ address })).toObject()
     return res
   };
 
   public async getBalance (address: string): Promise<number> {
-    const { outputsList } = await this.getUtxos(address)
-
-    let satoshis: number = 0
-    outputsList.forEach((x) => {
-      satoshis += x.value
-    })
-
-    return satoshis
+    const utxos = (await this.getUtxos(address)).outputsList
+    return utxos.reduce((acc, utxo) => acc + utxo.value, 0)
   };
 
   public async getTransactionDetails (hash: string, networkSlug: string): Promise<GetTransactionResponse.AsObject> {

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -166,8 +166,8 @@ export class GrpcBlockchainClient implements BlockchainClient {
   };
 
   public async getBalance (address: string): Promise<number> {
-    const utxos = (await this.getUtxos(address)).outputsList
-    return utxos.reduce((acc, utxo) => acc + utxo.value, 0)
+    const outputsList = (await this.getUtxos(address)).outputsList
+    return outputsList.reduce((acc, output) => acc + output.value, 0)
   };
 
   public async getTransactionDetails (hash: string, networkSlug: string): Promise<GetTransactionResponse.AsObject> {

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -129,9 +129,11 @@ export class GrpcBlockchainClient implements BlockchainClient {
 
       if (transactions.confirmedTransactionsList.length === 0 && transactions.unconfirmedTransactionsList.length === 0) break
 
-      // remove transactions older than the network
+      // filter out transactions that happened before a certain date set in constants/index,
+      //   this date is understood as the beginning and we don't look past it
       const confirmedTransactions = transactions.confirmedTransactionsList.filter(this.txThesholdFilter(address))
       const unconfirmedTransactions = transactions.unconfirmedTransactionsList.map(mempoolTx => this.parseMempoolTx(mempoolTx))
+
       totalFetchedConfirmedTransactions += confirmedTransactions.length
       page += 1
 

--- a/tests/unittests/grpcService.test.ts
+++ b/tests/unittests/grpcService.test.ts
@@ -1,5 +1,5 @@
-import { mockedBCHAddress, mockedXECAddress } from '../mockedObjects'
-import { getUtxos, getBalance, getTransactionDetails } from '../../services/blockchainService'
+import { mockedBCHAddress } from '../mockedObjects'
+import { getBalance, getTransactionDetails } from '../../services/blockchainService'
 import { NETWORK_SLUGS } from 'constants/index'
 
 describe('Test service returned objects consistency', () => {
@@ -15,32 +15,6 @@ describe('Test service returned objects consistency', () => {
     }))
   })
   */
-  it('test getUtxos', async () => {
-    const res = await getUtxos(mockedXECAddress.address)
-    expect(res).toEqual(expect.objectContaining({
-      outputsList: expect.arrayContaining([
-        {
-          outpoint: undefined,
-          pubkeyScript: 'dqkUYF1GSq6KqSQSKPbQtcOJWRBPEFaIrA==',
-          value: 547,
-          isCoinbase: false,
-          blockHeight: 684161
-        },
-        {
-          pubkeyScript: 'dqkUYF1GSq6KqSQSKPbQtcOJWRBPEFaIrA==',
-          value: 122,
-          isCoinbase: false,
-          blockHeight: 657711
-        },
-        expect.objectContaining({
-          pubkeyScript: 'dqkUYF1GSq6KqSQSKPbQtcOJWRBPEFaIrA==',
-          value: 1111,
-          isCoinbase: false,
-          blockHeight: 596627
-        })
-      ])
-    }))
-  })
   it('test getBalance', async () => {
     const res = await getBalance(mockedBCHAddress.address)
     expect(res).toBe(1780)


### PR DESCRIPTION
First review and merge #469, then merge master into this one, code to be reviewed will get a lot smaller.

--- Description:

- Implements chronik: `getUtxos` and `getBalance`
- Improves grpc: `getBalance`
- Makes private: `getUtxos`

The last point takes out `getUtxos` from the `blockchainService` interface which makes sense, normal people would never even want to know that this exists, it is used only to get the address' balance. For that same reason, testing of this method was removed, testing `getBalance` is sufficient to indirectly test this method.

--- Test plan

1. Change ’grpc’ to ‘chronik’ for XEC in constants/index.ts, like this:
export const NETWORK_BLOCKCHAIN_CLIENTS: KeyValueT<BLOCKCHAIN_CLIENT_OPTIONS> = {
  ecash: `'chronik'`,
  bitcoincash: 'grpc'
}
2. get balance for a XEC address: http://localhost:3000/api/address/balance/ecash:qp0kfg0uk64k4pa7tw226djx4v30attzzslrec0ypu
3. get balance for a BCH address: http://localhost:3000/api/address/balance/bitcoincash:qzqh7rwaq9zm4zcv40lh9c9u50gy07gcesdmja8426 