### PR TITLE
[Issue #432] feat: distinguish button syncing vs button with no txs

### DIFF
--- a/addresses
+++ b/addresses
@@ -1,0 +1,7 @@
+Some addresses:
+
+ecash:qpcwm9zu84shsgxf9smwn5zxv6vkz3hnzs5pfz24de
+bitcoincash:qzcnygsu2v56gdsm798y59u0ka6t5llv4gvsq563cv
+
+ecash:qr8ger8kn2fz5cr73cp7ylkqznauyjyzuqhrr7863u (30k)
+

--- a/components/Transaction/AddressTransactions.tsx
+++ b/components/Transaction/AddressTransactions.tsx
@@ -15,8 +15,12 @@ interface IProps {
   addressTransactions: {
     [address: string]: Transaction
   }
+  addressSynced: {
+    [address: string]: boolean
+  }
 }
-export default ({ addressTransactions }: IProps): FunctionComponent => {
+
+export default ({ addressTransactions, addressSynced }: IProps): FunctionComponent => {
   const columns = useMemo(
     () => [
       {
@@ -77,7 +81,10 @@ export default ({ addressTransactions }: IProps): FunctionComponent => {
         <div key={transactionAddress}>
           <div className={style.tablelabel}>{transactionAddress}</div>
           { addressTransactions[transactionAddress].length === 0
-            ? <div className={style.transaction_ctn}>No transactions yet</div>
+            ? <div className={style.transaction_ctn}> {
+              addressSynced[transactionAddress] ? 'No transactions yet' : 'Syncing address...'
+              }
+            </div>
             : <TableContainer columns={columns} data={addressTransactions[transactionAddress]} />
         }
       </div>

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -144,7 +144,7 @@ export const syncAndSubscribeUnsyncedAddressesWorker = async (queue: Queue): Pro
         if (failedAddresses.length > 0) {
           console.error(`automatic syncing of addresses failed for addresses: ${JSON.stringify(failedAddressesWithErrors)}`)
         }
-        job.data.syncedAddresses = newAddresses.filter(addr => addr.address in failedAddresses)
+        job.data.syncedAddresses = newAddresses.filter(addr => !failedAddresses.includes(addr.address))
       }
 
       // add same job to the queue again, so it runs repeating

--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -61,6 +61,7 @@ export default function Home ({ paybuttonId }: PaybuttonProps): React.ReactEleme
 const ProtectedPage = (props: PaybuttonProps): React.ReactElement => {
   const [transactions, setTransactions] = useState<KeyValueT<TransactionWithAddressAndPrices[]>>({})
   const [paybutton, setPaybutton] = useState(undefined as PaybuttonWithAddresses | undefined)
+  const [isSynced, setIsSynced] = useState<KeyValueT<boolean>>({})
   const router = useRouter()
 
   const fetchTransactions = async (address: string): Promise<void> => {
@@ -78,8 +79,13 @@ const ProtectedPage = (props: PaybuttonProps): React.ReactElement => {
       method: 'GET'
     })
     if (res.status === 200) {
-      const paybuttonData = await res.json()
+      const paybuttonData = await res.json() as PaybuttonWithAddresses
       setPaybutton(paybuttonData)
+      const newIsSynced = { ...isSynced }
+      paybuttonData.addresses.forEach(addr => {
+        newIsSynced[addr.address.address] = addr.address.lastSynced != null
+      })
+      setIsSynced(newIsSynced)
     }
   }
 
@@ -131,7 +137,7 @@ const ProtectedPage = (props: PaybuttonProps): React.ReactElement => {
         <div className='back_btn' onClick={() => router.back()}>Back</div>
         <PaybuttonDetail paybutton={paybutton} refreshPaybutton={refreshPaybutton}/>
         <h4>Transactions</h4>
-        <AddressTransactions addressTransactions={transactions} />
+        <AddressTransactions addressTransactions={transactions} addressSynced={isSynced}/>
       </>
     )
   }

--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -74,6 +74,14 @@ const ProtectedPage = (props: PaybuttonProps): React.ReactElement => {
     }
   }
 
+  const updateIsSynced = (addressStringList: string[]): void => {
+    const newIsSynced = { ...isSynced }
+    addressStringList.forEach((addressString) => {
+      newIsSynced[addressString] = true
+    })
+    setIsSynced(newIsSynced)
+  }
+
   const fetchPaybutton = async (): Promise<void> => {
     const res = await fetch(`/api/paybutton/${props.paybuttonId}`, {
       method: 'GET'
@@ -94,6 +102,7 @@ const ProtectedPage = (props: PaybuttonProps): React.ReactElement => {
       (event: MessageEvent) => {
         const insertedTxs: BroadcastTxData = JSON.parse(event.data)
         const updatedAddresses: string[] = Object.keys(insertedTxs)
+        updateIsSynced(updatedAddresses)
         const affectedAddresses = addressList.filter(el => updatedAddresses.includes(el))
         const refresh = affectedAddresses.length > 0
         if (paybutton != null && refresh) {

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -100,7 +100,12 @@ export class ChronikBlockchainClient implements BlockchainClient {
       //   this date is understood as the beginning and we don't look past it
       transactions = transactions.filter(this.txThesholdFilter(address))
 
-      if (transactions.length === 0) break
+      if (transactions.length === 0) {
+        const broadcastTxData: BroadcastTxData = {}
+        broadcastTxData[addressString] = []
+        await broadcastTxInsertion(broadcastTxData)
+        break
+      }
       const latestBlockTimestamp = Number(transactions[0].block?.timestamp)
       if (latestBlockTimestamp < latestTimestamp) break
 


### PR DESCRIPTION
<!-- Insert the related issue below -->
Related to #432
---
- [X] Partially solves



<!-- Non-technical, objective summary of what the PR accomplishes -->
Description
---

Distinguishes between having a button w no transactions and a button that hasn't been synced yet. This can be improved in terms of prettiness, right now I simply made so that the text "No transactions yet." is replaced by "Syncing address..." in the case that the address has not been synced yet.


Test plan
---

Create a new button and click on it right away. You should see:
![image](https://github.com/PayButton/paybutton-server/assets/21281174/cafe79ef-b302-436b-a0b7-f4e7031768a8)
(there is a small chance that the sync will happen just after you click the button and you will see "No transactions yet.")
This text should be replaced for the txs in case the address has txs and for the text "No transactions yet" in case the address has no txs. No refreshing of the page should be needed.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
