### PR TITLE
[#Issue 498, #491] feat: creating and deleting paybuttons updated address to user relation

### DIFF
--- a/components/Paybutton/EditButtonForm.tsx
+++ b/components/Paybutton/EditButtonForm.tsx
@@ -8,19 +8,20 @@ import s from '../Wallet/wallet.module.css'
 import EditIcon from 'assets/edit-icon.png'
 import TrashIcon from 'assets/trash-icon.png'
 import axios from 'axios'
+import Router from 'next/router'
 import { appInfo } from 'config/appInfo'
 
 interface IProps {
-  onDelete: Function
   paybutton: PaybuttonWithAddresses
   refreshPaybutton: Function
 }
 
-export default function EditButtonForm ({ paybutton, onDelete, refreshPaybutton }: IProps): ReactElement {
+export default function EditButtonForm ({ paybutton, refreshPaybutton }: IProps): ReactElement {
   const { register, handleSubmit, reset } = useForm<PaybuttonPOSTParameters>()
   const [modal, setModal] = useState(false)
   const [deleteModal, setDeleteModal] = useState(false)
   const [error, setError] = useState('')
+  const [deleteError, setDeleteError] = useState('')
   const [name, setName] = useState(paybutton.name)
   const [addresses, setAddresses] = useState(paybutton.addresses.map((conn) => conn.address.address).join('\n'))
 
@@ -42,6 +43,17 @@ export default function EditButtonForm ({ paybutton, onDelete, refreshPaybutton 
       refreshPaybutton()
     } catch (err: any) {
       setError(err.response.data.message)
+    }
+  }
+
+  async function onDelete (paybuttonId: string): Promise<void> {
+    try {
+      const res = await axios.delete<PaybuttonWithAddresses>(`${appInfo.websiteDomain}/api/paybutton/${paybuttonId}`)
+      if (res.status === 200) {
+        void Router.push(`${appInfo.websiteDomain}/buttons/`)
+      }
+    } catch (err: any) {
+      setDeleteError(err.response.data.message)
     }
   }
 
@@ -87,9 +99,10 @@ export default function EditButtonForm ({ paybutton, onDelete, refreshPaybutton 
             <div className={`${style.form_ctn} ${style.delete_button_form_ctn}`}>
                 <label htmlFor='name'>Are you sure you want to delete {paybutton.name}?<br />This action cannot be undone.</label>
                 <div className={style.btn_row}>
+                  {(deleteError === undefined || deleteError === '') ? null : <div className={style.error_message}>{deleteError}</div>}
                   <div>
 
-                    <button onClick={() => { onDelete(paybutton.id) }} className={style.delete_confirm_btn}>Yes, Delete This Button</button>
+                    <button onClick={() => { void onDelete(paybutton.id) }} className={style.delete_confirm_btn}>Yes, Delete This Button</button>
                     <button onClick={() => { setDeleteModal(false); reset(); setModal(true) }} className={style.cancel_btn}>Cancel</button>
                   </div>
                 </div>

--- a/components/Paybutton/PaybuttonDetail.tsx
+++ b/components/Paybutton/PaybuttonDetail.tsx
@@ -10,10 +10,9 @@ import { checkNetwork } from './PaybuttonList'
 
 interface IProps {
   paybutton: PaybuttonWithAddresses
-  onDelete: Function
   refreshPaybutton: Function
 }
-export default ({ paybutton, onDelete, refreshPaybutton }: IProps): FunctionComponent => {
+export default ({ paybutton, refreshPaybutton }: IProps): FunctionComponent => {
   return (
     <div className={style.paybutton_list_ctn}>
       <div className={`${style.paybutton_card} ${style.paybutton_card_no_hover}`}>
@@ -26,7 +25,7 @@ export default ({ paybutton, onDelete, refreshPaybutton }: IProps): FunctionComp
           </div>
         </div>
           <div>
-            <EditButtonForm paybutton={paybutton} onDelete={onDelete} refreshPaybutton={refreshPaybutton}/>
+            <EditButtonForm paybutton={paybutton} refreshPaybutton={refreshPaybutton}/>
           </div>
         </div>
           <div>

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -28,6 +28,7 @@ export const RESPONSE_MESSAGES = {
   NO_BUTTON_FOUND_404: { statusCode: 404, message: 'No button found.' },
   NO_WALLET_FOUND_404: { statusCode: 404, message: 'No wallet found.' },
   NO_USER_PROFILE_FOUND_ON_WALLET_404: { statusCode: 404, message: 'No user profile found for wallet.' },
+  NO_USER_PROFILE_FOUND_ON_PAYBUTTON_404: { statusCode: 404, message: 'No user profile found for paybutton.' },
   MULTIPLE_ADDRESSES_FOUND_400: { statusCode: 400, message: 'Multiple addresses found.' },
   RESOURCE_DOES_NOT_BELONG_TO_USER_400: { statusCode: 400, message: 'Resource does not belong to user.' },
   MISSING_PRICE_API_URL_400: { statusCode: 400, message: 'Missing PRICE_API_URL environment variable.' },

--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -11,8 +11,6 @@ import supertokensNode from 'supertokens-node'
 import * as SuperTokensConfig from '../../config/backendConfig'
 import Session from 'supertokens-node/recipe/session'
 import { GetServerSideProps } from 'next'
-import { appInfo } from 'config/appInfo'
-import axios from 'axios'
 
 const ThirdPartyEmailPasswordAuthNoSSR = dynamic(
   new Promise((resolve, reject) =>
@@ -117,19 +115,12 @@ class ProtectedPage extends React.Component<PaybuttonProps, PaybuttonState> {
     void ThirdPartyEmailPassword.redirectToAuth()
   }
 
-  async onDelete (paybuttonId: string): Promise<void> {
-    const res = await axios.delete<PaybuttonWithAddresses>(`${appInfo.websiteDomain}/api/paybutton/${paybuttonId}`)
-    if (res.status === 200) {
-      void Router.push(`${appInfo.websiteDomain}/buttons/`)
-    }
-  }
-
   render (): React.ReactElement {
     if (this.state.paybutton !== undefined && Object.keys(this.state.transactions).length !== 0) {
       return (
         <>
           <div className='back_btn' onClick={() => Router.back()}>Back</div>
-          <PaybuttonDetail paybutton={this.state.paybutton} onDelete={this.onDelete} refreshPaybutton={this.refreshPaybutton}/>
+          <PaybuttonDetail paybutton={this.state.paybutton} refreshPaybutton={this.refreshPaybutton}/>
           <h4>Transactions</h4>
           <AddressTransactions addressTransactions={this.state.transactions} />
         </>

--- a/redis/clientInstance.ts
+++ b/redis/clientInstance.ts
@@ -1,14 +1,41 @@
 import { appInfo } from 'config/appInfo'
 import IORedis from 'ioredis'
 
-export const redis = new IORedis(appInfo.redisURL, {
-  maxRetriesPerRequest: null
-})
+class RedisMocked {
+  async get (_: string): Promise<string> {
+    return ''
+  }
 
-export const redisBullMQ = new IORedis(appInfo.redisURL, {
-  maxRetriesPerRequest: null,
-  db: 1
-})
+  async set (key: string, data: any): Promise<void> {
+  }
 
-redis.on('error', (err) => console.log('Redis Client Error', err))
-redisBullMQ.on('error', (err) => console.log('Redis BullMQ Client Error', err))
+  async keys (key: string): Promise<string[]> {
+    return []
+  }
+
+  async on (key: string, fn: Function): Promise<void> {
+  }
+}
+
+const getRedisClient = (isBullMQ = false): IORedis | RedisMocked => {
+  console.log('env', process.env)
+  if (process.env.NODE_ENV === 'test') {
+    return new RedisMocked()
+  }
+  if (isBullMQ) {
+    return new IORedis(appInfo.redisURL, {
+      maxRetriesPerRequest: null,
+      db: 1
+    })
+  }
+
+  return new IORedis(appInfo.redisURL, {
+    maxRetriesPerRequest: null
+  })
+}
+
+export const redis = getRedisClient()
+export const redisBullMQ = getRedisClient(true)
+
+void redis.on('error', (err) => console.log('Redis Client Error', err))
+void redisBullMQ.on('error', (err) => console.log('Redis BullMQ Client Error', err))

--- a/services/addressesOnUserProfileService.ts
+++ b/services/addressesOnUserProfileService.ts
@@ -1,0 +1,29 @@
+import prisma from 'prisma/clientInstance'
+
+export const connectAddressToUser = async (addressId: string, userId: string, walletId: string | undefined): Promise<void> => {
+  void await prisma.addressesOnUserProfiles.upsert({
+    create: {
+      walletId,
+      userId,
+      addressId
+    },
+    update: walletId == null ? {} : { walletId },
+    where: {
+      userId_addressId: {
+        userId,
+        addressId
+      }
+    }
+  })
+}
+
+export const disconnectAddressFromUser = async (addressId: string, userId: string): Promise<void> => {
+  await prisma.addressesOnUserProfiles.delete({
+    where: {
+      userId_addressId: {
+        userId,
+        addressId
+      }
+    }
+  })
+}

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -1,6 +1,7 @@
 import * as addressService from 'services/addressService'
 import { Prisma, WalletsOnUserProfile } from '@prisma/client'
 import prisma from 'prisma/clientInstance'
+import { connectAddressToUser } from 'services/addressesOnUserProfileService'
 import { RESPONSE_MESSAGES, XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 
 export interface CreateWalletInput {
@@ -111,22 +112,7 @@ export async function connectAddressesToWallet (
     if (addr === null) {
       throw new Error(RESPONSE_MESSAGES.NO_ADDRESS_FOUND_404.message)
     }
-    await prisma.addressesOnUserProfiles.upsert({
-      create: {
-        walletId: wallet.id,
-        userId: wallet.userProfile.userId,
-        addressId
-      },
-      update: {
-        walletId: wallet.id
-      },
-      where: {
-        userId_addressId: {
-          userId: wallet.userProfile.userId,
-          addressId
-        }
-      }
-    })
+    void await connectAddressToUser(addressId, wallet.userProfile.userId, wallet.id)
   }
 }
 

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -133,33 +133,30 @@ export async function setAddressListForWallet (
 
 export async function createWallet (values: CreateWalletInput): Promise<WalletWithAddressesWithPaybuttons> {
   const defaultForNetworkIds = getDefaultForNetworkIds(values.isXECDefault, values.isBCHDefault)
-  const newWalletId: string = await prisma.$transaction(async (prisma) => {
-    const w = await prisma.wallet.create({
-      data: {
-        providerUserId: values.userId,
-        name: values.name,
-        userProfile: {
-          create: {
-            userProfile: {
-              connectOrCreate: {
-                where: {
-                  id: values.userId
-                },
-                create: {
-                  id: values.userId
-                }
+  const wallet = await prisma.wallet.create({
+    data: {
+      providerUserId: values.userId,
+      name: values.name,
+      userProfile: {
+        create: {
+          userProfile: {
+            connectOrCreate: {
+              where: {
+                id: values.userId
+              },
+              create: {
+                id: values.userId
               }
             }
           }
         }
-      },
-      include: includeAddressesWithPaybuttons
-    })
-    await setAddressListForWallet(prisma, values.addressIdList, w)
-    return w.id
+      }
+    },
+    include: includeAddressesWithPaybuttons
   })
+  await setAddressListForWallet(prisma, values.addressIdList, wallet)
   return await setDefaultWallet(
-    await fetchWalletById(newWalletId),
+    await fetchWalletById(wallet.id),
     defaultForNetworkIds
   )
 }

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -25,17 +25,26 @@ import {
   countPaybuttons,
   countAddresses,
   countWallets,
-  createCurrentPrices
+  createCurrentPrices,
+  createUserProfile
 } from 'tests/utils'
 
 import { RESPONSE_MESSAGES, NETWORK_SLUGS } from 'constants/index'
-
+const setUpUsers = async (): Promise<void> => {
+  await createUserProfile('test-u-id')
+  await createUserProfile('test-u-id2')
+  await createUserProfile('test-other-u-id')
+}
 jest.mock('../../utils/setSession', () => {
   return {
     setSession: (req: any, res: any) => {
       req.session = { userId: 'test-u-id' }
     }
   }
+})
+
+beforeAll(async () => {
+  await setUpUsers()
 })
 
 afterAll(async () => {

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -322,6 +322,7 @@ export const mockedWalletList = [
 export const mockedWalletsOnUserProfile = {
   walletId: '1f79bbe4-1c56-48af-b703-b22efd629104',
   userId: 'ddde6236-bde3-425f-b0fc-13a007cc584b',
+  addressId: '-',
   isXECDefault: null,
   isBCHDefault: null,
   createdAt: new Date('2022-05-27T15:18:42.000Z'),

--- a/tests/unittests/paybuttonService.test.ts
+++ b/tests/unittests/paybuttonService.test.ts
@@ -25,6 +25,8 @@ describe('Create services', () => {
   it('Should return paybutton nested', async () => {
     prismaMock.paybutton.create.mockResolvedValue(mockedPaybutton)
     prisma.paybutton.create = prismaMock.paybutton.create
+    prismaMock.address.findMany.mockResolvedValue([])
+    prisma.address.findMany = prismaMock.address.findMany
     prismaMock.addressesOnUserProfiles.upsert.mockResolvedValue(mockedWalletsOnUserProfile)
     prisma.addressesOnUserProfiles.upsert = prismaMock.addressesOnUserProfiles.upsert
 
@@ -59,6 +61,8 @@ describe('Delete services', () => {
     prismaMock.paybutton.findUnique.mockResolvedValue(mockedPaybutton)
     prisma.paybutton.findUnique = prismaMock.paybutton.findUnique
 
+    prismaMock.address.findMany.mockResolvedValue([])
+    prisma.address.findMany = prismaMock.address.findMany
     prismaMock.addressesOnUserProfiles.delete.mockResolvedValue(mockedWalletsOnUserProfile)
     prisma.addressesOnUserProfiles.delete = prismaMock.addressesOnUserProfiles.delete
     prismaMock.$transaction.mockImplementation(
@@ -82,6 +86,8 @@ describe('Update services', () => {
     prismaMock.paybutton.update.mockResolvedValue(mockedPaybutton)
     prisma.paybutton.update = prismaMock.paybutton.update
     prismaMock.addressesOnButtons.deleteMany.mockResolvedValue({ count: 0 })
+    prismaMock.address.findMany.mockResolvedValue([])
+    prisma.address.findMany = prismaMock.address.findMany
     prisma.addressesOnButtons.deleteMany = prismaMock.addressesOnButtons.deleteMany
     prisma.addressesOnButtons.deleteMany = prismaMock.addressesOnButtons.deleteMany
     prismaMock.$transaction.mockImplementation(

--- a/tests/unittests/paybuttonService.test.ts
+++ b/tests/unittests/paybuttonService.test.ts
@@ -1,7 +1,7 @@
 import prisma from 'prisma/clientInstance'
 import * as paybuttonService from 'services/paybuttonService'
 import { prismaMock } from 'prisma/mockedClient'
-import { mockedPaybutton, mockedPaybuttonList, mockedNetwork } from '../mockedObjects'
+import { mockedPaybutton, mockedPaybuttonList, mockedNetwork, mockedWalletsOnUserProfile } from '../mockedObjects'
 
 describe('Fetch services', () => {
   it('Should fetch paybutton by id', async () => {
@@ -25,6 +25,8 @@ describe('Create services', () => {
   it('Should return paybutton nested', async () => {
     prismaMock.paybutton.create.mockResolvedValue(mockedPaybutton)
     prisma.paybutton.create = prismaMock.paybutton.create
+    prismaMock.addressesOnUserProfiles.upsert.mockResolvedValue(mockedWalletsOnUserProfile)
+    prisma.addressesOnUserProfiles.upsert = prismaMock.addressesOnUserProfiles.upsert
 
     prismaMock.$transaction.mockImplementation(
       (fn: (prisma: any) => any) => {
@@ -56,6 +58,15 @@ describe('Delete services', () => {
 
     prismaMock.paybutton.findUnique.mockResolvedValue(mockedPaybutton)
     prisma.paybutton.findUnique = prismaMock.paybutton.findUnique
+
+    prismaMock.addressesOnUserProfiles.delete.mockResolvedValue(mockedWalletsOnUserProfile)
+    prisma.addressesOnUserProfiles.delete = prismaMock.addressesOnUserProfiles.delete
+    prismaMock.$transaction.mockImplementation(
+      (fn: (prisma: any) => any) => {
+        return fn(prisma)
+      }
+    )
+    prisma.$transaction = prismaMock.$transaction
 
     const deletePaybuttonInput = {
       userId: 'mocked-uid',

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -5,6 +5,7 @@ import { createWallet, WalletWithAddressesWithPaybuttons } from 'services/wallet
 import { upsertCurrentPricesForNetworkId } from 'services/priceService'
 import { SUPPORTED_ADDRESS_PATTERN } from 'constants/index'
 import RandExp from 'randexp'
+import { UserProfile } from '@prisma/client'
 
 export const testEndpoint = async (requestOptions: httpMocks.RequestOptions, endpoint: Function): Promise<httpMocks.MockResponse<any>> => {
   const req = httpMocks.createRequest(requestOptions)
@@ -29,6 +30,14 @@ const addressRandexp = new RandExp(SUPPORTED_ADDRESS_PATTERN)
 export const createWalletForUser = async (userId: string, addressIdList: string[], isXECDefault = false, isBCHDefault = false): Promise<WalletWithAddressesWithPaybuttons> => {
   const name = Math.random().toString(36).slice(2)
   return await createWallet({ userId, name, addressIdList, isXECDefault, isBCHDefault })
+}
+
+export const createUserProfile = async (userId: string): Promise<UserProfile> => {
+  return await prisma.userProfile.create({
+    data: {
+      id: userId
+    }
+  })
 }
 
 export const createPaybuttonForUser = async (userId: string, addressList?: string[], walletId?: string): Promise<PaybuttonWithAddresses> => {


### PR DESCRIPTION
Depends on
---
- [x] #497

Description
---
Almost fixes #491 and #498: Updates the table `AddressesOnUserProfiles` when paybuttons are removed or created, but not when they are updated 

Paybutton update will be addressed in the next PR


Test plan
---
Create paybuttons, delete paybuttons, and check in the wallets view if the shown networks are correctly reflecting the addresses associated do the wallets through its paybuttons.
