### PR TITLE
[Issue #513] feat: More incremental tx sync

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -68,7 +68,8 @@ export const NETWORK_IDS_FROM_SLUGS: KeyValueT<number> = {
 }
 
 // When fetching some address transactions, number of transactions to fetch at a time.
-export const FETCH_N = 100
+// On chronik, the max allowed is 200
+export const FETCH_N = 200
 
 // When fetching the FETCH_N transactions, max time (in ms) to wait to upsert them.
 export const FETCH_N_TIMEOUT = 120000

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -121,6 +121,7 @@ export async function createTransaction (
   if (transactionData.amount === new Prisma.Decimal(0)) { // out transactions
     return
   }
+  // we don't use `create` to ignore conflicts between the sync and the subscription
   const createdTx = await prisma.transaction.upsert({
     create: transactionData,
     include: includeAddressAndPrices,
@@ -181,7 +182,7 @@ export async function connectTransactionsListToPrices (txList: Transaction[]): P
 export async function createManyTransactions (
   transactionsData: Prisma.TransactionUncheckedCreateInput[]
 ): Promise<TransactionWithAddressAndPrices[]> {
-  // const uuidList = await addUUIDToTransactions(transactionsData)
+  // we don't use `createMany` to ignore conflicts between the sync and the subscription
   const insertedTransactions = await Promise.all(
     transactionsData.map(async tx =>
       await prisma.transaction.upsert({

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -121,9 +121,16 @@ export async function createTransaction (
   if (transactionData.amount === new Prisma.Decimal(0)) { // out transactions
     return
   }
-  const createdTx = await prisma.transaction.create({
-    data: transactionData,
-    include: includeAddressAndPrices
+  const createdTx = await prisma.transaction.upsert({
+    create: transactionData,
+    include: includeAddressAndPrices,
+    where: {
+      Transaction_hash_addressId_unique_constraint: {
+        hash: transactionData.hash,
+        addressId: transactionData.addressId
+      }
+    },
+    update: {}
   })
   void await connectTransactionToPrices(createdTx, prisma)
   const tx = await fetchTransactionById(createdTx.id)


### PR DESCRIPTION
Description
---
Modify  the sync of txs so that reinserting txs that already exists in DB is accepted.

They are now upserted one-by-one, in parallel.

Test plan
---
Re run the containers, it should work normally.
Furthermore, large addresses now should sync to completion (no errors between the syncing conflicting with the subscription because of inserting a tx that arrived after the sync started), but since this takes a while, this should better be tested in the PR [WIP] that requires this one.
