### PR TITLE
chore: error if no WS_AUTH_KEY

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 DATABASE_URL="mysql://paybutton-user-test:paybutton-password@db:3306/paybutton-test"
 NODE_ENV="test"
+WS_AUTH_KEY="test"
 REDIS_URL="redis://paybutton-cache:6379"

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint-master:
 github-test-unit:
 	$(create_test_paybutton_json)
 	$(touch_local_env)
-	PRICE_API_TOKEN="foo" DATABASE_URL="mysql://paybutton-user-test:paybutton-password@db:3306/paybutton-test" npx ts-node -O '{"module":"commonjs"}' node_modules/jest/bin/jest.js tests/unittests --forceExit
+	WS_AUTH_KEY="test" PRICE_API_TOKEN="foo" DATABASE_URL="mysql://paybutton-user-test:paybutton-password@db:3306/paybutton-test" npx ts-node -O '{"module":"commonjs"}' node_modules/jest/bin/jest.js tests/unittests --forceExit
 
 # WARNING: this shouldn't be run on local machine, only on github. It will replace your config file
 github-test-integration:

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -38,6 +38,7 @@ export const RESPONSE_MESSAGES = {
   RESOURCE_DOES_NOT_BELONG_TO_USER_400: { statusCode: 400, message: 'Resource does not belong to user.' },
   MISSING_PRICE_API_URL_400: { statusCode: 400, message: 'Missing PRICE_API_URL environment variable.' },
   MISSING_PRICE_API_TOKEN_400: { statusCode: 400, message: 'Missing PRICE_API_TOKEN environment variable.' },
+  MISSING_WS_AUTH_KEY_400: { statusCode: 400, message: 'Missing WS_AUTH_KEY environment variable' },
   MISSING_PRICE_FOR_TRANSACTION_400: { statusCode: 400, message: 'Missing price for transaction.' },
   INVALID_PRICE_STATE_400: { statusCode: 400, message: 'Missing expected quote price for transaction.' },
   COULD_NOT_GET_BLOCK_INFO_500: { statusCode: 500, message: "Couldn't get block info." },

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -22,6 +22,9 @@ export class ChronikBlockchainClient implements BlockchainClient {
   wsEndpoint: Socket
 
   constructor () {
+    if (process.env.WS_AUTH_KEY === '' || process.env.WS_AUTH_KEY === undefined) {
+      throw new Error(RESPONSE_MESSAGES.MISSING_WS_AUTH_KEY_400.message)
+    }
     this.chronik = new ChronikClient(config.chronikClientURL)
     this.availableNetworks = [NETWORK_SLUGS.ecash]
     this.subscribedAddresses = {}


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Not setting a `WS_AUTH_KEY` now returns an error.


Test plan
---
Run the containers without the env var on .env or .env.local, you should get an error when trying to access the site for the first time.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
