### PR TITLE
Fix - Docker Script Compatibility

### DIFF
--- a/scripts/docker-exec-shortcuts.sh
+++ b/scripts/docker-exec-shortcuts.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # docker container exec shortcuts
 
 node_container_name="paybutton-dev"


### PR DESCRIPTION
<!-- Non-technical -->
Description
---
Our production environment encounters an error when using `yarn docker x` commands:

`./scripts/docker-exec-shortcuts.sh: 16: Syntax error: "(" unexpected`

Adding a `bash` shebang seems to be the easy fix.

Test plan
---
I haven't been able to recreate this outside of production. This test plan shouldn't cause downtime.

1. SSH into production server, and navigate to the server directory (should be on `master`)
2. Run `yarn docker dbs`
3. You will encounter an error
4. Now checkout this branch `git checkout fix/docker-script-compatibility`
5. Run `yarn docker dbs`
6. You should receive the db container prompt
7. Checkout `master` when finished testing

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
