### PR TITLE
[Issue #264] feat: connect prices when inserting transactions

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -38,6 +38,7 @@ export const RESPONSE_MESSAGES = {
   NETWORK_SLUG_NOT_PROVIDED_400: { statusCode: 400, message: "'networkSlug' not provided." },
   QUOTE_SLUG_NOT_PROVIDED_400: { statusCode: 400, message: "'quoteSlug' not provided." },
   NO_CURRENT_PRICES_FOUND_404: { statusCode: 404, message: 'Current prices not found.' },
+  NO_PRICES_FOUND_404: { statusCode: 404, message: 'Prices not found.' },
   INVALID_QUOTE_SLUG_400: { statusCode: 400, message: 'Invalid quote slug.' },
   INVALID_TICKER_400: { statusCode: 400, message: 'Invalid ticker.' },
   MISSING_BLOCKCHAIN_CLIENT_400: { statusCode: 400, message: 'There is no blockchain client chosen for this network.' },

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -24,6 +24,7 @@ export const RESPONSE_MESSAGES = {
   ADDRESS_NOT_PROVIDED_400: { statusCode: 400, message: "'address' not provided." },
   INVALID_ADDRESS_400: { statusCode: 400, message: 'Invalid address.' },
   NO_ADDRESS_FOUND_404: { statusCode: 404, message: 'No address found.' },
+  NO_TRANSACTION_FOUND_404: { statusCode: 404, message: 'No transaction found.' },
   NO_BUTTON_FOUND_404: { statusCode: 404, message: 'No button found.' },
   NO_WALLET_FOUND_404: { statusCode: 404, message: 'No wallet found.' },
   NO_USER_PROFILE_FOUND_ON_WALLET_404: { statusCode: 404, message: 'No user profile found for wallet.' },

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -85,7 +85,7 @@ export const SUPPORTED_QUOTES = [ // avoids hitting the DB every time for data t
 
 export const HUMAN_READABLE_DATE_FORMAT = 'YYYY-MM-DD'
 
-export const PRICE_API_DATE_FORMAT = 'YYYYMMDD'
+export const PRICE_API_DATE_FORMAT = 'YYYY-MM-DD'
 export const PRICE_API_TIMEOUT = 40 * 1000 // 40 seconds
 export const PRICE_API_MAX_RETRIES = 3
 

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -10,6 +10,7 @@ export const RESPONSE_MESSAGES = {
   NAME_NOT_PROVIDED_400: { statusCode: 400, message: "'name' not provided." },
   PAYBUTTON_NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Button name already exists.' },
   WALLET_NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Wallet name already exists.' },
+  TRANSACTION_ALREADY_EXISTS_FOR_ADDRESS_400: { statusCode: 400, message: 'Transaction already exists for address.' },
   ADDRESSES_NOT_PROVIDED_400: { statusCode: 400, message: "'addresses' not provided." },
   BUTTON_IDS_NOT_PROVIDED_400: { statusCode: 400, message: 'Paybuttons were not provided.' },
   ADDRESS_IDS_NOT_PROVIDED_400: { statusCode: 400, message: 'Addresses were not provided.' },

--- a/redis/dashboardCache.ts
+++ b/redis/dashboardCache.ts
@@ -1,7 +1,7 @@
 import { redis } from 'redis/clientInstance'
 import { Prisma } from '@prisma/client'
 import { getTransactionValue, TransactionWithAddressAndPrices } from 'services/transactionService'
-import { fetchAddressById } from 'services/addressService'
+import { fetchAddressById, AddressWithPaybuttons } from 'services/addressService'
 import { RESPONSE_MESSAGES, PAYMENT_WEEK_KEY_FORMAT, KeyValueT } from 'constants/index'
 import moment from 'moment'
 
@@ -64,7 +64,7 @@ export const getPaymentsFromTransactions = async (transactionList: TransactionWi
   const paymentList: Payment[] = []
   for (const t of transactionList) {
     const value = (await getTransactionValue(t)).usd
-    const txAddress = await fetchAddressById(t.addressId)
+    const txAddress = await fetchAddressById(t.addressId, true) as AddressWithPaybuttons
     if (txAddress === undefined) throw new Error(RESPONSE_MESSAGES.NO_ADDRESS_FOUND_FOR_TRANSACTION_404.message)
     paymentList.push({
       timestamp: t.timestamp,

--- a/services/addressService.ts
+++ b/services/addressService.ts
@@ -193,13 +193,13 @@ export async function updateLastSynced (addressString: string): Promise<void> {
   })
 }
 
-export async function fetchAddressById (addressId: string): Promise<AddressWithPaybuttons> {
+export async function fetchAddressById (addressId: string, includePaybuttons = false): Promise<AddressWithPaybuttons | Address> {
   const result = await prisma.address.findUnique({
     where: {
       id: addressId
     },
     include: {
-      paybuttons: includePaybuttonsNested.paybuttons
+      paybuttons: includePaybuttons ? includePaybuttonsNested.paybuttons : false
     }
   })
   if (result === null) {

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -9,7 +9,6 @@ import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { satoshisToUnit } from 'utils'
 import { fetchAddressBySubstring } from './addressService'
-import { syncPricesFromTransactionList } from './priceService'
 
 export class ChronikBlockchainClient implements BlockchainClient {
   chronik: ChronikClient
@@ -110,8 +109,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
         [...confirmedTransactions, ...unconfirmedTransactions].map(async tx => await this.getTransactionFromChronikTransaction(tx, address))
       )
 
-      const persistedTransactions = await createManyTransactions(transactionsToPersist)
-      await syncPricesFromTransactionList(persistedTransactions)
+      const persistedTransactions = await createManyTransactions(transactionsToPersist, true)
       insertedTransactions = [...insertedTransactions, ...persistedTransactions]
 
       await new Promise(resolve => setTimeout(resolve, FETCH_DELAY))

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -13,7 +13,6 @@ import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { fetchAddressBySubstring } from './addressService'
 import { TransactionWithAddressAndPrices, createManyTransactions, base64HashToHex } from './transactionService'
-import { syncPricesFromTransactionList } from './priceService'
 
 export interface OutputsList {
   outpoint: object
@@ -150,8 +149,7 @@ export class GrpcBlockchainClient implements BlockchainClient {
       ]
       const t = Date.now()
       console.time(`creating transactions ${t}`)
-      const persistedTransactions = await createManyTransactions(transactionsToPersist)
-      await syncPricesFromTransactionList(persistedTransactions)
+      const persistedTransactions = await createManyTransactions(transactionsToPersist, true)
       console.timeEnd(`creating transactions ${t}`)
       insertedTransactions = [...insertedTransactions, ...persistedTransactions]
 

--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -1,4 +1,4 @@
-import { TransactionWithAddressAndPrices } from 'services/transactionService'
+import { TransactionWithAddressAndPrices, getTransactionNetworkId } from 'services/transactionService'
 import axios from 'axios'
 import { appInfo } from 'config/appInfo'
 import { Prisma, Transaction, Price } from '@prisma/client'
@@ -239,8 +239,9 @@ export interface SyncTransactionPricesInput {
 }
 
 // expects prices to already exist, returns true if successful
-export async function connectTransactionToPrices (tx: Transaction, networkId: number): Promise<boolean> {
+export async function connectTransactionToPrices (tx: Transaction): Promise<boolean> {
   const priceTimestamp = flattenTimestamp(tx.timestamp)
+  const networkId = await getTransactionNetworkId(tx)
   const cadPrice = await prisma.price.findUnique({
     where: {
       Price_timestamp_quoteId_networkId_unique_constraint: {

--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -1,4 +1,4 @@
-import { TransactionWithAddressAndPrices, getTransactionNetworkId } from 'services/transactionService'
+import { TransactionWithAddressAndPrices, getTransactionNetworkId, fetchTransactionById } from 'services/transactionService'
 import axios from 'axios'
 import { appInfo } from 'config/appInfo'
 import { Prisma, Transaction, Price } from '@prisma/client'
@@ -238,8 +238,19 @@ export interface SyncTransactionPricesInput {
   transactionId: string
 }
 
+export async function connectTransactionsToPricesByIdList (idList: string[]): Promise<boolean> {
+  return await prisma.$transaction(async (p) => {
+    const promises = idList.map(async (id) => {
+      const tx = await fetchTransactionById(id)
+      return await connectTransactionToPrices(tx, p)
+    })
+    const results = await Promise.all(promises)
+    return results.every((b) => b)
+  })
+}
+
 // expects prices to already exist, returns true if successful
-export async function connectTransactionToPrices (tx: Transaction): Promise<boolean> {
+export async function connectTransactionToPrices (tx: Transaction, prisma: Prisma.TransactionClient): Promise<boolean> {
   const priceTimestamp = flattenTimestamp(tx.timestamp)
   const networkId = await getTransactionNetworkId(tx)
   const cadPrice = await prisma.price.findUnique({

--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -140,13 +140,15 @@ export async function syncPastDaysNewerPrices (): Promise<void> {
   const allXECPrices = await getAllPricesByNetworkTicker(NETWORK_TICKERS.ecash)
   const allBCHPrices = await getAllPricesByNetworkTicker(NETWORK_TICKERS.bitcoincash)
   await Promise.all(
-    allXECPrices.filter(p => p.day in daysToRetrieve).map(async price =>
-      await upsertPricesForNetworkId(price, XEC_NETWORK_ID, date.unix())
+    allXECPrices.filter(p => daysToRetrieve.includes(p.day)).map(async price => {
+      return await upsertPricesForNetworkId(price, XEC_NETWORK_ID, moment(price.day).unix())
+    }
     )
   )
   await Promise.all(
-    allBCHPrices.filter(p => p.day in daysToRetrieve).map(async price =>
-      await upsertPricesForNetworkId(price, BCH_NETWORK_ID, date.unix())
+    allBCHPrices.filter(p => daysToRetrieve.includes(p.day)).map(async price => {
+      return await upsertPricesForNetworkId(price, BCH_NETWORK_ID, moment(price.day).unix())
+    }
     )
   )
 }

--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -1,9 +1,8 @@
-import { TransactionWithAddressAndPrices } from 'services/transactionService'
 import axios from 'axios'
 import { appInfo } from 'config/appInfo'
 import { Prisma, Price } from '@prisma/client'
 import prisma from 'prisma/clientInstance'
-import { HUMAN_READABLE_DATE_FORMAT, PRICE_API_TIMEOUT, PRICE_API_MAX_RETRIES, PRICE_API_DATE_FORMAT, RESPONSE_MESSAGES, NETWORK_TICKERS, XEC_NETWORK_ID, BCH_NETWORK_ID, USD_QUOTE_ID, CAD_QUOTE_ID, N_OF_QUOTES, UPSERT_TRANSACTION_PRICES_ON_DB_TIMEOUT } from 'constants/index'
+import { HUMAN_READABLE_DATE_FORMAT, PRICE_API_TIMEOUT, PRICE_API_MAX_RETRIES, PRICE_API_DATE_FORMAT, RESPONSE_MESSAGES, NETWORK_TICKERS, XEC_NETWORK_ID, BCH_NETWORK_ID, USD_QUOTE_ID, CAD_QUOTE_ID, N_OF_QUOTES } from 'constants/index'
 import { validatePriceAPIUrlAndToken, validateNetworkTicker } from 'utils/validators'
 import moment from 'moment'
 
@@ -199,33 +198,6 @@ export async function getCurrentPricesForNetworkId (networkId: number): Promise<
   }
 }
 
-export async function syncPricesFromTransactionList (transactions: TransactionWithAddressAndPrices[]): Promise<void> {
-  const promisedValuesList: Array<Promise<QuoteValues | undefined>> = []
-  const syncParamsList: SyncTransactionPricesInput[] = []
-  // create promises to request prices
-  for (const transaction of transactions) {
-    const syncParams: SyncTransactionPricesInput = {
-      networkId: transaction.address.networkId,
-      timestamp: flattenTimestamp(transaction.timestamp),
-      transactionId: transaction.id
-    }
-    syncParamsList.push(syncParams)
-    promisedValuesList.push(syncTransactionPriceValues(syncParams))
-  }
-  // send the requests
-  const valuesList = await Promise.all(promisedValuesList)
-  // save it on the database
-  const createPricesInputList: CreatePricesFromTransactionInput[] = syncParamsList.map((syncParams, idx) => {
-    return {
-      ...syncParams,
-      values: valuesList[idx]
-    }
-  })
-  for (const createPricesInput of createPricesInputList) {
-    await createTransactionPrices(createPricesInput)
-  }
-}
-
 export interface QuoteValues {
   'usd': Prisma.Decimal
   'cad': Prisma.Decimal
@@ -269,155 +241,5 @@ export async function fetchPricesForNetworkAndTimestamp (networkId: number, time
   return {
     cad: cadPrice,
     usd: usdPrice
-  }
-}
-
-export async function createTransactionPrices (params: CreatePricesFromTransactionInput): Promise<void> {
-  // Create USD price, if it does not already exist
-  return await prisma.$transaction(async (prisma) => {
-    if (params.values === undefined) return
-    const usdPrice = await prisma.price.upsert({
-      where: {
-        Price_timestamp_quoteId_networkId_unique_constraint: {
-          quoteId: USD_QUOTE_ID,
-          networkId: params.networkId,
-          timestamp: params.timestamp
-        }
-      },
-      create: {
-        value: params.values.usd,
-        timestamp: params.timestamp,
-        network: {
-          connect: {
-            id: params.networkId
-          }
-        },
-        quote: {
-          connect: {
-            id: USD_QUOTE_ID
-          }
-        }
-      },
-      update: {}
-    })
-    // Connect it with transaction, if not already connected
-    void await prisma.pricesOnTransactions.upsert({
-      where: {
-        priceId_transactionId: {
-          priceId: usdPrice.id,
-          transactionId: params.transactionId
-        }
-      },
-      create: {
-        transactionId: params.transactionId,
-        priceId: usdPrice.id
-      },
-      update: {}
-    })
-
-    // Create CAD price, if it does not already exist
-    const cadPrice = await prisma.price.upsert({
-      where: {
-        Price_timestamp_quoteId_networkId_unique_constraint: {
-          quoteId: CAD_QUOTE_ID,
-          networkId: params.networkId,
-          timestamp: params.timestamp
-        }
-      },
-      create: {
-        value: params.values.cad,
-        timestamp: params.timestamp,
-        network: {
-          connect: {
-            id: params.networkId
-          }
-        },
-        quote: {
-          connect: {
-            id: CAD_QUOTE_ID
-          }
-        }
-      },
-      update: {}
-    })
-    // Connect it with transaction, if not already connected
-    void await prisma.pricesOnTransactions.upsert({
-      where: {
-        priceId_transactionId: {
-          priceId: cadPrice.id,
-          transactionId: params.transactionId
-        }
-      },
-      create: {
-        transactionId: params.transactionId,
-        priceId: cadPrice.id
-      },
-      update: {}
-    })
-  },
-  {
-    timeout: UPSERT_TRANSACTION_PRICES_ON_DB_TIMEOUT
-  }
-  )
-}
-
-export async function syncTransactionPriceValues (params: SyncTransactionPricesInput): Promise<QuoteValues | undefined> {
-  const existentPrices = await prisma.price.findMany({
-    where: {
-      networkId: params.networkId,
-      timestamp: flattenTimestamp(params.timestamp)
-    }
-  })
-
-  if (existentPrices.length === N_OF_QUOTES) {
-    let cadPrice, usdPrice
-    for (const price of existentPrices) {
-      void await prisma.pricesOnTransactions.upsert({
-        where: {
-          priceId_transactionId: {
-            priceId: price.id,
-            transactionId: params.transactionId
-          }
-        },
-        create: {
-          transactionId: params.transactionId,
-          priceId: price.id
-        },
-        update: {}
-      })
-      if (price.quoteId === USD_QUOTE_ID) {
-        usdPrice = price.value
-      } else if (price.quoteId === CAD_QUOTE_ID) {
-        cadPrice = price.value
-      }
-    }
-    if (cadPrice === undefined || usdPrice === undefined) {
-      throw new Error(RESPONSE_MESSAGES.INVALID_PRICE_STATE_400.message)
-    }
-    return {
-      cad: cadPrice,
-      usd: usdPrice
-    }
-  }
-
-  let res
-
-  if (params.networkId === XEC_NETWORK_ID) {
-    res = await axios.get(getPriceURLForDayAndNetworkTicker(moment.unix(params.timestamp), 'XEC'))
-  } else if (params.networkId === BCH_NETWORK_ID) {
-    res = await axios.get(getPriceURLForDayAndNetworkTicker(moment.unix(params.timestamp), 'BCH'))
-  } else {
-    throw new Error(RESPONSE_MESSAGES.INVALID_NETWORK_ID_400.message)
-  }
-  const responseData = res.data
-  if (responseData.success === false) {
-    return undefined
-  }
-  const usdPriceString = responseData.Price_in_USD
-  const cadPriceString = responseData.Price_in_CAD
-
-  return {
-    usd: new Prisma.Decimal(usdPriceString),
-    cad: new Prisma.Decimal(cadPriceString)
   }
 }

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -61,6 +61,19 @@ export async function fetchAddressTransactions (addressString: string): Promise<
   return _.orderBy(transactions, ['timestamp'], ['desc'])
 }
 
+export async function fetchTransactionById (id: string): Promise<TransactionWithAddressAndPrices> {
+  const tx = await prisma.transaction.findUnique({
+    where: {
+      id
+    },
+    include: includeAddressAndPrices
+  })
+  if (tx === null) {
+    throw new Error(RESPONSE_MESSAGES.NO_TRANSACTION_FOUND_404.message)
+  }
+  return tx
+}
+
 export async function base64HashToHex (base64Hash: string): Promise<string> {
   return (
     atob(base64Hash)

--- a/tests/unittests/priceService.test.ts
+++ b/tests/unittests/priceService.test.ts
@@ -1,74 +1,8 @@
 import * as priceService from 'services/priceService'
 import prisma from 'prisma/clientInstance'
 import { Prisma } from '@prisma/client'
-import { RESPONSE_MESSAGES } from 'constants/index'
-import { appInfo } from 'config/appInfo'
 import { prismaMock } from 'prisma/mockedClient'
-import { mockedUSDPrice, mockedCADPrice, mockedPriceOnTransaction } from 'tests/mockedObjects'
-
-import axios from 'axios'
-jest.mock('axios')
-const mockedAxios = axios as jest.Mocked<typeof axios>
-
-describe('Sync price from transaction', () => {
-  beforeEach(async () => {
-    prismaMock.price.findMany.mockResolvedValue([])
-    prisma.price.findMany = prismaMock.price.findMany
-    prismaMock.pricesOnTransactions.upsert.mockResolvedValue(mockedPriceOnTransaction)
-    prisma.pricesOnTransactions.upsert = prismaMock.pricesOnTransactions.upsert
-  })
-  it('Ignore price API fail response', async () => {
-    mockedAxios.get.mockResolvedValue({ data: { success: false } })
-    const res = await priceService.syncTransactionPriceValues({
-      networkId: 1,
-      transactionId: 'mocked-uuid',
-      timestamp: 1
-    })
-    expect(res).toBeUndefined()
-  })
-  it('Fail if no PRICE_API_URL', async () => {
-    appInfo.priceAPIURL = ''
-    expect.assertions(1)
-    try {
-      await priceService.syncTransactionPriceValues({
-        networkId: 1,
-        transactionId: 'mocked-uuid',
-        timestamp: 1
-      })
-    } catch (e: any) {
-      expect(e.message).toMatch(RESPONSE_MESSAGES.MISSING_PRICE_API_URL_400.message)
-    }
-    appInfo.priceAPIURL = 'foo'
-  })
-  it('Fail if no PRICE_API_TOKEN', async () => {
-    appInfo.priceAPIToken = ''
-    expect.assertions(1)
-    try {
-      await priceService.syncTransactionPriceValues({
-        networkId: 1,
-        transactionId: 'mocked-uuid',
-        timestamp: 1
-      })
-    } catch (e: any) {
-      expect(e.message).toMatch(RESPONSE_MESSAGES.MISSING_PRICE_API_TOKEN_400.message)
-    }
-    appInfo.priceAPIToken = 'bar'
-  })
-  it('Existent price if price already exists', async () => {
-    mockedAxios.get.mockResolvedValue({ data: { success: false } })
-    prismaMock.price.findMany.mockResolvedValue([mockedUSDPrice, mockedCADPrice])
-    prisma.price.findMany = prismaMock.price.findMany
-    const res = await priceService.syncTransactionPriceValues({
-      networkId: 1,
-      transactionId: 'mocked-uuid',
-      timestamp: 1
-    })
-    expect(res).toStrictEqual({
-      cad: new Prisma.Decimal('18'),
-      usd: new Prisma.Decimal('10')
-    })
-  })
-})
+import { mockedUSDPrice, mockedCADPrice } from 'tests/mockedObjects'
 
 describe('Fetch services', () => {
   it('Get current prices for networkId', async () => {

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -65,6 +65,8 @@ export const parseError = function (error: Error): Error {
           return new Error(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message)
         } else if (error.message.includes('Wallet_name_providerUserId_unique_constraint')) {
           return new Error(RESPONSE_MESSAGES.WALLET_NAME_ALREADY_EXISTS_400.message)
+        } else if (error.message.includes('Transaction_hash_addressId_key')) {
+          return new Error(RESPONSE_MESSAGES.TRANSACTION_ALREADY_EXISTS_FOR_ADDRESS_400.message)
         }
         break
       case 'P2025':


### PR DESCRIPTION
Depends on
---
- [x] #487 

Description
---
When creating transactions, automatically connect them to the existent price.

Test plan
---
1. Spin up the containers
2. After all is up, add a new address that has some transactions on it. Make sure you see the transactions in the button detail view.
3. Enter the database with `yarn docker db`
5. The number returned by `SELECT COUNT(*) FROM PricesOnTransactions;` should be twice the number returned by `SELECT COUNT(*) FROM Transaction;`


Remarks
---
The rationale for this is so that the cached payments, that appear on the dashboard, can be updated as soon as a new transaction is inserted. This PR still does not acomplishes that yet, but makes so that the `createManyTransactions` and `createTransaction` functions return transactions already with it's connected prices.

I also removed all the code related to the previous logic of price syncing (on demand: if a price didn't exist, we would fetch it. Now we expect all prices to exist and just connect the txs to them.)
