### PR TITLE
411 6 2 chronik subscribe transactions implemented

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -111,7 +111,7 @@ export const QUOTE_IDS: KeyValueT<number> = { USD: 1, CAD: 2 }
 
 export type BLOCKCHAIN_CLIENT_OPTIONS = 'grpc' | 'chronik'
 export const NETWORK_BLOCKCHAIN_CLIENTS: KeyValueT<BLOCKCHAIN_CLIENT_OPTIONS> = {
-  ecash: 'grpc',
+  ecash: 'chronik',
   bitcoincash: 'grpc'
 }
 

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -180,7 +180,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
     }
     // create unconfirmed or confirmed transaction
     if (msg.type === 'AddedToMempool' || msg.type === 'Confirmed') {
-      const transaction = await await this.chronik.tx(msg.txid)
+      const transaction = await this.chronik.tx(msg.txid)
       const addressWithTransactions = await this.getPrismaTransactionsForSubscribedAddresses(transaction)
       await Promise.all(
         addressWithTransactions.map(async addressWithTransaction => {


### PR DESCRIPTION
Description
---
Subscribes to receive broadcast of new transactions in the blockchain (chronik client only). They should be added to our database at the same time as they happen in the blockchain, first as an unconfirmed transaction, then as a confirmed transaction when it confirms.

Also, this PR sets chronik as the blockchain client to be used for all XEC addresses.

Test plan
---
- add an address you control to the application (one that will receive the transfer)
- run: yarn docker c, then flushall, then exit
- run: yarn docker jr
- run: yarn docker jw
- transfer to the address in step 1
- run database select * from paybutton.Transaction, you will see your transaction added as unconfirmed fist, then as confirmed
