### PR TITLE
[Issue #422] feat: API endpoint to get user networks.

### DIFF
--- a/pages/api/networks/user.ts
+++ b/pages/api/networks/user.ts
@@ -1,0 +1,18 @@
+import * as networkService from 'services/networkService'
+import { setSession } from 'utils/setSession'
+
+export default async (req: any, res: any): Promise<void> => {
+  if (req.method === 'GET') {
+    await setSession(req, res)
+    const userId = req.session.userId
+    try {
+      const userNetworks = await networkService.getUserNetworks(userId)
+      res.status(200).json(userNetworks)
+    } catch (err: any) {
+      switch (err.message) {
+        default:
+          res.status(500).json({ statusCode: 500, message: err.message })
+      }
+    }
+  }
+}


### PR DESCRIPTION
Description
---
Add endpoint to get the networks for a user.

Test plan
---
This uses the user session to get the userId, so not simple `curl` possible.

Best way to test, add the following lines:
```
      let temp = await fetch('/api/networks/user')
      console.log('teste: ', await temp.json())

```
on `pages/dashboard/index.tsx:65`, that is, right after `      const fetchData = async (): Promise<void> => {`

Then, upon accessing the dashboard, the user networks should appear in the **browser** console.