### PR TITLE
[Issue #264] feat: dont sync prices with transactions

### DIFF
--- a/jobs/initJobs.ts
+++ b/jobs/initJobs.ts
@@ -40,16 +40,6 @@ const main = async (): Promise<void> => {
     },
     children: [
       {
-        name: 'syncXECAddresses',
-        data: { networkId: XEC_NETWORK_ID },
-        opts: {
-          removeOnFail: false,
-          jobId: 'syncXECAddresses',
-          ...RETRY_OPTS
-        },
-        queueName: initTransactionsSync.name
-      },
-      {
         name: 'syncBCHAddresses',
         data: { networkId: BCH_NETWORK_ID },
         opts: {
@@ -57,7 +47,31 @@ const main = async (): Promise<void> => {
           jobId: 'syncBCHAddresses',
           ...RETRY_OPTS
         },
-        queueName: initTransactionsSync.name
+        queueName: initTransactionsSync.name,
+        children: [
+          {
+            name: 'syncXECAddresses',
+            data: { networkId: XEC_NETWORK_ID },
+            opts: {
+              removeOnFail: false,
+              jobId: 'syncXECAddresses',
+              ...RETRY_OPTS
+            },
+            queueName: initTransactionsSync.name,
+            children: [
+              {
+                name: 'syncPastPrices',
+                data: { syncType: 'past' },
+                opts: {
+                  removeOnFail: false,
+                  jobId: 'syncPastPrices',
+                  ...RETRY_OPTS
+                },
+                queueName: pricesSync.name
+              }
+            ]
+          }
+        ]
       }
     ]
   })
@@ -70,13 +84,6 @@ const main = async (): Promise<void> => {
       repeat: {
         every: CURRENT_PRICE_SYNC_DELAY
       }
-    }
-  )
-  await pricesSync.add('syncPastPrices',
-    { syncType: 'past' },
-    {
-      removeOnFail: false,
-      jobId: 'syncPastPrices'
     }
   )
 

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -23,7 +23,7 @@ const syncAndSubscribeAddressList = async (addressList: Address[]): Promise<void
   // sync addresses
   await Promise.all(
     addressList.map(async (addr) => {
-      await transactionService.syncAllTransactionsAndPricesForAddress(addr.address, Infinity)
+      await transactionService.syncAllTransactionsForAddress(addr.address, Infinity)
     })
   )
   // subscribe addresses

--- a/pages/api/address/transactions/[address].ts
+++ b/pages/api/address/transactions/[address].ts
@@ -1,7 +1,7 @@
 import { NextApiResponse, NextApiRequest } from 'next'
 import { parseAddress } from 'utils/validators'
 import { NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY, RESPONSE_MESSAGES } from 'constants/index'
-import { fetchAddressTransactions, syncAllTransactionsAndPricesForAddress } from 'services/transactionService'
+import { fetchAddressTransactions, syncAllTransactionsForAddress } from 'services/transactionService'
 import { upsertAddress, addressExistsBySubstring } from 'services/addressService'
 import Cors from 'cors'
 
@@ -43,7 +43,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
         if (serverOnly) throw new Error(NO_ADDRESS_FOUND_404.message)
 
         await upsertAddress(address)
-        await syncAllTransactionsAndPricesForAddress(address, NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
+        await syncAllTransactionsForAddress(address, NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
       }
       const transactions = await fetchAddressTransactions(address)
 

--- a/pages/api/address/transactions/sync/[address].ts
+++ b/pages/api/address/transactions/sync/[address].ts
@@ -1,7 +1,7 @@
 import { NextApiResponse, NextApiRequest } from 'next'
 import { parseAddress } from 'utils/validators'
 import { NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY, RESPONSE_MESSAGES } from 'constants/index'
-import { syncAllTransactionsAndPricesForAddress } from 'services/transactionService'
+import { syncAllTransactionsForAddress } from 'services/transactionService'
 import { upsertAddress } from 'services/addressService'
 import Cors from 'cors'
 
@@ -35,7 +35,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
       }
       const addressString = parseAddress(req.query.address as string)
       void await upsertAddress(addressString)
