### PR TITLE
[Issue #479] feat/create transaction not upserting

### DIFF
--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -15,7 +15,7 @@ const grpc = new GrpcBlockchainClient()
 const subscribeGrpcTxJob = (address: Address, confirmed: boolean): (txn: Transaction.AsObject) => Promise<any> => {
   return async (txn: Transaction.AsObject) => {
     const transactionPrisma = await grpc.getTransactionFromGrpcTransaction(txn, address, confirmed)
-    await transactionService.upsertTransaction(transactionPrisma, address)
+    await transactionService.createTransaction(transactionPrisma)
   }
 }
 

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -4,7 +4,7 @@ import bs58 from 'bs58'
 import { BlockchainClient, BlockchainInfo, BlockInfo, GetAddressTransactionsParameters, TransactionDetails } from './blockchainService'
 import { Transaction } from 'grpc-bchrpc-node'
 import { NETWORK_SLUGS, RESPONSE_MESSAGES, CHRONIK_CLIENT_URL, XEC_TIMESTAMP_THRESHOLD, XEC_NETWORK_ID, BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N } from 'constants/index'
-import { TransactionWithAddressAndPrices, upsertManyTransactionsForAddress } from './transactionService'
+import { TransactionWithAddressAndPrices, createManyTransactionsForAddress } from './transactionService'
 import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { satoshisToUnit } from 'utils'
@@ -110,7 +110,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
         [...confirmedTransactions, ...unconfirmedTransactions].map(async tx => await this.getTransactionFromChronikTransaction(tx, address))
       )
 
-      const persistedTransactions = await upsertManyTransactionsForAddress(transactionsToPersist, address)
+      const persistedTransactions = await createManyTransactionsForAddress(transactionsToPersist)
       await syncPricesFromTransactionList(persistedTransactions)
       insertedTransactions = [...insertedTransactions, ...persistedTransactions]
 

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -4,7 +4,7 @@ import bs58 from 'bs58'
 import { BlockchainClient, BlockchainInfo, BlockInfo, GetAddressTransactionsParameters, TransactionDetails } from './blockchainService'
 import { Transaction } from 'grpc-bchrpc-node'
 import { NETWORK_SLUGS, RESPONSE_MESSAGES, CHRONIK_CLIENT_URL, XEC_TIMESTAMP_THRESHOLD, XEC_NETWORK_ID, BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N } from 'constants/index'
-import { TransactionWithAddressAndPrices, createManyTransactionsForAddress } from './transactionService'
+import { TransactionWithAddressAndPrices, createManyTransactions } from './transactionService'
 import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { satoshisToUnit } from 'utils'
@@ -110,7 +110,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
         [...confirmedTransactions, ...unconfirmedTransactions].map(async tx => await this.getTransactionFromChronikTransaction(tx, address))
       )
 
-      const persistedTransactions = await createManyTransactionsForAddress(transactionsToPersist)
+      const persistedTransactions = await createManyTransactions(transactionsToPersist)
       await syncPricesFromTransactionList(persistedTransactions)
       insertedTransactions = [...insertedTransactions, ...persistedTransactions]
 

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -4,7 +4,7 @@ import bs58 from 'bs58'
 import { BlockchainClient, BlockchainInfo, BlockInfo, GetAddressTransactionsParameters, TransactionDetails } from './blockchainService'
 import { Transaction } from 'grpc-bchrpc-node'
 import { NETWORK_SLUGS, RESPONSE_MESSAGES, CHRONIK_CLIENT_URL, XEC_TIMESTAMP_THRESHOLD, XEC_NETWORK_ID, BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N } from 'constants/index'
-import { TransactionWithAddressAndPrices, createManyTransactions } from './transactionService'
+import { TransactionWithAddressAndPrices, createManyTransactions, base64HashToHex } from './transactionService'
 import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { satoshisToUnit } from 'utils'
