### PR TITLE
Feat/411 5 3 hide get block info get blockchain info

### DIFF
--- a/services/blockchainService.ts
+++ b/services/blockchainService.ts
@@ -82,8 +82,8 @@ export async function syncTransactionsForAddress (parameters: GetAddressTransact
 
 export async function getLastBlockTimestamp (networkSlug: string): Promise<number> {
   const client = getObjectValueForNetworkSlug(networkSlug, BLOCKCHAIN_CLIENTS)
-  const getBlockchainInfo = await client.getBlockchainInfo(networkSlug)
-  const lastBlockInfo = await client.getBlockInfo(networkSlug, getBlockchainInfo.height)
+  const blockchainInfo = await client.getBlockchainInfo(networkSlug)
+  const lastBlockInfo = await client.getBlockInfo(networkSlug, blockchainInfo.height)
   return lastBlockInfo.timestamp
 }
 

--- a/services/blockchainService.ts
+++ b/services/blockchainService.ts
@@ -80,12 +80,11 @@ export async function syncTransactionsAndPricesForAddress (parameters: GetAddres
   return await getObjectValueForAddress(parameters.addressString, BLOCKCHAIN_CLIENTS).syncTransactionsAndPricesForAddress(parameters)
 }
 
-export async function getBlockchainInfo (networkSlug: string): Promise<BlockchainInfo> {
-  return await getObjectValueForNetworkSlug(networkSlug, BLOCKCHAIN_CLIENTS).getBlockchainInfo(networkSlug)
-}
-
-export async function getBlockInfo (networkSlug: string, height: number): Promise<BlockInfo> {
-  return await getObjectValueForNetworkSlug(networkSlug, BLOCKCHAIN_CLIENTS).getBlockInfo(networkSlug, height)
+export async function getLastBlockTimestamp (networkSlug: string): Promise<number> {
+  const client = getObjectValueForNetworkSlug(networkSlug, BLOCKCHAIN_CLIENTS)
+  const getBlockchainInfo = await client.getBlockchainInfo(networkSlug)
+  const lastBlockInfo = await client.getBlockInfo(networkSlug, getBlockchainInfo.height)
+  return lastBlockInfo.timestamp
 }
 
 export async function getTransactionDetails (hash: string, networkSlug: string): Promise<TransactionDetails> {

--- a/services/networkService.ts
+++ b/services/networkService.ts
@@ -1,7 +1,7 @@
 import { Network, Prisma } from '@prisma/client'
 import { RESPONSE_MESSAGES, NETWORK_SLUGS, NETWORK_IDS } from 'constants/index'
 import prisma from 'prisma/clientInstance'
-import { getBlockchainInfo, getBlockInfo } from 'services/blockchainService'
+import { getLastBlockTimestamp } from 'services/blockchainService'
 import { fetchAllUserAddresses } from 'services/addressService'
 
 export async function getNetworkFromSlug (slug: string): Promise<Network> {
@@ -19,12 +19,9 @@ export interface NetworkWithConnectionInfo extends Network, ConnectionInfo {}
 
 async function isConnected (networkSlug: string): Promise<ConnectionInfo> {
   try {
-    const blockchainInfo = await getBlockchainInfo(networkSlug)
-    const lastBlockInfo = await getBlockInfo(networkSlug, blockchainInfo.height)
-    const lastBlockTimestamp = lastBlockInfo.timestamp
     return {
       connected: true,
-      lastBlockTimestamp
+      lastBlockTimestamp: await getLastBlockTimestamp(networkSlug)
     }
   } catch (e: any) {
     return {


### PR DESCRIPTION
Depends on:
---
#474 

Description
---
`getBlockInfo` and `getBlockchainInfo` are no longer available in blockchainService file to be used by the rest of the application, they are too blockchain specific. `getLastBlockTimestamp` was created in their place since it is the only use of those methods to get the time of the last block.

Test plan
---
These functions are used only in the network page, so, to test that everything is still working as usual:
1. Change ’grpc’ to ‘chronik’ for XEC in constants/index.ts, like this:
export const NETWORK_BLOCKCHAIN_CLIENTS: KeyValueT<BLOCKCHAIN_CLIENT_OPTIONS> = {
ecash: `'chronik'`,
bitcoincash: 'grpc'
}
2. open: http://localhost:3000/networks 