### PR TITLE
UI hide unused networks

### DIFF
--- a/components/Network/NetworkList.tsx
+++ b/components/Network/NetworkList.tsx
@@ -1,26 +1,97 @@
-import React, { FunctionComponent } from 'react'
-import { NetworkWithConnectionInfo } from 'services/networkService'
+import React, { FunctionComponent, useState } from 'react'
+import {
+  NetworkWithConnectionInfo,
+  UserNetworksInfo
+} from 'services/networkService'
 import style from './network.module.css'
 import moment from 'moment'
 
-interface IProps { networks: NetworkWithConnectionInfo[] }
-export default ({ networks }: IProps): FunctionComponent<IProps> => {
+interface IProps {
+  networks: NetworkWithConnectionInfo[]
+  userNetworks: UserNetworksInfo[]
+}
+
+const NetworkComponent: FunctionComponent<IProps> = ({
+  networks,
+  userNetworks
+}) => {
+  const [show, setShow] = useState(false)
+
   return (
     <div className={style.network_ctn}>
-      {networks.map(network => (
-        <div key={network.id} className={style.card_wrapper}>
-            <div className={style.network_card_text}>
-              <div className={style.cardTitle}>{network.title}</div>
+      {networks.map((network) => {
+        if (userNetworks.some((n) => n.ticker === network.ticker) || userNetworks.length === 0) {
+          return (
+            <div key={network.id} className={style.card_wrapper}>
+              <div className={style.network_card_text}>
+                <div className={style.cardTitle}>{network.title}</div>
                 {network.connected
-                  ? <>
-                    <div className={style.cardStatus} style={{ color: '#04b504' }}>Connected</div>
-                    <div>Last block: {network.lastBlockTimestamp !== undefined ? moment.unix(network.lastBlockTimestamp).fromNow() : '-'}</div>
+                  ? (
+                  <>
+                    <div
+                      className={style.cardStatus}
+                      style={{ color: '#04b504' }}
+                    >
+                      Connected
+                    </div>
+                    <div>
+                      Last block:{' '}
+                      {network.lastBlockTimestamp !== undefined
+                        ? moment.unix(network.lastBlockTimestamp).fromNow()
+                        : '-'}
+                    </div>
                   </>
-                  : <div className={style.cardStatus}>Disconnected</div>
-                }
+                    )
+                  : (
+                  <div className={style.cardStatus}>Disconnected</div>
+                    )}
+              </div>
             </div>
-        </div>
-      ))}
+          )
+        } else {
+          return (
+              <div
+                key={network.id}
+                className={style.card_wrapper}
+                style={show ? { order: '2', display: 'inline-block' } : { order: '2', display: 'none' }}
+              >
+                <div className={style.network_card_text}>
+                  <div className={style.cardTitle}>{network.title}</div>
+                  {network.connected
+                    ? (
+                    <>
+                      <div
+                        className={style.cardStatus}
+                        style={{ color: '#04b504' }}
+                      >
+                        Connected
+                      </div>
+                      <div>
+                        Last block:{' '}
+                        {network.lastBlockTimestamp !== undefined
+                          ? moment.unix(network.lastBlockTimestamp).fromNow()
+                          : '-'}
+                      </div>
+                    </>
+                      )
+                    : (
+                    <div className={style.cardStatus}>Disconnected</div>
+                      )}
+                </div>
+              </div>
+          )
+        }
+      })}
+      {userNetworks.length < 2 && userNetworks.length !== 0 &&
+       <div
+        className={style.showNetworksCtn}
+        onClick={() => setShow(!show)}
+      >
+        {!show ? 'Show Other Networks' : 'Hide Other Networks'}
+      </div>
+      }
     </div>
   )
 }
+
+export default NetworkComponent

--- a/components/Network/network.module.css
+++ b/components/Network/network.module.css
@@ -2,24 +2,14 @@
   display: flex;
   margin-top: 25px;
   flex-wrap: wrap;
