### PR TITLE
feat: no job for sync addresses

### DIFF
--- a/services/paybuttonService.ts
+++ b/services/paybuttonService.ts
@@ -148,7 +148,7 @@ export async function createPaybutton (values: CreatePaybuttonInput): Promise<Pa
     values.prefixedAddressList.map(async (address) => {
       const upsertedAddress = await addressService.upsertAddress(address, prisma)
       addressIdList.push(upsertedAddress.id)
-      if (upsertedAddress.createdAt !== upsertedAddress.updatedAt) {
+      if (upsertedAddress.createdAt.getTime() !== upsertedAddress.updatedAt.getTime()) {
         updatedAddressIdList.push(upsertedAddress.id)
       }
     })

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -136,7 +136,7 @@ export async function createTransaction (
     update: {}
   })
   // only return if it was created, if it was updated return undefined
-  if (createdTx.createdAt === createdTx.updatedAt) {
+  if (createdTx.createdAt.getTime() === createdTx.updatedAt.getTime()) {
     void await connectTransactionToPrices(createdTx, prisma)
     const txWithPrices = await fetchTransactionById(createdTx.id)
     void await cacheManyTxs([txWithPrices])
@@ -207,7 +207,7 @@ export async function createManyTransactions (
       })
       return {
         tx: upsertedTx,
-        isCreated: upsertedTx.createdAt === upsertedTx.updatedAt
+        isCreated: upsertedTx.createdAt.getTime() === upsertedTx.updatedAt.getTime()
       }
     })
   )


### PR DESCRIPTION
<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Address sync is now done through a job that polls for new addresses anymore.

Now, when a new address is inserted through button creation/ updating a button, we sync it asynchronously.


Test plan
---
Should work better than before:
- now its faster because there is no delay in waiting for the poll to detect the new address,
- now its async, a big address won't block new address from sync. New addresses will sync just as they are inserted.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
