### PR TITLE
[Issue #334] feat: Server side events server setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-error.log*
 
 jobs/out.log
 /prisma/seeds/prices.csv
+redis/dump.rdb
+sse-service/out.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,4 @@ USER node
 WORKDIR /home/node/src/
 ENV PATH /home/node/src/node_modules/.bin:$PATH
 EXPOSE 3000
+EXPOSE 5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     build: .
     ports:
       - "3000:3000"
+      - "5000:5000"
     volumes:
       - .:/home/node/src
     command: sh ./scripts/paybutton-server-start.sh

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "dotenv -e .env.development -c development next dev",
     "build": "next build && tsc --project tsconfig.json",
     "initJobs": "dotenv -e .env.development -e .env -c -- tsx jobs/initJobs.ts",
+    "initSSEServer": "dotenv -e .env.development -e .env -c -- ts-node -O '{\"module\":\"commonjs\"}' sse-service/server.ts",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "prod": "npm run build && NODE_ENV=production pm2 start dist/index.js",
     "test": "dotenv -e .env.test -- ts-node -O '{\"module\":\"commonjs\"}' node_modules/jest/bin/jest.js",

--- a/scripts/docker-exec-shortcuts.sh
+++ b/scripts/docker-exec-shortcuts.sh
@@ -53,6 +53,17 @@ case "$command" in
         echo "Starting jobs..."
         eval "$base_command_node" sh ./scripts/init-jobs.sh
         ;;
+    "serverwatch" | "sw")
+        eval "$base_command_node" watch -n 1 'cat sse-service/out.log'
+        ;;
+    "serverstop" | "ss")
+        eval "$base_command_node" tmux kill-session -t sse && echo SSE server stoped. || echo SSE server not running.
+        ;;
+    "serverrestart" | "sr")
+        yarn docker ss
+        echo "Starting SSE server..."
+        eval "$base_command_node" sh ./scripts/init-sse-server.sh
+        ;;
     "yarn" | "y")
         eval "$base_command_node" yarn "$@"
         ;;
@@ -129,6 +140,9 @@ case "$command" in
         echo "  jw, jobswatch               [$node_container_name]     watch jobs logs"
         echo "  js, jobsstop                [$node_container_name]     stop jobs"
         echo "  jr, jobsrestart             [$node_container_name]     restart jobs"
+        echo "  sw, serverwatch            [$node_container_name]     watch SSE server logs"
+        echo "  ss, serverstop             [$node_container_name]     stop SSE server"
+        echo "  sr, serverrestart          [$node_container_name]     restart SSE server"
         ;;
 esac
 

--- a/scripts/init-sse-server.sh
+++ b/scripts/init-sse-server.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+date "+start date: %Y-%m-%d %H:%M:%S" > sse-service/out.log
+tmux new-session -d -s "sse" "yarn initSSEServer 2>&1 | tee -a sse-service/out.log"

--- a/scripts/paybutton-server-start.sh
+++ b/scripts/paybutton-server-start.sh
@@ -4,4 +4,5 @@ yarn || exit 1
 yarn prisma migrate dev || exit 1
 yarn prisma db seed || exit 1
 sh scripts/init-jobs.sh || exit 1
+sh scripts/init-sse-server.sh || exit 1
 yarn dev || exit 1

--- a/sse-service/client.ts
+++ b/sse-service/client.ts
@@ -3,7 +3,7 @@ export async function broadcastTxInsertion (addressList: string[]): Promise<Resp
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'X-Auth-Key': process.env.AUTH_KEY ?? ''
+      'X-Auth-Key': process.env.SSE_AUTH_KEY ?? ''
     },
     body: JSON.stringify({ addressList })
   })

--- a/sse-service/client.ts
+++ b/sse-service/client.ts
@@ -1,0 +1,10 @@
+export async function broadcastTxInsertion (addressList: string[]): Promise<Response> {
+  return await fetch('http://localhost:5000/broadcast-new-tx', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Auth-Key': process.env.AUTH_KEY ?? ''
+    },
+    body: JSON.stringify({ addressList })
+  })
+}