+  flex-direction: column;
 }
 
 .card_wrapper {
   margin-bottom: 15px;
   padding: 0 12px;
-  width: 33.333%;
-}
-
-.card_wrapper:nth-child(1),
-.card_wrapper:nth-child(4),
-.card_wrapper:nth-child(7) {
   padding-left: 0;
-}
-
-.card_wrapper:nth-child(3),
-.card_wrapper:nth-child(6),
-.card_wrapper:nth-child(9) {
-  padding-right: 0;
+  width: 33.333%;
 }
 
 .network_card {
@@ -41,6 +31,17 @@
 
 .cardStatus {
   color: red;
+}
+
+.showNetworksCtn {
+  background-color: var(--secondary-bg-color);
+  order: 3;
+  height: 100%;
+  padding: 10px 20px;
+  align-self: flex-start;
+  margin-bottom: 15px;
+  border-radius: 10px;
+  cursor: pointer;
 }
 
 @media (max-width: 1200px) {

--- a/components/Network/network.module.css
+++ b/components/Network/network.module.css
@@ -51,12 +51,11 @@
 
   .card_wrapper:nth-child(even) {
     padding-right: 0;
-    padding-left: 8px;
   }
 
   .card_wrapper:nth-child(odd) {
     padding-left: 0;
-    padding-right: 8px;
+    padding-right: 0px;
   }
 }
 

--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -10,14 +10,16 @@ import { WalletWithAddressesWithPaybuttons } from 'services/walletService'
 import { AddressWithPaybuttons } from 'services/addressService'
 import axios from 'axios'
 import { appInfo } from 'config/appInfo'
+import { UserNetworksInfo } from 'services/networkService'
 
 interface IProps {
   wallet: WalletWithAddressesWithPaybuttons
   userAddresses: AddressWithPaybuttons[]
   refreshWalletList: Function
+  usedNetworks: UserNetworksInfo[]
 }
 
-export default function EditWalletForm ({ wallet, userAddresses, refreshWalletList }: IProps): ReactElement {
+export default function EditWalletForm ({ wallet, userAddresses, refreshWalletList, usedNetworks }: IProps): ReactElement {
   const { register, handleSubmit, reset } = useForm<WalletPATCHParameters>()
   const [modal, setModal] = useState(false)
   const [deleteModal, setDeleteModal] = useState(false)
@@ -115,6 +117,7 @@ export default function EditWalletForm ({ wallet, userAddresses, refreshWalletLi
                   </div>
                   <hr/>
                   <div className={style.makedefault_ctn} key={`edit-wallet-${wallet.id}`}>
+                  {usedNetworks.some(network => network.ticker === 'xec') &&
                     <div className={style.input_field}>
                       <input
                         {...register('isXECDefault')}
@@ -124,7 +127,8 @@ export default function EditWalletForm ({ wallet, userAddresses, refreshWalletLi
                         disabled={wallet.userProfile?.isXECDefault === true}
                       />
                       <label htmlFor='xec-default' className={style.makedefault_margin}>Default XEC Wallet</label>
-                    </div>
+                    </div>}
+                    {usedNetworks.some(network => network.ticker === 'bch') &&
                     <div className={style.input_field}>
                       <input
                         {...register('isBCHDefault')}
@@ -135,6 +139,7 @@ export default function EditWalletForm ({ wallet, userAddresses, refreshWalletLi
                       />
                       <label htmlFor='bch-default' className={style.makedefault_margin}>Default BCH Wallet</label>
                     </div>
+}
                   </div>
 
                   <div className={style_pb.btn_row2}>

--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -9,15 +9,17 @@ import EditWalletForm from './EditWalletForm'
 import { WalletWithAddressesWithPaybuttons, WalletPaymentInfo } from 'services/walletService'
 import { AddressWithPaybuttons } from 'services/addressService'
 import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
+import { UserNetworksInfo } from 'services/networkService'
 
 interface IProps {
   wallet: WalletWithAddressesWithPaybuttons
   paymentInfo: WalletPaymentInfo
   userAddresses: AddressWithPaybuttons[]
   refreshWalletList: Function
+  usedNetworks: UserNetworksInfo[]
 }
 
-const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userAddresses, refreshWalletList }: IProps) => {
+const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userAddresses, refreshWalletList, usedNetworks }: IProps) => {
   const networks = wallet.userAddresses.map((addr) => addr.address.networkId)
   const differentPaybuttons = wallet.userAddresses.map(addr =>
     addr.address.paybuttons.map(conn => conn.paybutton)
@@ -38,12 +40,13 @@ const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userAddress
           </div>
         </div>
         <div className={style.edit_button_ctn}>
-          {wallet.userProfile?.isXECDefault === true && <div className={style.default_wallet}>Default XEC Wallet</div>}
-          {wallet.userProfile?.isBCHDefault === true && <div className={style.default_wallet}>Default BCH Wallet</div>}
+          {wallet.userProfile?.isXECDefault === true && usedNetworks.some(network => network.ticker === 'xec') && <div className={style.default_wallet}>Default XEC Wallet</div>}
+          {wallet.userProfile?.isBCHDefault === true && usedNetworks.some(network => network.ticker === 'bch') && <div className={style.default_wallet}>Default BCH Wallet</div>}
           <EditWalletForm
             wallet={wallet}
             userAddresses={userAddresses}
             refreshWalletList={refreshWalletList}
+            usedNetworks={usedNetworks}
           />
         </div>
       </div>

--- a/components/Wallet/WalletForm.tsx
+++ b/components/Wallet/WalletForm.tsx
@@ -8,14 +8,16 @@ import style_pb from 'components/Paybutton/paybutton.module.css'
 import Plus from 'assets/plus.png'
 import axios from 'axios'
 import { appInfo } from 'config/appInfo'
+import { UserNetworksInfo } from 'services/networkService'
 
 interface IProps {
   userAddresses: AddressWithPaybuttons[]
   refreshWalletList: Function
   userId: string
+  usedNetworks: UserNetworksInfo[]
 }
 
-export default function WalletForm ({ userAddresses, refreshWalletList, userId }: IProps): ReactElement {
+export default function WalletForm ({ userAddresses, refreshWalletList, userId, usedNetworks }: IProps): ReactElement {
   const { register, handleSubmit, reset } = useForm<WalletPOSTParameters>()
   const [modal, setModal] = useState(false)
   const [error, setError] = useState('')
@@ -104,14 +106,17 @@ export default function WalletForm ({ userAddresses, refreshWalletList, userId }
                     ))}
                   </div>
                   <div className={style.makedefault_ctn} key={'wallet-create'}>
-                    <div className={style.input_field}>
-                      <input
-                        {...register('isXECDefault')}
-                        type="checkbox"
-                        id='isXECDefault'
-                      />
-                      <label htmlFor='xec-default' className={style.makedefault_margin}>Default XEC Wallet</label>
-                    </div>
+                    {usedNetworks.some(network => network.ticker === 'xec') &&
+                      <div className={style.input_field}>
+                        <input
+                          {...register('isXECDefault')}
+                          type="checkbox"
+                          id='isXECDefault'
+                        />
+                        <label htmlFor='xec-default' className={style.makedefault_margin}>Default XEC Wallet</label>
+                      </div>
+                    }
+                     {usedNetworks.some(network => network.ticker === 'bch') &&
                     <div className={style.input_field}>
                       <input
                         {...register('isBCHDefault')}
@@ -120,8 +125,8 @@ export default function WalletForm ({ userAddresses, refreshWalletList, userId }
                       />
                       <label htmlFor='bch-default' className={style.makedefault_margin}>Default BCH Wallet</label>
                     </div>
+                   }
                   </div>
-
                   <div className={style_pb.btn_row}>
                     {error !== '' && <div className={style_pb.error_message}>{error}</div>}
                     <button type='submit'>Submit</button>
@@ -131,7 +136,7 @@ export default function WalletForm ({ userAddresses, refreshWalletList, userId }
               </div>
             </div>
           </div>)
-          : null}
+        : null}
     </>
   )
 }

--- a/pages/api/networks/user.ts
+++ b/pages/api/networks/user.ts
@@ -1,0 +1,18 @@
+import * as networkService from 'services/networkService'
+import { setSession } from 'utils/setSession'
+
+export default async (req: any, res: any): Promise<void> => {
+  if (req.method === 'GET') {
+    await setSession(req, res)
+    const userId = req.session.userId
+    try {
+      const userNetworks = await networkService.getUserNetworks(userId)
+      res.status(200).json(userNetworks)
+    } catch (err: any) {
+      switch (err.message) {
+        default:
+          res.status(500).json({ statusCode: 500, message: err.message })
+      }
+    }
+  }
+}

--- a/pages/networks/index.tsx
+++ b/pages/networks/index.tsx
@@ -7,6 +7,7 @@ import Session from 'supertokens-node/recipe/session'
 import { GetServerSideProps } from 'next'
 import { NetworkList } from 'components/Network'
 import { Network } from '@prisma/client'
+import { UserNetworksInfo } from 'services/networkService'
 
 const ThirdPartyEmailPasswordAuthNoSSR = dynamic(
   new Promise((resolve, reject) =>
@@ -44,6 +45,7 @@ interface NetworksProps {
 
 interface NetworksState {
   networks: Network[]
+  userNetworks: UserNetworksInfo[]
 }
 
 class ProtectedPage extends React.Component<NetworksProps, NetworksState> {
@@ -51,7 +53,8 @@ class ProtectedPage extends React.Component<NetworksProps, NetworksState> {
     super(props)
     this.props = props
     this.state = {
-      networks: []
+      networks: [],
+      userNetworks: []
     }
   }
 
@@ -63,9 +66,17 @@ class ProtectedPage extends React.Component<NetworksProps, NetworksState> {
     const res = await fetch('/api/networks/', {
       method: 'GET'
     })
+    const networksResponse = await fetch('/api/networks/user/', {
+      method: 'GET'
+    })
     if (res.status === 200) {
       this.setState({
         networks: await res.json()
+      })
+    }
+    if (networksResponse.status === 200) {
+      this.setState({
+        userNetworks: await networksResponse.json()
       })
     }
   }
@@ -75,7 +86,7 @@ class ProtectedPage extends React.Component<NetworksProps, NetworksState> {
       return (
         <>
           <h2>Networks</h2>
-          <NetworkList networks={this.state.networks} />
+          <NetworkList networks={this.state.networks} userNetworks={this.state.userNetworks} />
         </>
       )
     }

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -9,6 +9,7 @@ import WalletCard from 'components/Wallet/WalletCard'
 import WalletForm from 'components/Wallet/WalletForm'
 import { WalletWithPaymentInfo } from 'services/walletService'
 import { AddressWithPaybuttons } from 'services/addressService'
+import { UserNetworksInfo } from 'services/networkService'
 
 const ThirdPartyEmailPasswordAuthNoSSR = dynamic(
   new Promise((resolve, reject) =>
@@ -45,6 +46,7 @@ interface WalletsProps {
 interface WalletsState {
   walletsWithPaymentInfo: WalletWithPaymentInfo[]
   userAddresses: AddressWithPaybuttons[]
+  networksInfo: UserNetworksInfo[]
 }
 
 export default function Wallets ({ userId }: WalletsProps): React.ReactElement {
@@ -60,12 +62,14 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
     super(props)
     this.state = {
       walletsWithPaymentInfo: [],
-      userAddresses: []
+      userAddresses: [],
+      networksInfo: []
     }
   }
 
   async componentDidMount (): Promise<void> {
     await this.fetchWallets()
+    await this.fetchNetworks()
   }
 
   async fetchWallets (): Promise<void> {
@@ -83,6 +87,17 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
     if (addressesResponse.status === 200) {
       this.setState({
         userAddresses: await addressesResponse.json()
+      })
+    }
+  }
+
+  async fetchNetworks (): Promise<void> {
+    const networksResponse = await fetch('/api/networks/user/', {
+      method: 'GET'
+    })
+    if (networksResponse.status === 200) {
+      this.setState({
+        networksInfo: await networksResponse.json()
       })
     }
   }
@@ -118,10 +133,11 @@ class ProtectedPage extends React.Component<WalletsProps, WalletsState> {
             userAddresses={this.state.userAddresses}
             refreshWalletList={this.refreshWalletList}
             key={walletWithPaymentInfo.wallet.name}
+            usedNetworks={this.state.networksInfo}
           />
         }
         )}
-        <WalletForm userAddresses={this.state.userAddresses} refreshWalletList={this.refreshWalletList} userId={this.props.userId}/>
+        <WalletForm userAddresses={this.state.userAddresses} refreshWalletList={this.refreshWalletList} userId={this.props.userId} usedNetworks={this.state.networksInfo}/>
         </div>
       </>
     )

--- a/services/networkService.ts
+++ b/services/networkService.ts
@@ -13,9 +13,6 @@ export async function getNetworkFromSlug (slug: string): Promise<Network> {
 export interface ConnectionInfo {
   connected: boolean
   lastBlockTimestamp?: number
-  id: number
-  title: string
-  ticker: string
 }
 
 export interface NetworkWithConnectionInfo extends Network, ConnectionInfo {}

--- a/services/networkService.ts
+++ b/services/networkService.ts
@@ -13,6 +13,9 @@ export async function getNetworkFromSlug (slug: string): Promise<Network> {
 export interface ConnectionInfo {
   connected: boolean
   lastBlockTimestamp?: number
+  id: number
+  title: string
+  ticker: string
 }
 
 export interface NetworkWithConnectionInfo extends Network, ConnectionInfo {}
@@ -72,4 +75,8 @@ export async function getUserNetworks (userId: string): Promise<Network[] | null
     if (userNetworkIds.size === allNetworkIds.length) break
   }
   return networks.filter(n => userNetworkIds.has(n.id))
+}
+
+export interface UserNetworksInfo {
+  ticker: string
 }


### PR DESCRIPTION
Description
As per #422 hiding info and labels on networks not in use


Test plan
Run the app and remove all buttons. You should not see any network specific "default" labels on any wallet screens, and both networks should be visible in the networks tab
Next try adding one ecash address and you should see XEC labels in those places and the BCH network should be hidden in the networks tab
Next try adding a BCH address and check the same 