@@ -71,7 +71,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
 
   private async getTransactionFromChronikTransaction (transaction: Tx, address: Address): Promise<Prisma.TransactionUncheckedCreateInput> {
     return {
-      hash: transaction.txid,
+      hash: await base64HashToHex(transaction.txid),
       amount: await this.getTransactionAmount(transaction, address.address),
       timestamp: transaction.block !== undefined ? parseInt(transaction.block.timestamp) : parseInt(transaction.timeFirstSeen),
       addressId: address.id,

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -12,7 +12,7 @@ import { BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N, KeyValue
 import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { fetchAddressBySubstring } from './addressService'
-import { TransactionWithAddressAndPrices, upsertManyTransactionsForAddress } from './transactionService'
+import { TransactionWithAddressAndPrices, createManyTransactionsForAddress } from './transactionService'
 import { syncPricesFromTransactionList } from './priceService'
 
 export interface OutputsList {
@@ -148,10 +148,11 @@ export class GrpcBlockchainClient implements BlockchainClient {
           unconfirmedTransactions.map(async tx => await this.getTransactionFromGrpcTransaction(tx, address, false))
         )
       ]
-      console.time('upserting transactions')
-      const persistedTransactions = await upsertManyTransactionsForAddress(transactionsToPersist, address)
+      const t = Date.now()
+      console.time(`creating transactions ${t}`)
+      const persistedTransactions = await createManyTransactionsForAddress(transactionsToPersist)
       await syncPricesFromTransactionList(persistedTransactions)
-      console.timeEnd('upserting transactions')
+      console.timeEnd(`creating transactions ${t}`)
       insertedTransactions = [...insertedTransactions, ...persistedTransactions]
 
       await new Promise(resolve => setTimeout(resolve, FETCH_DELAY))

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -103,7 +103,7 @@ export class GrpcBlockchainClient implements BlockchainClient {
   // WIP: this should be private in the future (after 411-6)
   public async getTransactionFromGrpcTransaction (transaction: GrpcTransaction.AsObject, address: Address, confirmed: boolean): Promise<Prisma.TransactionUncheckedCreateInput> {
     return {
-      hash: await base64HashToHex(transaction.hash),
+      hash: await base64HashToHex(transaction.hash as string),
       amount: await this.getTransactionAmount(transaction, address.address),
       timestamp: transaction.timestamp,
       addressId: address.id,

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -12,7 +12,7 @@ import { BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N, KeyValue
 import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { fetchAddressBySubstring } from './addressService'
-import { TransactionWithAddressAndPrices, createManyTransactions } from './transactionService'
+import { TransactionWithAddressAndPrices, createManyTransactions, base64HashToHex } from './transactionService'
 import { syncPricesFromTransactionList } from './priceService'
 
 export interface OutputsList {
@@ -103,7 +103,7 @@ export class GrpcBlockchainClient implements BlockchainClient {
   // WIP: this should be private in the future (after 411-6)
   public async getTransactionFromGrpcTransaction (transaction: GrpcTransaction.AsObject, address: Address, confirmed: boolean): Promise<Prisma.TransactionUncheckedCreateInput> {
     return {
-      hash: transaction.hash as string,
+      hash: await base64HashToHex(transaction.hash),
       amount: await this.getTransactionAmount(transaction, address.address),
       timestamp: transaction.timestamp,
       addressId: address.id,

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -12,7 +12,7 @@ import { BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N, KeyValue
 import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { fetchAddressBySubstring } from './addressService'
-import { TransactionWithAddressAndPrices, createManyTransactionsForAddress } from './transactionService'
+import { TransactionWithAddressAndPrices, createManyTransactions } from './transactionService'
 import { syncPricesFromTransactionList } from './priceService'
 
 export interface OutputsList {
@@ -150,7 +150,7 @@ export class GrpcBlockchainClient implements BlockchainClient {
       ]
       const t = Date.now()
       console.time(`creating transactions ${t}`)
-      const persistedTransactions = await createManyTransactionsForAddress(transactionsToPersist)
+      const persistedTransactions = await createManyTransactions(transactionsToPersist)
       await syncPricesFromTransactionList(persistedTransactions)
       console.timeEnd(`creating transactions ${t}`)
       insertedTransactions = [...insertedTransactions, ...persistedTransactions]

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -77,7 +77,6 @@ export async function createTransaction (transactionData: Prisma.TransactionUnch
   if (transactionData.amount === new Prisma.Decimal(0)) { // out transactions
     return
   }
-  transactionData.hash = await base64HashToHex(transactionData.hash)
   return await prisma.transaction.create({
     data: transactionData,
     include: includeAddressAndPrices

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -95,7 +95,7 @@ async function addUUIDToTransactions (transactions: Prisma.TransactionUncheckedC
   return uuidList
 }
 
-export async function createManyTransactionsForAddress (transactionsData: Prisma.TransactionUncheckedCreateInput[]): Promise<TransactionWithAddressAndPrices[]> {
+export async function createManyTransactions (transactionsData: Prisma.TransactionUncheckedCreateInput[]): Promise<TransactionWithAddressAndPrices[]> {
   const uuidList = await addUUIDToTransactions(transactionsData)
   await prisma.transaction.createMany({
     data: transactionsData

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -1,10 +1,11 @@
 import prisma from 'prisma/clientInstance'
-import { Prisma, Address } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 import { syncTransactionsForAddress, GetAddressTransactionsParameters } from 'services/blockchainService'
 import { parseAddress } from 'utils/validators'
 import { fetchAddressBySubstring, updateLastSynced } from 'services/addressService'
 import { QuoteValues } from 'services/priceService'
-import { FETCH_N_TIMEOUT, RESPONSE_MESSAGES, USD_QUOTE_ID, CAD_QUOTE_ID, N_OF_QUOTES } from 'constants/index'
+import { RESPONSE_MESSAGES, USD_QUOTE_ID, CAD_QUOTE_ID, N_OF_QUOTES } from 'constants/index'
+import { v4 as uuid } from 'uuid'
 import _ from 'lodash'
 
 export async function getTransactionValue (transaction: TransactionWithAddressAndPrices): Promise<QuoteValues> {
@@ -72,43 +73,41 @@ export async function base64HashToHex (base64Hash: string): Promise<string> {
   )
 }
 
-export async function upsertTransaction (transaction: Prisma.TransactionUncheckedCreateInput, address: Address): Promise<TransactionWithAddressAndPrices | undefined> {
-  if (transaction.amount === new Prisma.Decimal(0)) { // out transactions
+export async function createTransaction (transactionData: Prisma.TransactionUncheckedCreateInput): Promise<TransactionWithAddressAndPrices | undefined> {
+  if (transactionData.amount === new Prisma.Decimal(0)) { // out transactions
     return
   }
-  const hash = await base64HashToHex(transaction.hash)
-  const transactionParams = {
-    hash,
-    amount: transaction.amount,
-    addressId: address.id,
-    timestamp: transaction.timestamp,
-    confirmed: transaction.confirmed
-  }
-  return await prisma.transaction.upsert({
-    where: {
-      Transaction_hash_addressId_unique_constraint: {
-        hash: transactionParams.hash,
-        addressId: address.id
-      }
-    },
-    update: transactionParams,
-    create: transactionParams,
+  transactionData.hash = await base64HashToHex(transactionData.hash)
+  return await prisma.transaction.create({
+    data: transactionData,
     include: includeAddressAndPrices
   })
 }
 
-export async function upsertManyTransactionsForAddress (transactions: Prisma.TransactionUncheckedCreateInput[], address: Address): Promise<TransactionWithAddressAndPrices[]> {
-  const ret = await prisma.$transaction(async (_) => {
-    const insertedTransactions: Array<TransactionWithAddressAndPrices | undefined> = await Promise.all(
-      transactions.map(async (transaction) => {
-        return await upsertTransaction(transaction, address)
-      })
-    )
-    return insertedTransactions
-  }, {
-    timeout: FETCH_N_TIMEOUT
+async function addUUIDToTransactions (transactions: Prisma.TransactionUncheckedCreateInput[]): Promise<string[]> {
+  const txsLen = transactions.length
+  const uuidList = []
+  for (let i = 0; i < txsLen; i++) {
+    const id = uuid()
+    transactions[i].id = id
+    uuidList.push(id)
+  }
+  return uuidList
+}
+
+export async function createManyTransactionsForAddress (transactionsData: Prisma.TransactionUncheckedCreateInput[]): Promise<TransactionWithAddressAndPrices[]> {
+  const uuidList = await addUUIDToTransactions(transactionsData)
+  await prisma.transaction.createMany({
+    data: transactionsData
   })
-  return ret.filter((t) => t !== undefined) as TransactionWithAddressAndPrices[]
+  return await prisma.transaction.findMany({
+    where: {
+      id: {
+        in: uuidList
+      }
+    },
+    include: includeAddressAndPrices
+  })
 }
 
 export async function syncAllTransactionsForAddress (addressString: string, maxTransactionsToReturn: number): Promise<TransactionWithAddressAndPrices[]> {


### PR DESCRIPTION
Depends on
---
- [x] #480 

Description
---
Reformulated the logic responsible to upsert transactions so that transactions are created, not upserted. The difference, essentially, is that if we try to create a transaction that already exists, it will return an error (as it should, because we should not be reinserting transactions).

Test plan
---
Initial sync of txs should happen normally.