### PR TITLE
chore: remove pm2 logs before starting

### DIFF
--- a/scripts/paybutton-server-start.sh
+++ b/scripts/paybutton-server-start.sh
@@ -4,6 +4,7 @@
 yarn || exit 1
 yarn prisma migrate dev || exit 1
 yarn prisma db seed || exit 1
+rm logs/*
 pm2 start yarn --time --interpreter ash --name jobs -- initJobs || exit 1
 pm2 start yarn --time --interpreter ash --name SSEServer -- initSSEServer || exit 1
 if [ "$ENVIRONMENT" = "production" ]; then


### PR DESCRIPTION
Description
---
Don't keep logs of previous container runs, always remove the logs before starting the app.

Test plan
---
restart the containers, make sure the files at `logs/` were deleted.