### PR TITLE
[Issue #527] fix: Only create payments for > 0 txs

### DIFF
--- a/redis/dashboardCache.ts
+++ b/redis/dashboardCache.ts
@@ -112,7 +112,8 @@ const getPaymentsByWeek = (addressId: string, payments: Payment[]): KeyValueT<Pa
 
 const getGroupedPaymentsFromAddress = async (address: AddressWithTransactionsWithPrices): Promise<KeyValueT<Payment[]>> => {
   let paymentList: Payment[] = []
-  for (const tx of address.transactions) {
+  const zero = new Prisma.Decimal(0)
+  for (const tx of address.transactions.filter(tx => tx.amount > zero)) {
     const payment = await getPaymentFromTx(tx)
     paymentList.push(payment)
   }
@@ -157,7 +158,8 @@ export const cacheAddress = async (address: AddressWithTransactionsWithPrices): 
 }
 
 export const cacheManyTxs = async (txs: TransactionWithAddressAndPrices[]): Promise<void> => {
-  for (const tx of txs) {
+  const zero = new Prisma.Decimal(0)
+  for (const tx of txs.filter(tx => tx.amount > zero)) {
     const payment = await getPaymentFromTx(tx)
     if (payment.value !== new Prisma.Decimal(0)) {
       const paymentsGroupedByKey = getPaymentsByWeek(tx.address.id, [payment])

--- a/scripts/paybutton-server-start.sh
+++ b/scripts/paybutton-server-start.sh
@@ -1,8 +1,4 @@
 #!/bin/sh
-echo pwd
-pwd
-echo ls
-ls
 . .env
 . .env.local
 yarn || exit 1


### PR DESCRIPTION
Description
---
Solves #527


Test plan
---
No need to rerun containers, just delete the cache with `yarn docker cmr` and check that the negative payments are gone.
