### PR TITLE
[Issue #509] fix: Tx hash on chronik

### DIFF
--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -1,7 +1,7 @@
 import { Worker, Job, Queue } from 'bullmq'
 import { Address } from '@prisma/client'
 import { redisBullMQ } from 'redis/clientInstance'
-import { SYNC_NEW_ADDRESSES_DELAY, DEFAULT_WORKER_LOCK_DURATION, RESPONSE_MESSAGES } from 'constants/index'
+import { SYNC_NEW_ADDRESSES_DELAY, DEFAULT_WORKER_LOCK_DURATION, RESPONSE_MESSAGES, KeyValueT } from 'constants/index'
 
 import * as transactionService from 'services/transactionService'
 import * as priceService from 'services/priceService'
@@ -9,34 +9,34 @@ import * as addressService from 'services/addressService'
 import { subscribeAddressesAddTransactions } from 'services/blockchainService'
 import { parseError } from 'utils/validators'
 
-const syncAndSubscribeAddresses = async (addresses: Address[]): Promise<string[]> => {
-  const failedAddresses: string[] = []
+const syncAndSubscribeAddresses = async (addresses: Address[]): Promise<KeyValueT<string>> => {
+  const failedAddressesWithErrors: KeyValueT<string> = {}
   await Promise.all(
     addresses.map(async (addr) => {
       try {
         await subscribeAddressesAddTransactions([addr])
         await transactionService.syncAllTransactionsForAddress(addr.address, Infinity)
       } catch (err: any) {
-        failedAddresses.push(addr.address)
+        failedAddressesWithErrors[addr.address] = err.message
       }
     })
   )
-  return failedAddresses
+  return failedAddressesWithErrors
 }
 
 const syncAndSubscribeAllAddressTransactionsForNetworkJob = async (job: Job): Promise<void> => {
   console.log(`job ${job.id as string}: syncing and subscribing all addresses for network ${job.data.networkId as string}...`)
-  let failedAddresses: string [] = []
+  let failedAddressesWithErrors: KeyValueT<string> = {}
   try {
     const addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
-    failedAddresses = await syncAndSubscribeAddresses(addresses)
+    failedAddressesWithErrors = await syncAndSubscribeAddresses(addresses)
   } catch (err: any) {
     const parsedError = parseError(err)
     if (parsedError.message === RESPONSE_MESSAGES.TRANSACTION_ALREADY_EXISTS_FOR_ADDRESS_400.message) {
       console.log(`initial syncing of network ${job.data.networkId as string} encountered known transaction, skipping...`)
     } else {
-      if (failedAddresses.length > 0) {
-        console.error(`ERROR: (skipping anyway) initial syncing of network ${job.data.networkId as string} FAILED for addresses ${JSON.stringify(failedAddresses)}: ${err.message as string}`)
+      if (Object.keys(failedAddressesWithErrors).length > 0) {
+        console.error(`ERROR: (skipping anyway) initial syncing of network ${job.data.networkId as string} FAILED for addresses ${JSON.stringify(failedAddressesWithErrors)}: ${err.message as string}`)
       } else {
         console.error(`ERROR: (skipping anyway) initial syncing of network ${job.data.networkId as string} FAILED: ${err.message as string}`)
       }
@@ -103,9 +103,10 @@ export const syncAndSubscribeUnsyncedAddressesWorker = async (queue: Queue): Pro
     async (job) => {
       const newAddresses = await addressService.fetchUnsyncedAddresses()
       if (newAddresses.length !== 0) {
-        const failedAddresses = await syncAndSubscribeAddresses(newAddresses)
+        const failedAddressesWithErrors = await syncAndSubscribeAddresses(newAddresses)
+        const failedAddresses = Object.keys(failedAddressesWithErrors)
         if (failedAddresses.length > 0) {
-          console.error(`automatic syncing of addresses failed for addresses: ${JSON.stringify(failedAddresses)}`)
+          console.error(`automatic syncing of addresses failed for addresses: ${JSON.stringify(failedAddressesWithErrors)}`)
         }
         job.data.syncedAddresses = newAddresses.filter(addr => !failedAddresses.includes(addr.address))
       }

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -3,7 +3,7 @@ import { encode, decode } from 'ecashaddrjs'
 import bs58 from 'bs58'
 import { AddressWithTransaction, BlockchainClient, BlockchainInfo, BlockInfo, GetAddressTransactionsParameters, TransactionDetails } from './blockchainService'
 import { NETWORK_SLUGS, RESPONSE_MESSAGES, CHRONIK_CLIENT_URL, XEC_TIMESTAMP_THRESHOLD, XEC_NETWORK_ID, BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N, KeyValueT } from 'constants/index'
-import { TransactionWithAddressAndPrices, createManyTransactions, base64HashToHex, deleteTransactions, fetchUnconfirmedTransactions, createTransaction } from './transactionService'
+import { TransactionWithAddressAndPrices, createManyTransactions, deleteTransactions, fetchUnconfirmedTransactions, createTransaction } from './transactionService'
 import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { groupAddressesByNetwork, satoshisToUnit } from 'utils'
@@ -74,7 +74,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
 
   private async getTransactionFromChronikTransaction (transaction: Tx, address: Address): Promise<Prisma.TransactionUncheckedCreateInput> {
     return {
-      hash: await base64HashToHex(transaction.txid),
+      hash: await transaction.txid,
       amount: await this.getTransactionAmount(transaction, address.address),
       timestamp: transaction.block !== undefined ? parseInt(transaction.block.timestamp) : parseInt(transaction.timeFirstSeen),
       addressId: address.id,

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -294,7 +294,7 @@ export class GrpcBlockchainClient implements BlockchainClient {
       addressWithConfirmedTransactions = await this.getPrismaTransactionsForSubscribedAddresses(confirmedTransaction, true)
 
       // remove unconfirmed transactions that have now been confirmed
-      const transactionsToDelete = await fetchUnconfirmedTransactions(confirmedTransaction.hash as string)
+      const transactionsToDelete = await fetchUnconfirmedTransactions(base64HashToHex(confirmedTransaction.hash as string))
       await deleteTransactions(transactionsToDelete)
     }
 

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -104,7 +104,7 @@ export async function getTransactionNetworkId (tx: Transaction): Promise<number>
   return (await fetchAddressById(tx.addressId)).networkId
 }
 
-export async function base64HashToHex (base64Hash: string): Promise<string> {
+export function base64HashToHex (base64Hash: string): string {
   return (
     atob(base64Hash)
       .split('')
@@ -231,7 +231,7 @@ export async function syncAllTransactionsForAddress (addressString: string, maxT
 export async function fetchUnconfirmedTransactions (hash: string): Promise<TransactionWithAddressAndPrices[]> {
   return await prisma.transaction.findMany({
     where: {
-      hash: await base64HashToHex(hash),
+      hash,
       confirmed: false
     },
     include: includeAddressAndPrices

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -14,7 +14,7 @@ export async function getTransactionValue (transaction: TransactionWithPrices): 
     usd: new Prisma.Decimal(0),
     cad: new Prisma.Decimal(0)
   }
-  if (transaction.prices.length !== N_OF_QUOTES) throw new Error(`txid${transaction.id}, ts${transaction.timestamp} ${RESPONSE_MESSAGES.MISSING_PRICE_FOR_TRANSACTION_400.message}`)
+  if (transaction.prices.length !== N_OF_QUOTES) throw new Error(`txid${transaction.id}, ts${transaction.timestamp} ${RESPONSE_MESSAGES.MISSING_PRICE_FOR_TRANSACTION_400.message}: found ${transaction.prices.length}.`)
   for (const p of transaction.prices) {
     if (p.price.quoteId === USD_QUOTE_ID) {
       ret.usd = ret.usd.plus(p.price.value.times(transaction.amount))


### PR DESCRIPTION
Description
---
Solves #509.
The hash for txs fetched from chronik were incorrectly assumend to be base64, leading to invalid URLs for the block explorer

Also improves some error messages related to syncing txs bugs

Test plan
---
Rebuild the containers, check that the ecash txs URLs on the paybutton detail view are correct.