### PR TITLE
[Issue #486] fix: price sync up to today

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -85,7 +85,7 @@ export const SUPPORTED_QUOTES = [ // avoids hitting the DB every time for data t
 
 export const HUMAN_READABLE_DATE_FORMAT = 'YYYY-MM-DD'
 
-export const PRICE_API_DATE_FORMAT = 'YYYYMMDD'
+export const PRICE_API_DATE_FORMAT = 'YYYY-MM-DD'
 export const PRICE_API_TIMEOUT = 40 * 1000 // 40 seconds
 export const PRICE_API_MAX_RETRIES = 3
 

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -10,6 +10,7 @@ export const RESPONSE_MESSAGES = {
   NAME_NOT_PROVIDED_400: { statusCode: 400, message: "'name' not provided." },
   PAYBUTTON_NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Button name already exists.' },
   WALLET_NAME_ALREADY_EXISTS_400: { statusCode: 400, message: 'Wallet name already exists.' },
+  TRANSACTION_ALREADY_EXISTS_FOR_ADDRESS_400: { statusCode: 400, message: 'Transaction already exists for address.' },
   ADDRESSES_NOT_PROVIDED_400: { statusCode: 400, message: "'addresses' not provided." },
   BUTTON_IDS_NOT_PROVIDED_400: { statusCode: 400, message: 'Paybuttons were not provided.' },
   ADDRESS_IDS_NOT_PROVIDED_400: { statusCode: 400, message: 'Addresses were not provided.' },

--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -140,13 +140,15 @@ export async function syncPastDaysNewerPrices (): Promise<void> {
   const allXECPrices = await getAllPricesByNetworkTicker(NETWORK_TICKERS.ecash)
   const allBCHPrices = await getAllPricesByNetworkTicker(NETWORK_TICKERS.bitcoincash)
   await Promise.all(
-    allXECPrices.filter(p => p.day in daysToRetrieve).map(async price =>
-      await upsertPricesForNetworkId(price, XEC_NETWORK_ID, date.unix())
+    allXECPrices.filter(p => daysToRetrieve.includes(p.day)).map(async price => {
+      return await upsertPricesForNetworkId(price, XEC_NETWORK_ID, moment(price.day).unix())
+    }
     )
   )
   await Promise.all(
-    allBCHPrices.filter(p => p.day in daysToRetrieve).map(async price =>
-      await upsertPricesForNetworkId(price, BCH_NETWORK_ID, date.unix())
+    allBCHPrices.filter(p => daysToRetrieve.includes(p.day)).map(async price => {
+      return await upsertPricesForNetworkId(price, BCH_NETWORK_ID, moment(price.day).unix())
+    }
     )
   )
 }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -65,6 +65,8 @@ export const parseError = function (error: Error): Error {
           return new Error(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message)
         } else if (error.message.includes('Wallet_name_providerUserId_unique_constraint')) {
           return new Error(RESPONSE_MESSAGES.WALLET_NAME_ALREADY_EXISTS_400.message)
+        } else if (error.message.includes('Transaction_hash_addressId_key')) {
+          return new Error(RESPONSE_MESSAGES.TRANSACTION_ALREADY_EXISTS_FOR_ADDRESS_400.message)
         }
         break
       case 'P2025':


### PR DESCRIPTION
Description
---
Solves #486 

Test plan
---
On master, spinning up the containers and entering the db container (`yarn docker db`), running the query:
```
select timestamp from Price order by timestamp desc limit 1;
```

...would give an old day equivalent to the most recent day in the `prisma/seeds/prices.csv` file.

In this branch, the same thing should give the today's date.

Remarks
---
Also makes so that the intial addresses sync is ignored if some tx is already found in the database (making it possible to rerun the jobs with no issue)