--- a/sse-service/server.ts
+++ b/sse-service/server.ts
@@ -27,7 +27,7 @@ app.get('/events', (req: Request, res: Response) => {
 
 app.post('/broadcast-new-tx', express.json(), (req: Request, res: Response) => {
   const authKey = req.headers['x-auth-key']
-  if (authKey !== process.env.AUTH_KEY) {
+  if (authKey !== process.env.SSE_AUTH_KEY) {
     return res.status(403).json({ error: 'Unauthorized' })
   }
 

--- a/sse-service/server.ts
+++ b/sse-service/server.ts
@@ -36,12 +36,10 @@ app.post('/broadcast-new-tx', express.json(), (req: Request, res: Response) => {
     return res.status(400).json({ error: 'Could not broadcast empty addressList' })
   }
 
-  clients.forEach(client =>
-    addressList.forEach(addr => {
-      client.write(`event: tx-${addr}\n`)
-      client.write('data: newtx\n\n')
-    })
-  )
+  clients.forEach(client => {
+    client.write('event: new-tx\n')
+    client.write(`data: ${JSON.stringify(addressList)}\n\n`)
+  })
 
   res.json({ statusCode: 200, message: `Message broadcasted to ${clients.length}` })
 })

--- a/sse-service/server.ts
+++ b/sse-service/server.ts
@@ -1,0 +1,51 @@
+import express, { Request, Response } from 'express'
+import { Server } from 'http'
+import cors from 'cors'
+
+const app = express()
+app.use(cors())
+app.options('/events', cors())
+const server = new Server(app)
+
+let clients: Response[] = []
+
+app.get('/events', (req: Request, res: Response) => {
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Content-Encoding', 'none')
+  res.setHeader('Cache-Control', 'no-cache')
+  res.setHeader('Connection', 'keep-alive')
+  res.flushHeaders()
+
+  clients.push(res)
+  console.log('client connected', clients.length)
+
+  req.on('close', () => {
+    clients = clients.filter(client => client !== res)
+    console.log('client disconnected', 'now have', clients.length)
+  })
+})
+
+app.post('/broadcast-new-tx', express.json(), (req: Request, res: Response) => {
+  const authKey = req.headers['x-auth-key']
+  if (authKey !== process.env.AUTH_KEY) {
+    return res.status(403).json({ error: 'Unauthorized' })
+  }
+
+  const addressList: string[] = req.body.addressList
+  if (addressList === undefined || addressList.length === 0) {
+    return res.status(400).json({ error: 'Could not broadcast empty addressList' })
+  }
+
+  clients.forEach(client =>
+    addressList.forEach(addr => {
+      client.write(`event: tx-${addr}\n`)
+      client.write('data: newtx\n\n')
+    })
+  )
+
+  res.json({ statusCode: 200, message: `Message broadcasted to ${clients.length}` })
+})
+
+server.listen(5000, () => {
+  console.log('SSE service listening on http://localhost:5000')
+})


### PR DESCRIPTION
Description
---
Part of #334.
Creates a dedicated server to send Server Side Events (SSE). In the next PR this will be used to send information to all clients viewing a paybutton page that one of their addresses has been updated, so that the transactions are refreshed live.


Test plan
---
1. Add a secret key to your `.env.local` file in the format: `SSE_AUTH_KEY=b5e38f40-0798-47ef-a4d2-1d6a41393af4`. I used the command `uuidgen` to get this example.
2. Restart the containers.
3. Listen to the server events with `curl -N http://localhost:5000/events`
4. Broadcast an tx event with e.g. `curl -X POST -H 'Content-type: application/json' -H 'X-auth-key: 71e4e0bf-976f-4408-9a7c-87bceab020a2' --data-raw '{"addressList": ["ecash:qzjg2tfdjlcm3hqy4vz2v08846a78v4mn586t0c27y"]}'  http://localhost:5000/broadcast-new-tx`. Notice  that in this command, the only relevant parameter for the brodcasted information is which addresses are affected by a new incoming tx.
5. See on the listening console the event info arriving.

When broadcasting a event, the returned response tells how many clients received the event. Inspecting `sse-service/out.log` can show how many clients are connected at once.