### PR TITLE
fix: do not use `websiteDomain` on axios

### DIFF
--- a/components/Paybutton/EditButtonForm.tsx
+++ b/components/Paybutton/EditButtonForm.tsx
@@ -39,7 +39,7 @@ export default function EditButtonForm ({ paybutton, refreshPaybutton }: IProps)
       params.name = paybutton.name
     }
     try {
-      void await axios.patch(`${appInfo.websiteDomain}/api/paybutton/${paybutton.id}`, params)
+      void await axios.patch(`/api/paybutton/${paybutton.id}`, params)
       refreshPaybutton()
     } catch (err: any) {
       setError(err.response.data.message)
@@ -48,7 +48,7 @@ export default function EditButtonForm ({ paybutton, refreshPaybutton }: IProps)
 
   async function onDelete (paybuttonId: string): Promise<void> {
     try {
-      const res = await axios.delete<PaybuttonWithAddresses>(`${appInfo.websiteDomain}/api/paybutton/${paybuttonId}`)
+      const res = await axios.delete<PaybuttonWithAddresses>(`/api/paybutton/${paybuttonId}`)
       if (res.status === 200) {
         void Router.push(`${appInfo.websiteDomain}/buttons/`)
       }

--- a/components/Wallet/EditWalletForm.tsx
+++ b/components/Wallet/EditWalletForm.tsx
@@ -9,7 +9,6 @@ import TrashIcon from 'assets/trash-icon.png'
 import { WalletWithAddressesWithPaybuttons } from 'services/walletService'
 import { AddressWithPaybuttons } from 'services/addressService'
 import axios from 'axios'
-import { appInfo } from 'config/appInfo'
 import { UserNetworksInfo } from 'services/networkService'
 
 interface IProps {
@@ -34,7 +33,7 @@ export default function EditWalletForm ({ wallet, userAddresses, refreshWalletLi
       params.name = wallet.name
     }
     try {
-      void await axios.patch(`${appInfo.websiteDomain}/api/wallet/${wallet.id}`, params)
+      void await axios.patch(`/api/wallet/${wallet.id}`, params)
       refreshWalletList()
       setError('')
     } catch (err: any) {
@@ -43,7 +42,7 @@ export default function EditWalletForm ({ wallet, userAddresses, refreshWalletLi
   }
 
   async function onDelete (walletId: string): Promise<void> {
-    const res = await axios.delete<WalletWithAddressesWithPaybuttons>(`${appInfo.websiteDomain}/api/wallet/${walletId}`)
+    const res = await axios.delete<WalletWithAddressesWithPaybuttons>(`/api/wallet/${walletId}`)
     if (res.status === 200) {
       refreshWalletList()
     }

--- a/components/Wallet/WalletForm.tsx
+++ b/components/Wallet/WalletForm.tsx
@@ -7,7 +7,6 @@ import style from '../Wallet/wallet.module.css'
 import style_pb from 'components/Paybutton/paybutton.module.css'
 import Plus from 'assets/plus.png'
 import axios from 'axios'
-import { appInfo } from 'config/appInfo'
 import { UserNetworksInfo } from 'services/networkService'
 
 interface IProps {
@@ -27,8 +26,8 @@ export default function WalletForm ({ userAddresses, refreshWalletList, userId, 
     params.userId = userId
     params.addressIdList = selectedAddressIdList
     try {
-      void await axios.post(`${appInfo.websiteDomain}/api/wallet`, params)
-      refreshWalletList()
+      void await axios.post(`/api/wallet`, params)
+      void refreshWalletList()
       setError('')
     } catch (err: any) {
       setError(err.response.data.message)


### PR DESCRIPTION


<!-- Non-technical, objective summary of what the PR accomplishes -->
Description
---
Fixes problem in prod where some requests would have the repeated domain, e.g:
`https://api.paybutton.org/button/api.paybutton.org/api/paybutton/94f0a111-6f92-4eb2-b5c5-d3cc0b044973`


Test plan
---
E.g. creating wallets, editing buttons & deleting buttons should work normally locally, as it did before, and should work now on prod.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
