### PR TITLE
Remove  unneeded margin

### DIFF
--- a/pages/account/account.module.css
+++ b/pages/account/account.module.css
@@ -1,7 +1,6 @@
 .account_ctn {
   display: flex;
   flex-direction: column;
-  margin-top: 30px;
 }
 
 .account_card {


### PR DESCRIPTION

<!-- Non-technical -->
Description
---
Taking out the css rule that was adding some extra margin to the h2 on the account page.


Test plan
---
run the app and go to /account. The title at the top should be in the same place as the other pages 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
