### PR TITLE
[Issue #572] fix: update prices on days passing

### DIFF
--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { Prisma, Price } from '@prisma/client'
 import config from 'config'
 import prisma from 'prisma/clientInstance'
-import { HUMAN_READABLE_DATE_FORMAT, PRICE_API_TIMEOUT, PRICE_API_MAX_RETRIES, PRICE_API_DATE_FORMAT, RESPONSE_MESSAGES, NETWORK_TICKERS, XEC_NETWORK_ID, BCH_NETWORK_ID, USD_QUOTE_ID, CAD_QUOTE_ID, N_OF_QUOTES, CURRENT_PRICE_REPEAT_DELAY } from 'constants/index'
+import { HUMAN_READABLE_DATE_FORMAT, PRICE_API_TIMEOUT, PRICE_API_MAX_RETRIES, PRICE_API_DATE_FORMAT, RESPONSE_MESSAGES, NETWORK_TICKERS, XEC_NETWORK_ID, BCH_NETWORK_ID, USD_QUOTE_ID, CAD_QUOTE_ID, N_OF_QUOTES } from 'constants/index'
 import { validatePriceAPIUrlAndToken, validateNetworkTicker } from 'utils/validators'
 import moment from 'moment'
 
@@ -157,19 +157,6 @@ export async function syncPastDaysNewerPrices (): Promise<void> {
   )
 }
 
