### PR TITLE
fix: Env var for SSE

### DIFF
--- a/config/appInfo.ts
+++ b/config/appInfo.ts
@@ -6,7 +6,7 @@ export const appInfo = {
   apiDomain: process.env.API_DOMAIN,
   websiteBasePath: `${websiteBasePath}/auth`,
   websiteDomain: process.env.WEBSITE_DOMAIN ?? 'localhost:3000',
-  sseBaseURL: process.env.SSE_BASE_URL ?? 'localhost:5000',
+  sseBaseURL: process.env.SSE_BASE_URL ?? 'http://localhost:5000',
   showTestNetworks: JSON.parse(process.env.SHOW_TEST_NETWORKS ?? 'false'),
   priceAPIURL: process.env.PRICE_API_URL ?? '',
   priceAPIToken: process.env.PRICE_API_TOKEN ?? '',

--- a/config/appInfo.ts
+++ b/config/appInfo.ts
@@ -6,6 +6,7 @@ export const appInfo = {
   apiDomain: process.env.API_DOMAIN,
   websiteBasePath: `${websiteBasePath}/auth`,
   websiteDomain: process.env.WEBSITE_DOMAIN ?? 'localhost:3000',
+  sseBaseURL: process.env.SSE_BASE_URL ?? 'localhost:5000',
   showTestNetworks: JSON.parse(process.env.SHOW_TEST_NETWORKS ?? 'false'),
   priceAPIURL: process.env.PRICE_API_URL ?? '',
   priceAPIToken: process.env.PRICE_API_TOKEN ?? '',

--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'next/router'
 import { BroadcastTxData } from 'sse-service/client'
 import { KeyValueT } from 'constants/index'
 import { TransactionWithAddressAndPrices } from 'services/transactionService'
+import { appInfo } from 'config/appInfo'
 
 const ThirdPartyEmailPasswordAuthNoSSR = dynamic(
   new Promise((resolve, reject) =>
@@ -118,7 +119,7 @@ const ProtectedPage = (props: PaybuttonProps): React.ReactElement => {
         void fetchTransactions(connector.address.address)
         addressesToListen.push(connector.address.address)
       }
-      const es = new EventSource('http://localhost:5000/events')
+      const es = new EventSource(`${appInfo.sseBaseURL}/events`)
       void createListeners(es, addressesToListen)
       return () => es.close()
     }

--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -96,8 +96,8 @@ const ProtectedPage = (props: PaybuttonProps): React.ReactElement => {
             setTransactions(prevTransactions => ({
               ...prevTransactions,
               [addr]: [...prevTransactions[addr]
-                .filter(tx => tx.hash !== insertedTxs[addr].hash), // avoid keeping unconfirmed tx together with confirmed
-              insertedTxs[addr]]
+                .filter(tx => !insertedTxs[addr].map(newTx => newTx.hash).includes(tx.hash)), // avoid keeping unconfirmed tx together with confirmed
+              ...insertedTxs[addr]]
             }))
           }
         }

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -294,7 +294,7 @@ export class GrpcBlockchainClient implements BlockchainClient {
       [...addressWithUnconfirmedTransactions, ...addressWithConfirmedTransactions].map(async addressWithTransaction => {
         const tx = await createTransaction(addressWithTransaction.transaction)
         if (tx !== undefined) {
-          insertedTxs[addressWithTransaction.address.address] = tx
+          insertedTxs[addressWithTransaction.address.address] = [tx]
         }
         return tx
       })

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -254,7 +254,7 @@ export class GrpcBlockchainClient implements BlockchainClient {
     }
   }
 
-  private async getPrismaTransactionsForSubscribedAddresses (transaction: Transaction.AsObject, confirmed: boolean): Promise<AddressWithTransaction[]> {
+  private async getAddressesForTransaction (transaction: Transaction.AsObject, confirmed: boolean): Promise<AddressWithTransaction[]> {
     const addressWithTransactions: AddressWithTransaction[] = await Promise.all(Object.values(this.subscribedAddresses).map(
       async address => {
         return {
@@ -275,7 +275,7 @@ export class GrpcBlockchainClient implements BlockchainClient {
     // get new confirmed transactions
     const confirmedTransaction = data.getConfirmedTransaction()?.toObject()
     if (confirmedTransaction != null) {
-      addressWithConfirmedTransactions = await this.getPrismaTransactionsForSubscribedAddresses(confirmedTransaction, true)
+      addressWithConfirmedTransactions = await this.getAddressesForTransaction(confirmedTransaction, true)
 
       // remove unconfirmed transactions that have now been confirmed
       const transactionsToDelete = await fetchUnconfirmedTransactions(base64HashToHex(confirmedTransaction.hash as string))
@@ -286,7 +286,7 @@ export class GrpcBlockchainClient implements BlockchainClient {
     const unconfirmedTransaction = data.getUnconfirmedTransaction()?.toObject()
     if (unconfirmedTransaction != null) {
       const parsedUnconfirmedTransaction = this.parseMempoolTx(unconfirmedTransaction)
-      addressWithUnconfirmedTransactions = await this.getPrismaTransactionsForSubscribedAddresses(parsedUnconfirmedTransaction, false)
+      addressWithUnconfirmedTransactions = await this.getAddressesForTransaction(parsedUnconfirmedTransaction, false)
     }
 
     const insertedTxs: BroadcastTxData = {}

--- a/sse-service/client.ts
+++ b/sse-service/client.ts
@@ -1,10 +1,11 @@
+import { appInfo } from '../config/appInfo'
 import { KeyValueT } from 'constants/index'
 import { TransactionWithAddressAndPrices } from 'services/transactionService'
 
 export type BroadcastTxData = KeyValueT<TransactionWithAddressAndPrices>
 
 export async function broadcastTxInsertion (insertedTxs: BroadcastTxData): Promise<Response> {
-  return await fetch('http://localhost:5000/broadcast-new-tx', {
+  return await fetch(`${appInfo.sseBaseURL}/broadcast-new-tx`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/sse-service/client.ts
+++ b/sse-service/client.ts
@@ -2,7 +2,7 @@ import { appInfo } from '../config/appInfo'
 import { KeyValueT } from 'constants/index'
 import { TransactionWithAddressAndPrices } from 'services/transactionService'
 
-export type BroadcastTxData = KeyValueT<TransactionWithAddressAndPrices>
+export type BroadcastTxData = KeyValueT<TransactionWithAddressAndPrices[]>
 
 export async function broadcastTxInsertion (insertedTxs: BroadcastTxData): Promise<Response> {
   return await fetch(`${appInfo.sseBaseURL}/broadcast-new-tx`, {

--- a/sse-service/server.ts
+++ b/sse-service/server.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express'
 import { Server } from 'http'
 import cors from 'cors'
 import { BroadcastTxData } from './client'
+import { appInfo } from '../config/appInfo'
 
 const app = express()
 app.use(cors())
@@ -46,5 +47,5 @@ app.post('/broadcast-new-tx', express.json(), (req: Request, res: Response) => {
 })
 
 server.listen(5000, () => {
-  console.log('SSE service listening on http://localhost:5000')
+  console.log(`SSE service listening on ${appInfo.sseBaseURL}`)
 })

--- a/sse-service/server.ts
+++ b/sse-service/server.ts
@@ -6,6 +6,7 @@ import { appInfo } from '../config/appInfo'
 
 const app = express()
 app.use(cors())
+app.use(express.json({ limit: '1mb' }))
 app.options('/events', cors())
 const server = new Server(app)
 


### PR DESCRIPTION
Depends on
---
- [x] #535 

Description
---
Uses a env var to set up the SSE server.

Test plan
---
All should work normally due to the fallback. Nonetheless, for prod this can be changed by setting the `SSE_BASE_URL` var in the `.env.local` file.

You can try breaking it setting a dummy URL in this file, or in `.env.development.local` in case you don't have `ENV=production` in `.env.local`. Then reset the containers

