### PR TITLE
fix: only delete uncofirmed txs if they exist

### DIFF
--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -157,7 +157,7 @@ ALTER TABLE `AddressesOnButtons` ADD CONSTRAINT `AddressesOnButtons_addressId_fk
 ALTER TABLE `AddressesOnButtons` ADD CONSTRAINT `AddressesOnButtons_paybuttonId_fkey` FOREIGN KEY (`paybuttonId`) REFERENCES `Paybutton`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE `Transaction` ADD CONSTRAINT `Transaction_addressId_fkey` FOREIGN KEY (`addressId`) REFERENCES `Address`(`id`) ON DELETE CASCADE ON UPDATE RESTRICT;
+ALTER TABLE `Transaction` ADD CONSTRAINT `Transaction_addressId_fkey` FOREIGN KEY (`addressId`) REFERENCES `Address`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE `WalletsOnUserProfile` ADD CONSTRAINT `WalletsOnUserProfile_walletId_fkey` FOREIGN KEY (`walletId`) REFERENCES `Wallet`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,7 +67,7 @@ model Transaction {
   confirmed Boolean                @default(false)
   timestamp Int
   addressId String
-  address   Address                @relation(fields: [addressId], references: [id], onDelete: Cascade, onUpdate: Restrict)
+  address   Address                @relation(fields: [addressId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   prices    PricesOnTransactions[]
   createdAt DateTime                  @default(now())
   updatedAt DateTime                  @updatedAt

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -194,8 +194,8 @@ export class ChronikBlockchainClient implements BlockchainClient {
 
   private async processWsMessage (msg: SubscribeMsg): Promise<void> {
     // delete unconfirmed transaction from our database
-    // if they exist
-    if (msg.type === 'RemovedFromMempool' || msg.type === 'Confirmed') {
+    // if they were cancelled and not confirmed
+    if (msg.type === 'RemovedFromMempool') {
       const transactionsToDelete = await fetchUnconfirmedTransactions(msg.txid)
       try {
         await deleteTransactions(transactionsToDelete)

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -12,6 +12,7 @@ import * as ws from 'ws'
 import { BroadcastTxData } from 'ws-service/types'
 import config from 'config'
 import io, { Socket } from 'socket.io-client'
+import { parseError } from 'utils/validators'
 
 export class ChronikBlockchainClient implements BlockchainClient {
   chronik: ChronikClient
@@ -193,9 +194,17 @@ export class ChronikBlockchainClient implements BlockchainClient {
 
   private async processWsMessage (msg: SubscribeMsg): Promise<void> {
     // delete unconfirmed transaction from our database
+    // if they exist
     if (msg.type === 'RemovedFromMempool' || msg.type === 'Confirmed') {
       const transactionsToDelete = await fetchUnconfirmedTransactions(msg.txid)
-      await deleteTransactions(transactionsToDelete)
+      try {
+        await deleteTransactions(transactionsToDelete)
+      } catch (err: any) {
+        const parsedError = parseError(err)
+        if (parsedError.message !== RESPONSE_MESSAGES.NO_TRANSACTION_FOUND_404.message) {
+          throw err
+        }
+      }
     }
     // create unconfirmed or confirmed transaction
     if (msg.type === 'AddedToMempool' || msg.type === 'Confirmed') {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -133,7 +133,9 @@ export async function createTransaction (
         addressId: transactionData.addressId
       }
     },
-    update: {}
+    update: {
+      confirmed: transactionData.confirmed
+    }
   })
   // only return if it was created, if it was updated return undefined
   if (createdTx.createdAt.getTime() === createdTx.updatedAt.getTime()) {

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -80,6 +80,10 @@ export const parseError = function (error: Error): Error {
           error.message.includes('prisma.address.update')
         ) {
           return new Error(RESPONSE_MESSAGES.NO_ADDRESS_FOUND_404.message)
+        } else if (
+          error.message.includes('prisma.transaction.delete')
+        ) {
+          return new Error(RESPONSE_MESSAGES.NO_TRANSACTION_FOUND_404.message)
         }
         break
     }


### PR DESCRIPTION
Related to #565

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
#565 may be happening for other reasons, but right now I noticed on the logs that sometimes we were trying to delete non-existent txs. This PR fixed that



Test plan
---
1. Add two of your addresses to some paybutton, one of which has spendable coins.
2. Transfer money from one to the other. On ABC's wallet you can do that by right clicking an address and selecting "Spend from this address".
3. When the tx is confirmed, it should in parallel try to delete the unconfirmed tx twice. This makes so that we get the error "Record doesn't exist", but this can also not happen since async is non deterministic (one process can be executed quite further away from the other so that when it tries to find the unconfirmed tx this has already been deleted). This error should happen on master but not in this branch.

Overall, this is tricky to test and long also. The changes only makes so that we ignore the case where we try to delete a transaction that doesn't exist, so one option is just to approve it and see if we actually stop getting this error on prod.
<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
