### PR TITLE
[Issue #465] Default sort payments by date

### DIFF
--- a/components/TableContainer.tsx
+++ b/components/TableContainer.tsx
@@ -21,7 +21,7 @@ const TableContainer = ({ columns, data }) => {
     {
       columns,
       data,
-      initialState: { pageIndex: 0, pageSize: 10 }
+      initialState: { pageIndex: 0, pageSize: 10, sortBy: [{ id: 'timestamp', desc: true }] }
     },
     useSortBy,
     usePagination


### PR DESCRIPTION
Description
Setting the default table sort to the timestamp desc so latest transactions on top


Test plan
Go to payments page and see if its sorted correctly 
