### PR TITLE
 [Issue #498, #491] feat: updating paybuttons updates address to user relation 

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -27,6 +27,7 @@ export const RESPONSE_MESSAGES = {
   NO_TRANSACTION_FOUND_404: { statusCode: 404, message: 'No transaction found.' },
   NO_BUTTON_FOUND_404: { statusCode: 404, message: 'No button found.' },
   NO_WALLET_FOUND_404: { statusCode: 404, message: 'No wallet found.' },
+  NO_WALLET_FOUND_FOR_USER_ADDRESS_404: { statusCode: 404, message: 'No wallet found for user address.' },
   NO_USER_PROFILE_FOUND_ON_WALLET_404: { statusCode: 404, message: 'No user profile found for wallet.' },
   NO_USER_PROFILE_FOUND_ON_PAYBUTTON_404: { statusCode: 404, message: 'No user profile found for paybutton.' },
   MULTIPLE_ADDRESSES_FOUND_400: { statusCode: 400, message: 'Multiple addresses found.' },
@@ -47,6 +48,7 @@ export const RESPONSE_MESSAGES = {
   DEFAULT_WALLET_CANNOT_BE_DELETED_400: { statusCode: 400, message: 'A default wallet cannot be deleted.' },
   USER_PROFILE_NOT_FOUND_400: { statusCode: 400, message: 'User profile not found.' },
   CACHED_PAYMENT_NOT_FOUND_404: { statusCode: 404, message: 'Cached payment not found.' },
+  NO_CONTEXT_TO_INFER_USER_ADRESS_WALLET_400: { statusCode: 400, message: 'Trying to update the wallet for a user address without contex.' },
   NO_ADDRESS_FOUND_FOR_TRANSACTION_404: { statusCode: 404, message: 'No address found for transaction.' }
 }
 

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -50,9 +50,7 @@ export const RESPONSE_MESSAGES = {
   NO_ADDRESS_FOUND_FOR_TRANSACTION_404: { statusCode: 404, message: 'No address found for transaction.' }
 }
 
-export interface KeyValueT<T> {
-  [key: string]: T
-}
+export type KeyValueT<T> = Record<string, T>
 
 export const NETWORK_SLUGS: KeyValueT<string> = {
   ecash: 'ecash',
@@ -60,6 +58,10 @@ export const NETWORK_SLUGS: KeyValueT<string> = {
   ectest: 'ectest',
   bchtest: 'bchtest',
   bchreg: 'bchreg'
+}
+export const NETWORK_IDS_FROM_SLUGS: KeyValueT<number> = {
+  ecash: 1,
+  bitcoincash: 2
 }
 
 // When fetching some address transactions, number of transactions to fetch at a time.

--- a/pages/api/paybutton/[id].ts
+++ b/pages/api/paybutton/[id].ts
@@ -13,7 +13,6 @@ export default async (
   if (req.method === 'GET') {
     try {
       const paybutton = await paybuttonService.fetchPaybuttonById(paybuttonId)
-      if (paybutton == null) throw new Error(RESPONSE_MESSAGES.NOT_FOUND_404.message)
       res.status(200).json(paybutton)
     } catch (err: any) {
       switch (err.message) {

--- a/pages/api/paybutton/[id].ts
+++ b/pages/api/paybutton/[id].ts
@@ -15,9 +15,10 @@ export default async (
       const paybutton = await paybuttonService.fetchPaybuttonById(paybuttonId)
       res.status(200).json(paybutton)
     } catch (err: any) {
-      switch (err.message) {
-        case RESPONSE_MESSAGES.NOT_FOUND_404.message:
-          res.status(404).json(RESPONSE_MESSAGES.NOT_FOUND_404)
+      const parsedError = parseError(err)
+      switch (parsedError.message) {
+        case RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message:
+          res.status(404).json(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404)
           break
         default:
           res.status(500).json({ statusCode: 500, message: err.message })

--- a/pages/api/paybutton/[id].ts
+++ b/pages/api/paybutton/[id].ts
@@ -46,8 +46,12 @@ export default async (
   if (req.method === 'PATCH') {
     try {
       const values = req.body
-      const updatePaybuttonInput = parsePaybuttonPATCHRequest(values)
-      const paybutton = await paybuttonService.updatePaybutton(paybuttonId, updatePaybuttonInput)
+      const params = {
+        ...values,
+        userId
+      }
+      const updatePaybuttonInput = parsePaybuttonPATCHRequest(params, paybuttonId)
+      const paybutton = await paybuttonService.updatePaybutton(updatePaybuttonInput)
       res.status(200).json(paybutton)
     } catch (err: any) {
       const parsedError = parseError(err)

--- a/services/addressesOnUserProfileService.ts
+++ b/services/addressesOnUserProfileService.ts
@@ -1,4 +1,6 @@
 import prisma from 'prisma/clientInstance'
+import { type Wallet } from '@prisma/client'
+import { RESPONSE_MESSAGES } from 'constants/index'
 
 export const connectAddressToUser = async (addressId: string, userId: string, walletId: string | undefined): Promise<void> => {
   void await prisma.addressesOnUserProfiles.upsert({
@@ -26,4 +28,22 @@ export const disconnectAddressFromUser = async (addressId: string, userId: strin
       }
     }
   })
+}
+
+export const fetchAddressWallet = async (userId: string, addressId: string): Promise<Wallet | null> => {
+  const conn = (await prisma.addressesOnUserProfiles.findUnique({
+    where: {
+      userId_addressId: {
+        userId,
+        addressId
+      }
+    },
+    select: {
+      wallet: true
+    }
+  }))
+  if (conn === null) {
+    throw new Error(RESPONSE_MESSAGES.NO_WALLET_FOUND_FOR_USER_ADDRESS_404.message)
+  }
+  return conn.wallet
 }

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -4,9 +4,10 @@ import prisma from 'prisma/clientInstance'
 import { RESPONSE_MESSAGES, NETWORK_IDS_FROM_SLUGS } from 'constants/index'
 import { getObjectValueForNetworkSlug } from 'utils/index'
 import { connectAddressToUser, disconnectAddressFromUser } from 'services/addressesOnUserProfileService'
-
 export interface UpdatePaybuttonInput {
+  paybuttonId: string
   name?: string
+  userId: string
   prefixedAddressList?: string[]
 }
 
@@ -195,7 +196,7 @@ export async function fetchPaybuttonArrayByUserId (userId: string): Promise<Payb
   })
 }
 
-export async function updatePaybutton (paybuttonId: string, params: UpdatePaybuttonInput): Promise<PaybuttonWithAddresses> {
+export async function updatePaybutton (params: UpdatePaybuttonInput): Promise<PaybuttonWithAddresses> {
   const updateData: Prisma.PaybuttonUpdateInput = {}
   if (params.name !== undefined && params.name !== '') {
     updateData.name = params.name
@@ -221,7 +222,7 @@ export async function updatePaybutton (paybuttonId: string, params: UpdatePaybut
     if (params.prefixedAddressList !== undefined && params.prefixedAddressList.length !== 0) {
       void await prisma.addressesOnButtons.deleteMany({
         where: {
-          paybuttonId
+          paybuttonId: params.paybuttonId
         }
       })
     }
@@ -233,7 +234,6 @@ export async function updatePaybutton (paybuttonId: string, params: UpdatePaybut
       addressIdListToAdd,
       addressIdListToRemove,
       paybuttonIdToIgnore: values.paybuttonId,
-      params.
     })
      */
     return await prisma.paybutton.update({

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -14,7 +14,7 @@ export interface UpdatePaybuttonInput {
 
 export interface CreatePaybuttonInput {
   userId: string
-  walletId: string
+  walletId?: string
   name: string
   buttonData: string
   prefixedAddressList: string[]

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -1,8 +1,8 @@
-import * as networkService from 'services/networkService'
 import * as addressService from 'services/addressService'
 import { Prisma } from '@prisma/client'
 import prisma from 'prisma/clientInstance'
-import { RESPONSE_MESSAGES } from 'constants/index'
+import { RESPONSE_MESSAGES, NETWORK_IDS_FROM_SLUGS } from 'constants/index'
+import { getObjectValueForNetworkSlug } from 'utils/index'
 import { connectAddressToUser, disconnectAddressFromUser } from 'services/addressesOnUserProfileService'
 
 export interface UpdatePaybuttonInput {
@@ -42,10 +42,10 @@ async function getAddressObjectsToCreateOrConnect (prefixedAddressList: string[]
     prefixedAddressList.map(
       async (addressWithPrefix) => {
         const prefix = addressWithPrefix.split(':')[0].toLowerCase()
-        const network = await networkService.getNetworkFromSlug(prefix)
+        const networkId = getObjectValueForNetworkSlug(prefix, NETWORK_IDS_FROM_SLUGS)
         return {
           address: addressWithPrefix.toLowerCase(),
-          networkId: Number(network.id)
+          networkId: Number(networkId)
         }
       })
   )

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -121,9 +121,10 @@ async function updateAddressUserConnectors ({
       // Infer wallet to other newly added addresses
       if (walletId == null) {
         if (paybuttonIdToIgnore == null) {
-          throw new Error(RESPONSE_MESSAGES.NO_CONTEXT_TO_INFER_USER_ADRESS_WALLET_400.message)
+          walletId = undefined
+        } else {
+          walletId = await inferWalletIdForPaybuttonNewAddress(userId, paybuttonIdToIgnore, id, addressIdListToAdd)
         }
-        walletId = await inferWalletIdForPaybuttonNewAddress(userId, paybuttonIdToIgnore, id, addressIdListToAdd)
       }
       await connectAddressToUser(id, userId, walletId)
     })

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -75,13 +75,15 @@ interface UpdateAddressUserConnectorsParams {
 async function inferWalletIdForPaybuttonNewAddress (userId: string, paybuttonId: string, newAddressId: string, addressIdListToAdd: string[]): Promise<string> {
   const paybutton = await fetchPaybuttonById(paybuttonId)
   if (paybutton.addresses.length !== 0) {
-    const firstOtherAddress = paybutton
+    const otherAddressConns = paybutton
       .addresses
-      .filter(addr => !addressIdListToAdd.includes(addr.address.id))[0]
-      .address
-    const wallet = await fetchAddressWallet(userId, firstOtherAddress.id)
-    if (wallet !== null) {
-      return wallet.id
+      .filter(addr => !addressIdListToAdd.includes(addr.address.id))
+    if (otherAddressConns.length > 0) {
+      const firstOtherAddress = otherAddressConns[0].address
+      const wallet = await fetchAddressWallet(userId, firstOtherAddress.id)
+      if (wallet !== null) {
+        return wallet.id
+      }
     }
   }
   const address = await addressService.fetchAddressById(newAddressId)

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -280,7 +280,7 @@ export async function updatePaybutton (params: UpdatePaybuttonInput): Promise<Pa
     })
   })
 
-  // List with new paybuttons addresses ids, after updating
+  // List with paybuttons addresses ids, after updating
   const paybuttonNewAddressesIds = (await prisma.address.findMany({
     where: {
       paybuttons: {

--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -223,14 +223,10 @@ export async function fetchPaybuttonArrayByIds (paybuttonIdList: string[]): Prom
 }
 
 export async function fetchPaybuttonById (paybuttonId: string): Promise<PaybuttonWithAddresses> {
-  try {
-    return await prisma.paybutton.findUniqueOrThrow({
-      where: { id: paybuttonId },
-      include: includeAddresses
-    })
-  } catch {
-    throw new Error(RESPONSE_MESSAGES.NOT_FOUND_404.message)
-  }
+  return await prisma.paybutton.findUniqueOrThrow({
+    where: { id: paybuttonId },
+    include: includeAddresses
+  })
 }
 
 export async function fetchPaybuttonArrayByUserId (userId: string): Promise<PaybuttonWithAddresses[]> {

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -162,7 +162,7 @@ export async function setAddressListForWallet (
 
 export async function createWallet (values: CreateWalletInput): Promise<WalletWithAddressesWithPaybuttons> {
   const defaultForNetworkIds = getDefaultForNetworkIds(values.isXECDefault, values.isBCHDefault)
-  const newWallet = await prisma.wallet.create({
+  const wallet = await prisma.wallet.create({
     data: {
       providerUserId: values.userId,
       name: values.name,
@@ -183,9 +183,9 @@ export async function createWallet (values: CreateWalletInput): Promise<WalletWi
     },
     include: includeAddressesWithPaybuttons
   })
-  await setAddressListForWallet(prisma, values.addressIdList, newWallet)
+  await setAddressListForWallet(prisma, values.addressIdList, wallet)
   return await setDefaultWallet(
-    await fetchWalletById(newWallet.id),
+    await fetchWalletById(wallet.id),
     defaultForNetworkIds
   )
 }

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -438,6 +438,6 @@ export async function fetchWalletArrayByUserId (userId: string): Promise<WalletW
     where: { providerUserId: userId },
     include: includeAddressesWithPaybuttons
   })
-  walletList.forEach((w) => { filterOutOtherUsersPaybuttons(w) })
+  walletList.forEach((w) => filterOutOtherUsersPaybuttons(w))
   return walletList
 }

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -1086,7 +1086,7 @@ describe('GET /api/paybutton/[id]', () => {
     const res = await testEndpoint(baseRequestOptions, paybuttonIdEndpoint)
     expect(res.statusCode).toBe(404)
     const responseData = res._getJSONData()
-    expect(responseData.message).toBe(RESPONSE_MESSAGES.NOT_FOUND_404.message)
+    expect(responseData.message).toBe(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message)
   })
 })
 

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -14,7 +14,7 @@ import balanceEndpoint from 'pages/api/address/balance/[address]'
 import dashboardEndpoint from 'pages/api/dashboard/index'
 import currentPriceEndpoint from 'pages/api/price/[networkSlug]'
 import currentPriceForQuoteEndpoint from 'pages/api/price/[networkSlug]/[quoteSlug]'
-import { WalletWithAddressesWithPaybuttons, fetchWalletById } from 'services/walletService'
+import { WalletWithAddressesWithPaybuttons, fetchWalletById, createDefaultWalletForUser } from 'services/walletService'
 import {
   exampleAddresses,
   testEndpoint,
@@ -204,6 +204,8 @@ describe('PATCH /api/paybutton/', () => {
     createdPaybuttons = []
     const userA = 'test-u-id'
     const userB = 'test-other-u-id'
+    await createDefaultWalletForUser(userA)
+    await createDefaultWalletForUser(userB)
     for (let i = 0; i < 4; i++) {
       const userId = i === 3 ? userB : userA
       const paybutton = await createPaybuttonForUser(userId)
@@ -256,8 +258,8 @@ describe('PATCH /api/paybutton/', () => {
       addresses: `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`
     }
     const res = await testEndpoint(baseRequestOptions, paybuttonIdEndpoint)
-    expect(res.statusCode).toBe(200)
     const responseData = res._getJSONData()
+    expect(res.statusCode).toBe(200)
     expect(responseData.providerUserId).toBe('test-u-id')
     expect(responseData.name).toBe('blablabla')
     expect(responseData.addresses).toEqual(

--- a/tests/unittests/paybuttonService.test.ts
+++ b/tests/unittests/paybuttonService.test.ts
@@ -46,7 +46,8 @@ describe('Create services', () => {
       userId: 'mocked-uid',
       name: 'mocked-name',
       prefixedAddressList: ['mockednetwork:mockaddress'],
-      buttonData: ''
+      buttonData: '',
+      walletId: 'mocked-wallet-uuid'
     }
     const result = await paybuttonService.createPaybutton(createPaybuttonInput)
     expect(result).toEqual(mockedPaybutton)
@@ -102,9 +103,11 @@ describe('Update services', () => {
     const updatePaybuttonInput = {
       userId: 'mocked-uid',
       name: 'mocked-name',
-      prefixedAddressList: ['mockednetwork:mockaddress']
+      paybuttonId: 'mocked-uuid',
+      walletId: 'mocked-wallet-uuid',
+      prefixedAddressList: ['ecash:mockaddress']
     }
-    const result = await paybuttonService.updatePaybutton('mocked-uuid', updatePaybuttonInput)
+    const result = await paybuttonService.updatePaybutton(updatePaybuttonInput)
     expect(result).toEqual(mockedPaybutton)
   })
 })

--- a/tests/unittests/paybuttonService.test.ts
+++ b/tests/unittests/paybuttonService.test.ts
@@ -5,8 +5,8 @@ import { mockedPaybutton, mockedPaybuttonList, mockedNetwork, mockedWalletsOnUse
 
 describe('Fetch services', () => {
   it('Should fetch paybutton by id', async () => {
-    prismaMock.paybutton.findUnique.mockResolvedValue(mockedPaybutton)
-    prisma.paybutton.findUnique = prismaMock.paybutton.findUnique
+    prismaMock.paybutton.findUniqueOrThrow.mockResolvedValue(mockedPaybutton)
+    prisma.paybutton.findUniqueOrThrow = prismaMock.paybutton.findUniqueOrThrow
 
     const result = await paybuttonService.fetchPaybuttonById(mockedPaybutton.id)
     expect(result).toEqual(mockedPaybutton)
@@ -59,8 +59,8 @@ describe('Delete services', () => {
     prismaMock.paybutton.delete.mockResolvedValue(mockedPaybutton)
     prisma.paybutton.delete = prismaMock.paybutton.delete
 
-    prismaMock.paybutton.findUnique.mockResolvedValue(mockedPaybutton)
-    prisma.paybutton.findUnique = prismaMock.paybutton.findUnique
+    prismaMock.paybutton.findUniqueOrThrow.mockResolvedValue(mockedPaybutton)
+    prisma.paybutton.findUniqueOrThrow = prismaMock.paybutton.findUniqueOrThrow
 
     prismaMock.address.findMany.mockResolvedValue([])
     prisma.address.findMany = prismaMock.address.findMany

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -184,17 +184,18 @@ describe('parsePaybuttonPOSTRequest', () => {
 describe('parsePaybuttonPATCHRequest', () => {
   const data: v.PaybuttonPOSTParameters = {
     name: 'somename',
-    addresses: undefined
+    addresses: undefined,
+    userId: 'mocked-uid'
   }
   it('Invalid addresses throws error', () => {
     expect(() => {
       data.addresses = 'ecash:lkajsdl\nll'
-      v.parsePaybuttonPATCHRequest(data)
+      v.parsePaybuttonPATCHRequest(data, 'mocked-paybuton-uuid')
     }).toThrow(RESPONSE_MESSAGES.INVALID_ADDRESS_400.message)
   })
   it('Addresses text is split', () => {
     data.addresses = `ecash:${exampleAddresses.ecash}\nbitcoincash:${exampleAddresses.bitcoincash}`
-    const res = v.parsePaybuttonPATCHRequest(data)
+    const res = v.parsePaybuttonPATCHRequest(data, 'mocked-paybuton-uuid')
     expect(res.prefixedAddressList).toStrictEqual([
       `ecash:${exampleAddresses.ecash}`,
       `bitcoincash:${exampleAddresses.bitcoincash}`

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,7 +1,7 @@
 import { RESPONSE_MESSAGES, SUPPORTED_ADDRESS_PATTERN, NETWORK_TICKERS } from '../constants/index'
 import { Prisma } from '@prisma/client'
-import { CreatePaybuttonInput, UpdatePaybuttonInput } from '../services/paybuttonService'
-import { CreateWalletInput, UpdateWalletInput } from '../services/walletService'
+import { type CreatePaybuttonInput, type UpdatePaybuttonInput } from '../services/paybuttonService'
+import { type CreateWalletInput, type UpdateWalletInput } from '../services/walletService'
 import { getAddressPrefix } from './index'
 import { appInfo } from 'config/appInfo'
 import xecaddr from 'xecaddrjs'
@@ -125,6 +125,7 @@ export interface WalletPOSTParameters {
 export interface PaybuttonPATCHParameters {
   name?: string
   addresses?: string
+  userId?: string
 }
 
 export interface WalletPATCHParameters {
@@ -159,9 +160,12 @@ export const parseWalletPATCHRequest = function (params: WalletPATCHParameters):
   }
 }
 
-export const parsePaybuttonPATCHRequest = function (params: PaybuttonPATCHParameters): UpdatePaybuttonInput {
+export const parsePaybuttonPATCHRequest = function (params: PaybuttonPATCHParameters, paybuttonId: string): UpdatePaybuttonInput {
+  if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   const ret: UpdatePaybuttonInput = {
-    name: params.name
+    name: params.name,
+    userId: params.userId,
+    paybuttonId
   }
 
   if (params.addresses !== '' && params.addresses !== undefined) {

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -72,7 +72,8 @@ export const parseError = function (error: Error): Error {
       case 'P2025':
         if (
           error.message.includes('prisma.paybutton.delete') ||
-          error.message.includes('prisma.paybutton.update')
+          error.message.includes('prisma.paybutton.update') ||
+          error.message.includes('No Paybutton found')
         ) {
           return new Error(RESPONSE_MESSAGES.NO_BUTTON_FOUND_404.message)
         } else if (

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -98,10 +98,10 @@ export const parsePaybuttonPOSTRequest = function (params: PaybuttonPOSTParamete
   if (params.userId === '' || params.userId === undefined) throw new Error(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message)
   if (params.name === '' || params.name === undefined) throw new Error(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message)
   if (params.addresses === '' || params.addresses === undefined) throw new Error(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message)
-  const walletId: string | undefined = params.walletId
   if (params.walletId === '' || params.walletId === undefined) {
     throw new Error(RESPONSE_MESSAGES.WALLET_ID_NOT_PROVIDED_400.message)
   }
+  const walletId = params.walletId
 
   const parsedAddresses = parseAddressTextBlock(params.addresses)
   const parsedButtonData = parseButtonData(params.buttonData)


### PR DESCRIPTION
Description
---
Solves #498, #491
Updates the table `AddressOnUserProfiles` when updating paybuttons.

Test plan
---
These changes simultaneously affects updating paybuttons & also wallets. Ideally, creating & deleting those should also be tested.

After updating a paybutton or a wallet with different addresses, it is expected that the network icon (that can show the XEC symbol, the BCH symbol, or both) is correctly immediately updated. This is not the case on master.