-      const transactions = await syncAllTransactionsAndPricesForAddress(addressString, NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
+      const transactions = await syncAllTransactionsForAddress(addressString, NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
       res.status(200).send(transactions)
     } catch (err: any) {
       switch (err.message) {

--- a/scripts/redis-start.sh
+++ b/scripts/redis-start.sh
@@ -3,7 +3,6 @@
 umask 000 || exit 1
 redis-server /data/redis/redis.conf --loglevel warning &
 # Wait for Redis to start
-#sleep 10
 while ! redis-cli ping > /dev/null 2>&1;
 do
   sleep 1

--- a/services/blockchainService.ts
+++ b/services/blockchainService.ts
@@ -25,7 +25,6 @@ export interface GetAddressTransactionsParameters {
 
 export interface BlockchainClient {
   getBalance: (address: string) => Promise<number>
-  syncTransactionsAndPricesForAddress: (parameters: GetAddressTransactionsParameters) => Promise<TransactionWithAddressAndPrices[]>
   syncTransactionsForAddress: (parameters: GetAddressTransactionsParameters) => Promise<TransactionWithAddressAndPrices[]>
   getBlockchainInfo: (networkSlug: string) => Promise<BlockchainInfo>
   getBlockInfo: (networkSlug: string, height: number) => Promise<BlockInfo>

--- a/services/blockchainService.ts
+++ b/services/blockchainService.ts
@@ -26,6 +26,7 @@ export interface GetAddressTransactionsParameters {
 export interface BlockchainClient {
   getBalance: (address: string) => Promise<number>
   syncTransactionsAndPricesForAddress: (parameters: GetAddressTransactionsParameters) => Promise<TransactionWithAddressAndPrices[]>
+  syncTransactionsForAddress: (parameters: GetAddressTransactionsParameters) => Promise<TransactionWithAddressAndPrices[]>
   getBlockchainInfo: (networkSlug: string) => Promise<BlockchainInfo>
   getBlockInfo: (networkSlug: string, height: number) => Promise<BlockInfo>
   getTransactionDetails: (hash: string, networkSlug: string) => Promise<GetTransactionResponse.AsObject>
@@ -59,8 +60,8 @@ export async function getBalance (address: string): Promise<number> {
   return await getObjectValueForAddress(address, BLOCKCHAIN_CLIENTS).getBalance(address)
 }
 
-export async function syncTransactionsAndPricesForAddress (parameters: GetAddressTransactionsParameters): Promise<TransactionWithAddressAndPrices[]> {
-  return await getObjectValueForAddress(parameters.addressString, BLOCKCHAIN_CLIENTS).syncTransactionsAndPricesForAddress(parameters)
+export async function syncTransactionsForAddress (parameters: GetAddressTransactionsParameters): Promise<TransactionWithAddressAndPrices[]> {
+  return await getObjectValueForAddress(parameters.addressString, BLOCKCHAIN_CLIENTS).syncTransactionsForAddress(parameters)
 }
 
 export async function getBlockchainInfo (networkSlug: string): Promise<BlockchainInfo> {

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -79,7 +79,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
     }
   }
 
-  public async syncTransactionsAndPricesForAddress (parameters: GetAddressTransactionsParameters): Promise<TransactionWithAddressAndPrices[]> {
+  public async syncTransactionsForAddress (parameters: GetAddressTransactionsParameters): Promise<TransactionWithAddressAndPrices[]> {
     const address = await fetchAddressBySubstring(parameters.addressString)
     const pageSize = FETCH_N
     let totalFetchedConfirmedTransactions = 0

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -14,7 +14,6 @@ import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { fetchAddressBySubstring } from './addressService'
 import { TransactionWithAddressAndPrices, upsertManyTransactionsForAddress } from './transactionService'
-import { syncPricesFromTransactionList } from './priceService'
 
 export interface OutputsList {
   outpoint: object
@@ -149,8 +148,9 @@ export class GrpcBlockchainClient implements BlockchainClient {
           unconfirmedTransactions.map(async tx => await this.getTransactionFromGrpcTransaction(tx, address, false))
         )
       ]
+      console.time('upserting transactions')
       const persistedTransactions = await upsertManyTransactionsForAddress(transactionsToPersist, address)
-      await syncPricesFromTransactionList(persistedTransactions)
+      console.timeEnd('upserting transactions')
       insertedTransactions = [...insertedTransactions, ...persistedTransactions]
 
       await new Promise(resolve => setTimeout(resolve, FETCH_DELAY))

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -111,7 +111,7 @@ export class GrpcBlockchainClient implements BlockchainClient {
     }
   }
 
-  public async syncTransactionsAndPricesForAddress (parameters: GetAddressTransactionsParameters): Promise<TransactionWithAddressAndPrices[]> {
+  public async syncTransactionsForAddress (parameters: GetAddressTransactionsParameters): Promise<TransactionWithAddressAndPrices[]> {
     const address = await fetchAddressBySubstring(parameters.addressString)
     const pageSize = FETCH_N
     let totalFetchedConfirmedTransactions = 0

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -1,6 +1,6 @@
 import prisma from 'prisma/clientInstance'
 import { Prisma, Address } from '@prisma/client'
-import { syncTransactionsAndPricesForAddress, GetAddressTransactionsParameters } from 'services/blockchainService'
+import { syncTransactionsForAddress, GetAddressTransactionsParameters } from 'services/blockchainService'
 import { parseAddress } from 'utils/validators'
 import { fetchAddressBySubstring, updateLastSynced } from 'services/addressService'
 import { QuoteValues } from 'services/priceService'
@@ -111,7 +111,7 @@ export async function upsertManyTransactionsForAddress (transactions: Prisma.Tra
   return ret.filter((t) => t !== undefined) as TransactionWithAddressAndPrices[]
 }
 
-export async function syncAllTransactionsAndPricesForAddress (addressString: string, maxTransactionsToReturn: number): Promise<TransactionWithAddressAndPrices[]> {
+export async function syncAllTransactionsForAddress (addressString: string, maxTransactionsToReturn: number): Promise<TransactionWithAddressAndPrices[]> {
   addressString = parseAddress(addressString)
   const parameters = {
     addressString,
@@ -119,7 +119,7 @@ export async function syncAllTransactionsAndPricesForAddress (addressString: str
     maxTransactionsToReturn
   }
 
-  const insertedTransactions: TransactionWithAddressAndPrices[] = await syncTransactionsAndPricesForAddress(parameters)
+  const insertedTransactions: TransactionWithAddressAndPrices[] = await syncTransactionsForAddress(parameters)
 
   if (parameters.maxTransactionsToReturn === Infinity || insertedTransactions.filter(t => t.confirmed).length < parameters.maxTransactionsToReturn) {
     await updateLastSynced(addressString)
@@ -129,7 +129,7 @@ export async function syncAllTransactionsAndPricesForAddress (addressString: str
       start: insertedTransactions.filter(t => t.confirmed).length,
       maxTransactionsToReturn: Infinity
     }
-    void syncTransactionsAndPricesForAddress(newParameters)
+    void syncTransactionsForAddress(newParameters)
   }
 
   return insertedTransactions


### PR DESCRIPTION
Description
---
Removes the syncing of prices together with transactions. The reasoning for this is that the syncing was causing significant overload when syncing the transactions, and it was unnecessary, since our code is already supposed to have all prices synced upon build.

Test plan
---
Rebuild the codebase, it should function just as before (tho now a bit faster)

Remarks
---
- Now we only sync the codebase transactions after ALL prices have been syncing,
- Left `console.time` on the code to time how long is it taking to upsert the transacitions into the DB. I've noticed it takes significantly longer in the BullMQ jobs then when using the API. When we get reasonable upsert prices, I'll take it off.

Depends on
---
- [x] #471 