### PR TITLE
[#538] feat: add admin dashboard view

### DIFF
--- a/config/backendConfig.ts
+++ b/config/backendConfig.ts
@@ -4,6 +4,7 @@ import { appInfo } from './appInfo'
 import { TypeInput } from 'supertokens-node/types'
 import * as walletService from 'services/walletService'
 import EmailVerification from 'supertokens-node/recipe/emailverification'
+import Dashboard from 'supertokens-node/recipe/dashboard'
 
 export const backendConfig = (): TypeInput => {
   let connectionURI: string | undefined = process.env.SUPERTOKENS_CONNECTION_URI
@@ -84,7 +85,8 @@ export const backendConfig = (): TypeInput => {
       SessionNode.init(),
       EmailVerification.init({
         mode: 'REQUIRED'
-      })
+      }),
+      Dashboard.init()
     ],
     isInServerlessEnv: true
   }

--- a/prisma/migrations/20230818181919_admin_user/migration.sql
+++ b/prisma/migrations/20230818181919_admin_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `UserProfile` ADD COLUMN `isAdmin` BOOLEAN NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -156,6 +156,7 @@ model UserProfile {
   id        String                    @id @db.VarChar(255)
   createdAt DateTime                  @default(now())
   updatedAt DateTime                  @updatedAt
+  isAdmin   Boolean?
   lastSentVerificationEmailAt DateTime?
   wallets   WalletsOnUserProfile[]
   addresses AddressesOnUserProfiles[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,7 +8,7 @@ import { addressUserConnectors } from './seeds/addressUserConnectors'
 import { wallets } from './seeds/wallets'
 import { getPrices } from './seeds/prices'
 import { quotes } from './seeds/quotes'
-import { createDevUserRawQueryList, userProfiles } from './seeds/devUser'
+import { createDevUsersRawQueryList, createAdminUserRawQueryList, devUserProfiles, adminUserProfiles } from './seeds/users'
 import { getTxsFromFile } from './seeds/transactions'
 const prisma = new PrismaClient()
 
@@ -39,13 +39,17 @@ async function main (): Promise<void> {
     await prisma.address.createMany({ data: addresses })
     await prisma.addressesOnButtons.createMany({ data: paybuttonAddressConnectors })
   }
-  // create default dev user
-  for (const q of createDevUserRawQueryList) {
+  // create users
+  for (const q of createDevUsersRawQueryList) {
+    await prisma.$executeRawUnsafe(q)
+  }
+  for (const q of createAdminUserRawQueryList) {
     await prisma.$executeRawUnsafe(q)
   }
   // create user profiles
   if (await prisma.userProfile.count() === 0) {
-    await prisma.userProfile.createMany({ data: userProfiles })
+    await prisma.userProfile.createMany({ data: devUserProfiles })
+    await prisma.userProfile.createMany({ data: adminUserProfiles })
   }
   // create wallet user profiles connectors
   if (await prisma.walletsOnUserProfile.count() === 0) {

--- a/prisma/seeds/users.ts
+++ b/prisma/seeds/users.ts
@@ -1,4 +1,4 @@
-export const createDevUserRawQueryList = [
+export const createDevUsersRawQueryList = [
   'USE supertokens;',
   'INSERT INTO app_id_to_user_id VALUES (\'public\', \'dev-uid\', \'emailpassword\') ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO app_id_to_user_id VALUES (\'public\', \'dev2-uid\', \'emailpassword\') ON DUPLICATE KEY UPDATE user_id=user_id;',
@@ -12,7 +12,7 @@ export const createDevUserRawQueryList = [
   'INSERT INTO emailpassword_user_to_tenant VALUES (\'public\', \'public\', \'dev2-uid\', \'dev2@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;'
 ]
 
-export const userProfiles = [
+export const devUserProfiles = [
   {
     id: 'dev-uid',
     createdAt: new Date(),
@@ -22,5 +22,26 @@ export const userProfiles = [
     id: 'dev2-uid',
     createdAt: new Date(),
     updatedAt: new Date()
+  }
+]
+
+export const createAdminUserRawQueryList = [
+  'USE supertokens;',
+  // create the dashboard user
+  'INSERT INTO dashboard_users VALUES (\'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'admin@paybutton.org\', \'$2a$11$/QAw1kqTCkOXDlBLE2McMu70zFkGJdlX..PDI4BqDYEOgpYyTxCn.\', 1692381805105) ON DUPLICATE KEY UPDATE user_id=user_id;',
+  // create the actual user, which is not related, but with the same data
+  'INSERT INTO app_id_to_user_id VALUES (\'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'emailpassword\') ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO emailpassword_users VALUES (\'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'admin@paybutton.org\', \'$2a$11$/QAw1kqTCkOXDlBLE2McMu70zFkGJdlX..PDI4BqDYEOgpYyTxCn.\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO emailverification_verified_emails VALUES (\'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'admin@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO all_auth_recipe_users VALUES (\'public\', \'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'emailpassword\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO emailpassword_user_to_tenant VALUES (\'public\', \'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'admin@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;'
+]
+
+export const adminUserProfiles = [
+  {
+    id: '085211a0-215f-4f3f-bf07-68f55bb6c7ed',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isAdmin: true
   }
 ]

--- a/utils/setSession.ts
+++ b/utils/setSession.ts
@@ -2,12 +2,8 @@ import { Response } from 'express'
 import { superTokensNextWrapper } from 'supertokens-node/nextjs'
 import { verifySession } from 'supertokens-node/recipe/session/framework/express'
 import { SessionRequest } from 'supertokens-node/framework/express'
-import supertokens from 'supertokens-node'
-import * as SuperTokensConfig from 'config/backendConfig'
 import { VerifySessionOptions } from 'supertokens-node/recipe/session'
 import { EmailVerificationClaim } from 'supertokens-node/recipe/emailverification'
-
-supertokens.init(SuperTokensConfig.backendConfig())
 
 /* Uses supertokens middleware to create `session` property in the request. */
 export async function setSession (req: SessionRequest, res: Response, allowUnverified = false): Promise<void> {


### PR DESCRIPTION
Related to #538


<!-- Non-technical -->
Description
---
Enables the default user dashboard of supertokens and create an admin account for it. 


Test plan
---
Authenticate as the admin user at http://localhost:3000/api/auth/dashboard and try it out.
