### PR TITLE
[Issue #491] refactor: user profile same id as supertokens

### DIFF
--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -85,16 +85,16 @@ CREATE TABLE `UserProfile` (
 -- CreateTable
 CREATE TABLE `WalletsOnUserProfile` (
     `walletId` VARCHAR(191) NOT NULL,
-    `userProfileId` VARCHAR(191) NOT NULL,
+    `userId` VARCHAR(191) NOT NULL,
     `isXECDefault` BOOLEAN NULL,
     `isBCHDefault` BOOLEAN NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
 
     UNIQUE INDEX `WalletsOnUserProfile_walletId_key`(`walletId`),
-    UNIQUE INDEX `WalletsOnUserProfile_userProfileId_isXECDefault_key`(`userProfileId`, `isXECDefault`),
-    UNIQUE INDEX `WalletsOnUserProfile_userProfileId_isBCHDefault_key`(`userProfileId`, `isBCHDefault`),
-    PRIMARY KEY (`walletId`, `userProfileId`)
+    UNIQUE INDEX `WalletsOnUserProfile_userId_isXECDefault_key`(`userId`, `isXECDefault`),
+    UNIQUE INDEX `WalletsOnUserProfile_userId_isBCHDefault_key`(`userId`, `isBCHDefault`),
+    PRIMARY KEY (`walletId`, `userId`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
@@ -137,12 +137,12 @@ CREATE TABLE `Quote` (
 -- CreateTable
 CREATE TABLE `AddressesOnUserProfiles` (
     `addressId` VARCHAR(191) NOT NULL,
-    `userProfileId` VARCHAR(191) NOT NULL,
+    `userId` VARCHAR(191) NOT NULL,
     `walletId` VARCHAR(191) NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
 
-    PRIMARY KEY (`userProfileId`, `addressId`)
+    PRIMARY KEY (`userId`, `addressId`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- AddForeignKey
@@ -161,7 +161,7 @@ ALTER TABLE `Transaction` ADD CONSTRAINT `Transaction_addressId_fkey` FOREIGN KE
 ALTER TABLE `WalletsOnUserProfile` ADD CONSTRAINT `WalletsOnUserProfile_walletId_fkey` FOREIGN KEY (`walletId`) REFERENCES `Wallet`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE `WalletsOnUserProfile` ADD CONSTRAINT `WalletsOnUserProfile_userProfileId_fkey` FOREIGN KEY (`userProfileId`) REFERENCES `UserProfile`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE `WalletsOnUserProfile` ADD CONSTRAINT `WalletsOnUserProfile_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `UserProfile`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE `Price` ADD CONSTRAINT `Price_networkId_fkey` FOREIGN KEY (`networkId`) REFERENCES `Network`(`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
@@ -182,4 +182,4 @@ ALTER TABLE `AddressesOnUserProfiles` ADD CONSTRAINT `AddressesOnUserProfiles_ad
 ALTER TABLE `AddressesOnUserProfiles` ADD CONSTRAINT `AddressesOnUserProfiles_walletId_fkey` FOREIGN KEY (`walletId`) REFERENCES `Wallet`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE `AddressesOnUserProfiles` ADD CONSTRAINT `AddressesOnUserProfiles_userProfileId_fkey` FOREIGN KEY (`userProfileId`) REFERENCES `UserProfile`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE `AddressesOnUserProfiles` ADD CONSTRAINT `AddressesOnUserProfiles_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `UserProfile`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -75,12 +75,10 @@ CREATE TABLE `Wallet` (
 
 -- CreateTable
 CREATE TABLE `UserProfile` (
-    `id` VARCHAR(191) NOT NULL DEFAULT (uuid()),
+    `id` VARCHAR(255) NOT NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
-    `userId` VARCHAR(255) NOT NULL,
 
-    UNIQUE INDEX `UserProfile_userId_key`(`userId`),
     PRIMARY KEY (`id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -151,7 +151,7 @@ model WalletsOnUserProfile {
 }
 
 model UserProfile {
-  id        String                    @id
+  id        String                    @id @db.VarChar(255)
   createdAt DateTime                  @default(now())
   updatedAt DateTime                  @updatedAt
   wallets   WalletsOnUserProfile[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -151,10 +151,9 @@ model WalletsOnUserProfile {
 }
 
 model UserProfile {
-  id        String                 @id @default(dbgenerated("(uuid())"))
+  id        String                 @id
   createdAt DateTime               @default(now())
   updatedAt DateTime               @updatedAt
-  userId    String                 @unique @db.VarChar(255)
   wallets   WalletsOnUserProfile[]
   addresses   AddressesOnUserProfiles[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,13 +11,13 @@ datasource db {
 }
 
 model Address {
-  id           String               @id @default(dbgenerated("(uuid())"))
-  address      String               @unique @db.VarChar(255)
-  createdAt    DateTime             @default(now())
-  updatedAt    DateTime             @updatedAt
+  id           String                    @id @default(dbgenerated("(uuid())"))
+  address      String                    @unique @db.VarChar(255)
+  createdAt    DateTime                  @default(now())
+  updatedAt    DateTime                  @updatedAt
   networkId    Int
-  network      Network              @relation(fields: [networkId], references: [id], onUpdate: Restrict)
-  userProfiles   AddressesOnUserProfiles[]
+  network      Network                   @relation(fields: [networkId], references: [id], onUpdate: Restrict)
+  userProfiles AddressesOnUserProfiles[]
   lastSynced   DateTime?
   paybuttons   AddressesOnButtons[]
   transactions Transaction[]
@@ -75,11 +75,11 @@ model Transaction {
 }
 
 model Wallet {
-  id             String                @id @default(dbgenerated("(uuid())"))
-  createdAt      DateTime              @default(now())
-  updatedAt      DateTime              @updatedAt
-  name           String                @db.VarChar(255)
-  providerUserId String?               @db.VarChar(255)
+  id             String                    @id @default(dbgenerated("(uuid())"))
+  createdAt      DateTime                  @default(now())
+  updatedAt      DateTime                  @updatedAt
+  name           String                    @db.VarChar(255)
+  providerUserId String?                   @db.VarChar(255)
   userAddresses  AddressesOnUserProfiles[]
   userProfile    WalletsOnUserProfile?
 
@@ -126,11 +126,11 @@ model AddressesOnUserProfiles {
   addressId     String
   userProfileId String
   walletId      String?
-  createdAt     DateTime     @default(now())
-  updatedAt     DateTime     @updatedAt
-  address       Address      @relation(fields: [addressId], references: [id], onDelete: Cascade)
-  userProfile   UserProfile  @relation(fields: [userProfileId], references: [id], onDelete: Cascade)
-  wallet        Wallet?      @relation(fields: [walletId], references: [id], onDelete: SetNull)
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+  address       Address     @relation(fields: [addressId], references: [id], onDelete: Cascade)
+  userProfile   UserProfile @relation(fields: [userProfileId], references: [id], onDelete: Cascade)
+  wallet        Wallet?     @relation(fields: [walletId], references: [id], onDelete: SetNull)
 
   @@id([userProfileId, addressId])
 }
@@ -151,9 +151,9 @@ model WalletsOnUserProfile {
 }
 
 model UserProfile {
-  id        String                 @id
-  createdAt DateTime               @default(now())
-  updatedAt DateTime               @updatedAt
+  id        String                    @id
+  createdAt DateTime                  @default(now())
+  updatedAt DateTime                  @updatedAt
   wallets   WalletsOnUserProfile[]
-  addresses   AddressesOnUserProfiles[]
+  addresses AddressesOnUserProfiles[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,30 +124,30 @@ model PricesOnTransactions {
 
 model AddressesOnUserProfiles {
   addressId     String
-  userProfileId String
+  userId String
   walletId      String?
   createdAt     DateTime    @default(now())
   updatedAt     DateTime    @updatedAt
   address       Address     @relation(fields: [addressId], references: [id], onDelete: Cascade)
-  userProfile   UserProfile @relation(fields: [userProfileId], references: [id], onDelete: Cascade)
+  userProfile   UserProfile @relation(fields: [userId], references: [id], onDelete: Cascade)
   wallet        Wallet?     @relation(fields: [walletId], references: [id], onDelete: SetNull)
 
-  @@id([userProfileId, addressId])
+  @@id([userId, addressId])
 }
 
 model WalletsOnUserProfile {
   walletId      String      @unique
-  userProfileId String
+  userId String
   isXECDefault  Boolean?
   isBCHDefault  Boolean?
   createdAt     DateTime    @default(now())
   updatedAt     DateTime    @updatedAt
   wallet        Wallet      @relation(fields: [walletId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  userProfile   UserProfile @relation(fields: [userProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  userProfile   UserProfile @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
 
-  @@id([walletId, userProfileId])
-  @@unique([userProfileId, isBCHDefault], name: "WalletsOnUserProfile_userProfileId_isBCHDefault_unique_constraint")
-  @@unique([userProfileId, isXECDefault], name: "WalletsOnUserProfile_userProfileId_isXECDefault_unique_constraint")
+  @@id([walletId, userId])
+  @@unique([userId, isBCHDefault], name: "WalletsOnUserProfile_userId_isBCHDefault_unique_constraint")
+  @@unique([userId, isXECDefault], name: "WalletsOnUserProfile_userId_isXECDefault_unique_constraint")
 }
 
 model UserProfile {

--- a/prisma/seeds/addressUserConnectors.ts
+++ b/prisma/seeds/addressUserConnectors.ts
@@ -2,21 +2,21 @@ export const addressUserConnectors = [
   {
     walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
     addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
-    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25'
+    userProfileId: 'dev-uid'
   },
   {
     walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
     addressId: 'a37b9a8c-d262-468b-b1dd-571434a16308',
-    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25'
+    userProfileId: 'dev-uid'
   },
   {
     walletId: '408093c4-2eff-4b35-a0c5-c369220ca236',
     addressId: '1ca6b7f5-6930-42a7-8ea4-8de57de03251',
-    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25'
+    userProfileId: 'dev-uid'
   },
   {
     walletId: 'ed9b656f-3fb0-4563-af9a-e6ad536c609d',
     addressId: '4f68e74f-de19-467a-b195-139d98217ada',
-    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25'
+    userProfileId: 'dev-uid'
   }
 ]

--- a/prisma/seeds/addressUserConnectors.ts
+++ b/prisma/seeds/addressUserConnectors.ts
@@ -2,21 +2,21 @@ export const addressUserConnectors = [
   {
     walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
     addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
-    userProfileId: 'dev-uid'
+    userId: 'dev-uid'
   },
   {
     walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
     addressId: 'a37b9a8c-d262-468b-b1dd-571434a16308',
-    userProfileId: 'dev-uid'
+    userId: 'dev-uid'
   },
   {
     walletId: '408093c4-2eff-4b35-a0c5-c369220ca236',
     addressId: '1ca6b7f5-6930-42a7-8ea4-8de57de03251',
-    userProfileId: 'dev-uid'
+    userId: 'dev-uid'
   },
   {
     walletId: 'ed9b656f-3fb0-4563-af9a-e6ad536c609d',
     addressId: '4f68e74f-de19-467a-b195-139d98217ada',
-    userProfileId: 'dev-uid'
+    userId: 'dev-uid'
   }
 ]

--- a/prisma/seeds/devUser.ts
+++ b/prisma/seeds/devUser.ts
@@ -12,14 +12,12 @@ export const createDevUserRawQueryList = [
 
 export const userProfiles = [
   {
-    id: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25',
-    userId: 'dev-uid',
+    id: 'dev-uid',
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
-    id: '2f51c061-9c5a-48b9-8212-98a8a6c079df',
-    userId: 'dev2-uid',
+    id: 'dev2-uid',
     createdAt: new Date(),
     updatedAt: new Date()
   }

--- a/prisma/seeds/walletUserConnectors.ts
+++ b/prisma/seeds/walletUserConnectors.ts
@@ -1,27 +1,27 @@
 export const walletUserConnectors = [
   {
     walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
-    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25',
+    userProfileId: 'dev-uid',
     isBCHDefault: true,
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
     walletId: '408093c4-2eff-4b35-a0c5-c369220ca236',
-    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25',
+    userProfileId: 'dev-uid',
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
     walletId: 'ed9b656f-3fb0-4563-af9a-e6ad536c609d',
-    userProfileId: 'e5352ec4-c8ab-4ba2-a3d9-2455ccccab25',
+    userProfileId: 'dev-uid',
     isXECDefault: true,
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
     walletId: 'db14e515-ede8-4949-b20a-a450f9171f77',
-    userProfileId: '2f51c061-9c5a-48b9-8212-98a8a6c079df',
+    userProfileId: 'dev2-uid',
     isXECDefault: true,
     isBCHDefault: true,
     createdAt: new Date(),

--- a/prisma/seeds/walletUserConnectors.ts
+++ b/prisma/seeds/walletUserConnectors.ts
@@ -1,27 +1,27 @@
 export const walletUserConnectors = [
   {
     walletId: '80fcbeb5-f6bd-4b3b-aca8-d604a670e978',
-    userProfileId: 'dev-uid',
+    userId: 'dev-uid',
     isBCHDefault: true,
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
     walletId: '408093c4-2eff-4b35-a0c5-c369220ca236',
-    userProfileId: 'dev-uid',
+    userId: 'dev-uid',
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
     walletId: 'ed9b656f-3fb0-4563-af9a-e6ad536c609d',
-    userProfileId: 'dev-uid',
+    userId: 'dev-uid',
     isXECDefault: true,
     createdAt: new Date(),
     updatedAt: new Date()
   },
   {
     walletId: 'db14e515-ede8-4949-b20a-a450f9171f77',
-    userProfileId: 'dev2-uid',
+    userId: 'dev2-uid',
     isXECDefault: true,
     isBCHDefault: true,
     createdAt: new Date(),

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -27,7 +27,7 @@ export interface DeleteWalletInput {
 const includeAddressesWithPaybuttons = {
   userProfile: {
     select: {
-      userProfileId: true,
+      userId: true,
       isXECDefault: true,
       isBCHDefault: true
     }
@@ -89,8 +89,8 @@ async function removeAddressesFromWallet (
         walletId: null
       },
       where: {
-        userProfileId_addressId: {
-          userProfileId: wallet.userProfile.userProfileId,
+        userId_addressId: {
+          userId: wallet.userProfile.userId,
           addressId
         }
       }
@@ -114,15 +114,15 @@ export async function connectAddressesToWallet (
     await prisma.addressesOnUserProfiles.upsert({
       create: {
         walletId: wallet.id,
-        userProfileId: wallet.userProfile.userProfileId,
+        userId: wallet.userProfile.userId,
         addressId
       },
       update: {
         walletId: wallet.id
       },
       where: {
-        userProfileId_addressId: {
-          userProfileId: wallet.userProfile.userProfileId,
+        userId_addressId: {
+          userId: wallet.userProfile.userId,
           addressId
         }
       }
@@ -208,9 +208,9 @@ export async function setDefaultWallet (wallet: WalletWithAddressesWithPaybutton
     // see if any wallet is already the default
     const prevXECDefault = await prisma.walletsOnUserProfile.findUnique({
       where: {
-        WalletsOnUserProfile_userProfileId_isXECDefault_unique_constraint: {
+        WalletsOnUserProfile_userId_isXECDefault_unique_constraint: {
           isXECDefault: true,
-          userProfileId: wallet.userProfile.userProfileId
+          userId: wallet.userProfile.userId
         }
       }
     })
@@ -246,9 +246,9 @@ export async function setDefaultWallet (wallet: WalletWithAddressesWithPaybutton
     // see if any wallet is already the default
     const prevBCHDefault = await prisma.walletsOnUserProfile.findUnique({
       where: {
-        WalletsOnUserProfile_userProfileId_isBCHDefault_unique_constraint: {
+        WalletsOnUserProfile_userId_isBCHDefault_unique_constraint: {
           isBCHDefault: true,
-          userProfileId: wallet.userProfile.userProfileId
+          userId: wallet.userProfile.userId
         }
       }
     })
@@ -341,13 +341,13 @@ export async function getWalletBalance (wallet: WalletWithAddressesWithPaybutton
   return ret
 }
 
-export async function getUserDefaultWalletForNetworkId (userProfileId: string, networkId: number): Promise<WalletWithAddressesWithPaybuttons> {
+export async function getUserDefaultWalletForNetworkId (userId: string, networkId: number): Promise<WalletWithAddressesWithPaybuttons> {
   let userWalletProfile: WalletsOnUserProfile | null
   if (networkId === BCH_NETWORK_ID) {
     userWalletProfile = await prisma.walletsOnUserProfile.findUnique({
       where: {
-        WalletsOnUserProfile_userProfileId_isBCHDefault_unique_constraint: {
-          userProfileId,
+        WalletsOnUserProfile_userId_isBCHDefault_unique_constraint: {
+          userId,
           isBCHDefault: true
         }
       }
@@ -355,8 +355,8 @@ export async function getUserDefaultWalletForNetworkId (userProfileId: string, n
   } else if (networkId === XEC_NETWORK_ID) {
     userWalletProfile = await prisma.walletsOnUserProfile.findUnique({
       where: {
-        WalletsOnUserProfile_userProfileId_isXECDefault_unique_constraint: {
-          userProfileId,
+        WalletsOnUserProfile_userId_isXECDefault_unique_constraint: {
+          userId,
           isXECDefault: true
         }
       }
@@ -375,8 +375,8 @@ export async function moveAddressesToDefaultWallet (wallet: WalletWithAddressesW
   if (wallet.userProfile === null) {
     throw new Error(RESPONSE_MESSAGES.NO_USER_PROFILE_FOUND_ON_WALLET_404.message)
   }
-  const XECDefaultWallet = await getUserDefaultWalletForNetworkId(wallet.userProfile?.userProfileId, XEC_NETWORK_ID)
-  const BCHDefaultWallet = await getUserDefaultWalletForNetworkId(wallet.userProfile?.userProfileId, BCH_NETWORK_ID)
+  const XECDefaultWallet = await getUserDefaultWalletForNetworkId(wallet.userProfile?.userId, XEC_NETWORK_ID)
+  const BCHDefaultWallet = await getUserDefaultWalletForNetworkId(wallet.userProfile?.userId, BCH_NETWORK_ID)
   for (const addr of wallet.userAddresses) {
     // Get id of default wallet to move
     let defaultWalletId: string
@@ -393,8 +393,8 @@ export async function moveAddressesToDefaultWallet (wallet: WalletWithAddressesW
         walletId: defaultWalletId
       },
       where: {
-        userProfileId_addressId: {
-          userProfileId: wallet.userProfile.userProfileId,
+        userId_addressId: {
+          userId: wallet.userProfile.userId,
           addressId: addr.addressId
         }
       }

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -157,10 +157,10 @@ export async function createWallet (values: CreateWalletInput): Promise<WalletWi
             userProfile: {
               connectOrCreate: {
                 where: {
-                  userId: values.userId
+                  id: values.userId
                 },
                 create: {
-                  userId: values.userId
+                  id: values.userId
                 }
               }
             }

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -510,7 +510,7 @@ describe('POST /api/wallets/', () => {
     expect(responseData.userProfile).toStrictEqual({
       isXECDefault: null,
       isBCHDefault: null,
-      userProfileId: expect.any(String)
+      userId: expect.any(String)
     })
     void expect(countWallets()).resolves.toBe(1)
   })
@@ -567,7 +567,7 @@ describe('POST /api/wallets/', () => {
     expect(responseData.userProfile).toStrictEqual({
       isXECDefault: null,
       isBCHDefault: null,
-      userProfileId: expect.any(String)
+      userId: expect.any(String)
     })
     expect(responseData.userAddresses).toEqual(
       expect.arrayContaining([expectedAddressObject])
@@ -589,7 +589,7 @@ describe('POST /api/wallets/', () => {
     expect(responseData.userProfile).toStrictEqual({
       isXECDefault: null,
       isBCHDefault: null,
-      userProfileId: expect.any(String)
+      userId: expect.any(String)
     })
     expect(responseData.userAddresses).toEqual(
       expect.arrayContaining([expectedAddressObject])

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -65,7 +65,7 @@ export const mockedXECAddress = {
 
 export const mockedAddressesOnUserProfile = {
   addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
-  userProfileId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
+  userId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
   walletId: '570fbb7e-fc7f-4096-8541-e68405cf9b56',
   createdAt: new Date('2022-05-27T15:18:42.000Z'),
   updatedAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -204,12 +204,12 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
   userProfile: {
     isXECDefault: null,
     isBCHDefault: null,
-    userProfileId: 'ddde6236-bde3-425f-b0fc-13a007cc584b'
+    userId: 'ddde6236-bde3-425f-b0fc-13a007cc584b'
   },
   userAddresses: [
     {
       addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
-      userProfileId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
+      userId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
       walletId: '570fbb7e-fc7f-4096-8541-e68405cf9b56',
       createdAt: new Date('2022-05-27T15:18:42.000Z'),
       updatedAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -254,7 +254,7 @@ export const mockedWallet: WalletWithAddressesWithPaybuttons = {
     },
     {
       addressId: 'a37b9a8c-d262-468b-b1dd-571434a16308',
-      userProfileId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
+      userId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
       walletId: '0da1977f-d65b-43a7-a7c8-b2a1f01da7a0',
       createdAt: new Date('2022-05-27T15:18:42.000Z'),
       updatedAt: new Date('2022-05-27T15:18:42.000Z'),
@@ -321,7 +321,7 @@ export const mockedWalletList = [
 
 export const mockedWalletsOnUserProfile = {
   walletId: '1f79bbe4-1c56-48af-b703-b22efd629104',
-  userProfileId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
+  userId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
   isXECDefault: null,
   isBCHDefault: null,
   createdAt: new Date('2022-05-27T15:18:42.000Z'),


### PR DESCRIPTION
Description
---
Changes the `UserProfile` table so its primary key is the same as the table in the `supertokens` table.

Before, if I had the `id` for a `userProfile`, I would have to fetch that info from the DB to get its `userId` just to e.g. see the wallets or addresses associated with it. Now `id` and `userId` are the same thing, which is what before was called `userId`.

Test plan
---
Nothing should change.