### PR TITLE
[Issue #494] UI - payments page button column

### DIFF
--- a/pages/payments/index.tsx
+++ b/pages/payments/index.tsx
@@ -95,11 +95,12 @@ export default function Payments ({ userId }: PaybuttonsProps): React.ReactEleme
         accessor: 'buttonDisplayDataList',
         Cell: (cellProps) => {
           return (
-            <> {cellProps.cell.value.map((buttonDisplayData: ButtonDisplayData) =>
+            <div className='payments-btn-cell'> {cellProps.cell.value.map((buttonDisplayData: ButtonDisplayData) =>
               <div style={{ textAlign: 'center' }} className="table-button" key={buttonDisplayData.id}>
               <Link href={`/button/${buttonDisplayData.id}`}>{buttonDisplayData.name}</Link>
               </div>
-            )} </>
+            )}
+             </div>
 
           )
         }

--- a/pages/payments/index.tsx
+++ b/pages/payments/index.tsx
@@ -101,7 +101,6 @@ export default function Payments ({ userId }: PaybuttonsProps): React.ReactEleme
               </div>
             )}
              </div>
-
           )
         }
       },

--- a/styles/global.css
+++ b/styles/global.css
@@ -162,6 +162,12 @@ body[data-theme='dark'] button {
   margin-left: 22px;
 }
 
+.payments-btn-cell {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
 .table-button a {
   border: 1px solid var(--primary-bg-color);
   padding: 2px 10px;
@@ -169,7 +175,7 @@ body[data-theme='dark'] button {
   display: inline-block;
   font-size: 12px;
   word-break: keep-all;
-  margin: 0;
+  margin: 2px;
   box-sizing: border-box;
   transition: all ease-in-out 200ms;
 }


### PR DESCRIPTION
Description
Adding some styles to allow for multiple buttons to be on the same line in the button column on the payments page on larger screens. Currently they each are on new line if there are multiple buttons

Test plan
Run the app and see if the buttons column is no longer stacking multiple buttons 
