### PR TITLE
[Issue #539] fix: no new txs on endpoint

### DIFF
--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -13,7 +13,7 @@ const syncAndSubscribeAllAddressTransactionsForNetworkJob = async (job: Job): Pr
   try {
     let addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
     addresses = addresses.filter(addr => addr.lastSynced == null)
-    failedAddressesWithErrors = await transactionService.syncAndSubscribeAddresses(addresses)
+    failedAddressesWithErrors = (await transactionService.syncAndSubscribeAddresses(addresses)).failedAddressesWithErrors
   } catch (err: any) {
     const parsedError = parseError(err)
     if (parsedError.message === RESPONSE_MESSAGES.TRANSACTION_ALREADY_EXISTS_FOR_ADDRESS_400.message) {

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -1,38 +1,11 @@
 import { Worker, Job, Queue } from 'bullmq'
-import { Address, Prisma } from '@prisma/client'
 import { redisBullMQ } from 'redis/clientInstance'
 import { SYNC_NEW_ADDRESSES_DELAY, DEFAULT_WORKER_LOCK_DURATION, RESPONSE_MESSAGES, KeyValueT } from 'constants/index'
 
 import * as transactionService from 'services/transactionService'
 import * as priceService from 'services/priceService'
 import * as addressService from 'services/addressService'
-import { subscribeAddressesAddTransactions } from 'services/blockchainService'
 import { parseError } from 'utils/validators'
-import { productionAddresses } from 'prisma/seeds/addresses'
-import { appendTxsToFile } from 'prisma/seeds/transactions'
-
-const syncAndSubscribeAddresses = async (addresses: Address[]): Promise<KeyValueT<string>> => {
-  const failedAddressesWithErrors: KeyValueT<string> = {}
-  let txsToSave: Prisma.TransactionCreateManyInput[] = []
-  const productionAddressesIds = productionAddresses.map(addr => addr.id)
-  await Promise.all(
-    addresses.map(async (addr) => {
-      try {
-        await subscribeAddressesAddTransactions([addr])
-        const txs = await transactionService.syncAllTransactionsForAddress(addr, Infinity)
-        if (productionAddressesIds.includes(addr.id)) {
-          txsToSave = txsToSave.concat(txs)
-        }
-      } catch (err: any) {
-        failedAddressesWithErrors[addr.address] = err.stack
-      }
-    })
-  )
-  if (txsToSave.length !== 0) {
-    await appendTxsToFile(txsToSave)
-  }
-  return failedAddressesWithErrors
-}
 
 const syncAndSubscribeAllAddressTransactionsForNetworkJob = async (job: Job): Promise<void> => {
   console.log(`job ${job.id as string}: syncing and subscribing all addresses for network ${job.data.networkId as string}...`)
@@ -40,7 +13,7 @@ const syncAndSubscribeAllAddressTransactionsForNetworkJob = async (job: Job): Pr
   try {
     let addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
     addresses = addresses.filter(addr => addr.lastSynced == null)
-    failedAddressesWithErrors = await syncAndSubscribeAddresses(addresses)
+    failedAddressesWithErrors = await transactionService.syncAndSubscribeAddresses(addresses)
   } catch (err: any) {
     const parsedError = parseError(err)
     if (parsedError.message === RESPONSE_MESSAGES.TRANSACTION_ALREADY_EXISTS_FOR_ADDRESS_400.message) {

--- a/pages/api/address/transactions/[address].ts
+++ b/pages/api/address/transactions/[address].ts
@@ -43,7 +43,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
         if (serverOnly) throw new Error(NO_ADDRESS_FOUND_404.message)
 
         const addressObject = await upsertAddress(address)
-        await syncAndSubscribeAddresses(addressObject, NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
+        await syncAndSubscribeAddresses([addressObject], NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
       }
       const transactions = await fetchAddressTransactions(address)
 

--- a/pages/api/address/transactions/[address].ts
+++ b/pages/api/address/transactions/[address].ts
@@ -1,7 +1,7 @@
 import { NextApiResponse, NextApiRequest } from 'next'
 import { parseAddress } from 'utils/validators'
 import { NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY, RESPONSE_MESSAGES } from 'constants/index'
-import { fetchAddressTransactions, syncAllTransactionsForAddress } from 'services/transactionService'
+import { fetchAddressTransactions, syncAndSubscribeAddresses } from 'services/transactionService'
 import { upsertAddress, addressExistsBySubstring } from 'services/addressService'
 import Cors from 'cors'
 
@@ -43,7 +43,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
         if (serverOnly) throw new Error(NO_ADDRESS_FOUND_404.message)
 
         const addressObject = await upsertAddress(address)
-        await syncAllTransactionsForAddress(addressObject, NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
+        await syncAndSubscribeAddresses(addressObject, NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
       }
       const transactions = await fetchAddressTransactions(address)
 

--- a/pages/api/address/transactions/sync/[address].ts
+++ b/pages/api/address/transactions/sync/[address].ts
@@ -1,7 +1,7 @@
 import { NextApiResponse, NextApiRequest } from 'next'
 import { parseAddress } from 'utils/validators'
 import { NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY, RESPONSE_MESSAGES } from 'constants/index'
-import { syncAllTransactionsForAddress } from 'services/transactionService'
+import { syncAndSubscribeAddresses } from 'services/transactionService'
 import { upsertAddress } from 'services/addressService'
 import Cors from 'cors'
 
@@ -35,7 +35,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
       }
       const addressString = parseAddress(req.query.address as string)
       const address = await upsertAddress(addressString)
-      const transactions = await syncAllTransactionsForAddress(address, NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
+      const transactions = await syncAndSubscribeAddresses(address, NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
       res.status(200).send(transactions)
     } catch (err: any) {
       switch (err.message) {

--- a/pages/api/address/transactions/sync/[address].ts
+++ b/pages/api/address/transactions/sync/[address].ts
@@ -35,8 +35,8 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
       }
       const addressString = parseAddress(req.query.address as string)
       const address = await upsertAddress(addressString)
-      const transactions = await syncAndSubscribeAddresses(address, NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
-      res.status(200).send(transactions)
+      const syncedData = await syncAndSubscribeAddresses([address], NUMBER_OF_TRANSACTIONS_TO_SYNC_INITIALLY)
+      res.status(200).send(syncedData.syncedTxs)
     } catch (err: any) {
       switch (err.message) {
         case ADDRESS_NOT_PROVIDED_400.message:

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -254,15 +254,17 @@ export async function syncAllTransactionsForAddress (address: Address, maxTransa
   return insertedTransactions
 }
 
-export const syncAndSubscribeAddresses = async (addresses: Address[]): Promise<KeyValueT<string>> => {
+export const syncAndSubscribeAddresses = async (addresses: Address[], maxTransactionsToReturn?: number): Promise<KeyValueT<string>> => {
   const failedAddressesWithErrors: KeyValueT<string> = {}
   let txsToSave: Prisma.TransactionCreateManyInput[] = []
+  if (maxTransactionsToReturn === undefined) maxTransactionsToReturn = Infinity
+
   const productionAddressesIds = productionAddresses.map(addr => addr.id)
   await Promise.all(
     addresses.map(async (addr) => {
       try {
         await subscribeAddressesAddTransactions([addr])
-        const txs = await syncAllTransactionsForAddress(addr, Infinity)
+        const txs = await syncAllTransactionsForAddress(addr, maxTransactionsToReturn!)
         if (productionAddressesIds.includes(addr.id)) {
           txsToSave = txsToSave.concat(txs)
         }


### PR DESCRIPTION
Solves #539 

<!-- Non-technical, objective summary of what the PR accomplishes -->
Description
---
Endpoint `address/transactions` now will also subscribe the addresses, so that we monitor them for when new txs arrive.


Test plan
---
This is running now in prod, so it should solve #539
