### PR TITLE
[Issue #565] fix: ignore tx broadcast issue

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -50,7 +50,8 @@ export const RESPONSE_MESSAGES = {
   CACHED_PAYMENT_NOT_FOUND_404: { statusCode: 404, message: 'Cached payment not found.' },
   NO_CONTEXT_TO_INFER_USER_ADRESS_WALLET_400: { statusCode: 400, message: 'Trying to update the wallet for a user address without contex.' },
   NO_ADDRESS_FOUND_FOR_TRANSACTION_404: { statusCode: 404, message: 'No address found for transaction.' },
-  FAILED_TO_UPSERT_TRANSACTION_500: { statusCode: 500, message: 'Failed to upsert transaction.' }
+  FAILED_TO_UPSERT_TRANSACTION_500: { statusCode: 500, message: 'Failed to upsert transaction.' },
+  COULD_NOT_BROADCAST_TX_TO_SSE_SERVER_500: { statusCode: 500, message: 'Could not broadcast upcoming transaction to SSE server.' }
 }
 
 export type KeyValueT<T> = Record<string, T>

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -101,7 +101,7 @@ export const connectAllTransactionsToPricesWorker = async (queueName: string): P
   worker.on('failed', (job, err) => {
     if (job !== undefined) {
       console.log('automatic connecting of txs to prices FAILED')
-      console.log(`error for connecting txs to prices: ${err.message}`)
+      console.log(`error for connecting txs to prices: ${err.message}: ${err.stack ?? 'no stack'}`)
     }
   })
 }

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -205,7 +205,11 @@ export class ChronikBlockchainClient implements BlockchainClient {
           return tx
         })
       )
-      await broadcastTxInsertion(insertedTxs)
+      try {
+        await broadcastTxInsertion(insertedTxs)
+      } catch (err: any) {
+        console.error(RESPONSE_MESSAGES.COULD_NOT_BROADCAST_TX_TO_SSE_SERVER_500.message, err.stack)
+      }
     }
   }
 

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -300,6 +300,10 @@ export class GrpcBlockchainClient implements BlockchainClient {
         return tx
       })
     )
-    await broadcastTxInsertion(insertedTxs)
+    try {
+      await broadcastTxInsertion(insertedTxs)
+    } catch (err: any) {
+      console.error(RESPONSE_MESSAGES.COULD_NOT_BROADCAST_TX_TO_SSE_SERVER_500.message, err.stack)
+    }
   }
 }

--- a/sse-service/server.ts
+++ b/sse-service/server.ts
@@ -16,7 +16,7 @@ app.get('/events', (req: Request, res: Response) => {
   res.setHeader('Content-Type', 'text/event-stream')
   res.setHeader('Content-Encoding', 'none')
   res.setHeader('Cache-Control', 'no-cache')
-  res.setHeader('Connection', 'keep-alive')
+  res.setHeader('Access-Control-Allow-Origin', '*')
   res.flushHeaders()
 
   clients.push(res)


### PR DESCRIPTION
Related to #565 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
We were getting errors in prod in trying to broadcast the upcoming transaction to the SSE server, which would break the subscription.
Now we log and ignore this issue if it happens.



Test plan
---
Querying for e.g. `https://api.paybutton.org/api/address/transactions/ecash:qqfttx62h6uqn73978rjatl680rccxfd5uuwyfp6nl`  should always return new txs if those exist. That means a button client should not stop receving txs updates.

Remarks
---
It's good that this CORS problem does not breaks tx subscription, but we should not be getting it anyway. This would be addressed seperately.
