### PR TITLE
fix: wallet payment count

### DIFF
--- a/services/addressService.ts
+++ b/services/addressService.ts
@@ -230,7 +230,8 @@ export async function getAddressPaymentInfo (addressString: string): Promise<Add
   const balance = transactionsAmounts.reduce((a, b) => {
     return a.plus(b)
   }, new Prisma.Decimal(0))
-  const paymentCount = transactionsAmounts.length
+  const zero = new Prisma.Decimal(0)
+  const paymentCount = transactionsAmounts.filter(t => t > zero).length
   return {
     balance,
     paymentCount


### PR DESCRIPTION


<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Payment count on wallet was counting negative txs.


Test plan
---
Check that the payment count sum of wallets is different from the value in the dashboard. After this PR should be the same


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