-async function upsertNextDayPrice (responseData: IResponseData, networkId: number, date: moment.Moment): Promise<void> {
-  const minuteThreshold = (
-    60 - ( // total of minutes in an hour, minus...
-      CURRENT_PRICE_REPEAT_DELAY / 1000 / 60 * // (convert delay from miliseconds to minutes)
-      2 // ... double than the amount of minutes
-    )
-  )
-  if (date.hour() === 23 && date.minute() >= minuteThreshold) {
-    const nextDayInitialTimestamp = date.clone().add(1, 'days').startOf('day').unix()
-    await upsertPricesForNetworkId(responseData, networkId, nextDayInitialTimestamp)
-  }
-}
-
 export async function syncCurrentPrices (): Promise<boolean> {
   let success = true
   const today = moment()
@@ -177,15 +164,11 @@ export async function syncCurrentPrices (): Promise<boolean> {
   const bchPrice = await getPriceForDayAndNetworkTicker(today, NETWORK_TICKERS.bitcoincash)
   if (bchPrice != null) {
     void upsertCurrentPricesForNetworkId(bchPrice, BCH_NETWORK_ID)
-    void await upsertPricesForNetworkId(bchPrice, BCH_NETWORK_ID, flattenTimestamp(today.unix()))
-    void await upsertNextDayPrice(bchPrice, BCH_NETWORK_ID, today)
   } else success = false
 
   const xecPrice = await getPriceForDayAndNetworkTicker(today, NETWORK_TICKERS.ecash)
   if (xecPrice != null) {
     void upsertCurrentPricesForNetworkId(xecPrice, XEC_NETWORK_ID)
-    void await upsertPricesForNetworkId(xecPrice, XEC_NETWORK_ID, flattenTimestamp(today.unix()))
-    void await upsertNextDayPrice(xecPrice, XEC_NETWORK_ID, today)
   } else success = false
 
   return success
@@ -232,7 +215,7 @@ export interface SyncTransactionPricesInput {
   transactionId: string
 }
 
-export async function fetchPricesForNetworkAndTimestamp (networkId: number, timestamp: number, prisma: Prisma.TransactionClient): Promise<AllPrices> {
+export async function fetchPricesForNetworkAndTimestamp (networkId: number, timestamp: number, prisma: Prisma.TransactionClient, attempt: number = 1): Promise<AllPrices> {
   timestamp = flattenTimestamp(timestamp)
   const cadPrice = await prisma.price.findUnique({
     where: {
@@ -253,6 +236,17 @@ export async function fetchPricesForNetworkAndTimestamp (networkId: number, time
     }
   })
   if (cadPrice === null || usdPrice === null) {
+    const xecPrice = await getPriceForDayAndNetworkTicker(moment(timestamp), NETWORK_TICKERS.ecash)
+    if (xecPrice !== null) {
+      await upsertPricesForNetworkId(xecPrice, networkId, timestamp)
+    }
+    const bchPrice = await getPriceForDayAndNetworkTicker(moment(timestamp), NETWORK_TICKERS.bitcoincash)
+    if (bchPrice !== null) {
+      await upsertPricesForNetworkId(bchPrice, networkId, timestamp)
+    }
+    if (attempt < PRICE_API_MAX_RETRIES) {
+      return await fetchPricesForNetworkAndTimestamp(networkId, timestamp, prisma, attempt + 1)
+    }
     throw new Error(RESPONSE_MESSAGES.NO_PRICES_FOUND_404.message)
   }
   return {

--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -236,14 +236,7 @@ export async function fetchPricesForNetworkAndTimestamp (networkId: number, time
     }
   })
   if (cadPrice === null || usdPrice === null) {
-    const xecPrice = await getPriceForDayAndNetworkTicker(moment(timestamp), NETWORK_TICKERS.ecash)
-    if (xecPrice !== null) {
-      await upsertPricesForNetworkId(xecPrice, networkId, timestamp)
-    }
-    const bchPrice = await getPriceForDayAndNetworkTicker(moment(timestamp), NETWORK_TICKERS.bitcoincash)
-    if (bchPrice !== null) {
-      await upsertPricesForNetworkId(bchPrice, networkId, timestamp)
-    }
+    await renewPricesForTimestamp(timestamp)
     if (attempt < PRICE_API_MAX_RETRIES) {
       return await fetchPricesForNetworkAndTimestamp(networkId, timestamp, prisma, attempt + 1)
     }
@@ -252,5 +245,16 @@ export async function fetchPricesForNetworkAndTimestamp (networkId: number, time
   return {
     cad: cadPrice,
     usd: usdPrice
+  }
+}
+
+async function renewPricesForTimestamp (timestamp: number): Promise<void> {
+  const xecPrice = await getPriceForDayAndNetworkTicker(moment(timestamp * 1000), NETWORK_TICKERS.ecash)
+  if (xecPrice !== null) {
+    await upsertPricesForNetworkId(xecPrice, XEC_NETWORK_ID, timestamp)
+  }
+  const bchPrice = await getPriceForDayAndNetworkTicker(moment(timestamp * 1000), NETWORK_TICKERS.bitcoincash)
+  if (bchPrice !== null) {
+    await upsertPricesForNetworkId(bchPrice, BCH_NETWORK_ID, timestamp)
   }
 }

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -212,7 +212,7 @@ export async function createManyTransactions (
     })
   )
   const insertedTransactions = insertedTransactionsDistinguished
-    .filter(txD => !txD.isCreated)
+    .filter(txD => txD.isCreated)
     .map(txD => txD.tx)
   void await connectTransactionsListToPrices(insertedTransactions)
   const txsWithPrices = await prisma.transaction.findMany({


### PR DESCRIPTION
Related to #572

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Solves #572 and also another bug where prices wouldn't be connected to new arriving addresses/txs.



Test plan
---
1. Restart the containers, then  go to the DB container and check the timestamp of today by running:
`select timestamp from Price order by timestamp DESC limit 4;`
e.g. on the day of writing this PR, this is `1689033600`.

2. Then delete those prices by running e.g.` DELETE FROM Price WHERE timestamp=1689033600;`
You should see: `Query OK, 4 rows affected`.
Running ` SELECT * FROM Price WHERE timestamp=1689033600;` should return nothing

3.  Now either add a paybutton that has a tx that was done today, or add any paybutton and make a tx to it.
4. In both cases, the tx should appear in the detail normally, the dashboard should work normally and now running `SELECT * FROM Price WHERE timestamp=1689033600;` should give 4 results again (the price was recreated).




<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
