### PR TITLE
[#613] feat: payment triggers frontend skeleton

### DIFF
--- a/components/Paybutton/PaybuttonDetail.tsx
+++ b/components/Paybutton/PaybuttonDetail.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import React from 'react'
 import { PaybuttonWithAddresses } from 'services/paybuttonService'
 import style from './paybutton.module.css'
 import EditButtonForm from './EditButtonForm'
@@ -12,7 +12,7 @@ interface IProps {
   paybutton: PaybuttonWithAddresses
   refreshPaybutton: Function
 }
-export default ({ paybutton, refreshPaybutton }: IProps): FunctionComponent => {
+export default ({ paybutton, refreshPaybutton }: IProps): JSX.Element => {
   return (
     <div className={style.paybutton_list_ctn}>
       <div className={`${style.paybutton_card} ${style.paybutton_card_no_hover}`}>

--- a/components/Paybutton/PaybuttonTrigger.tsx
+++ b/components/Paybutton/PaybuttonTrigger.tsx
@@ -28,7 +28,7 @@ export default ({ paybuttonId }: IProps): JSX.Element => {
   return (
     <div>
       <div>
-        <h4>Set triggers</h4>
+        <h4>When a Payment is Received...</h4>
         {success
           ? <p>Trigger set successfully</p>
           : <div className={style.form_ctn}>
@@ -52,16 +52,16 @@ export default ({ paybuttonId }: IProps): JSX.Element => {
               ...
               }"></textarea>
               <p >
-                Possible placeholders:
-                <ul>
-                  <li>buttonName</li>
-                  <li>paymentAddress</li>
-                  <li>currency</li>
-                  <li>amount</li>
-                  <li>Datetime</li>
-                  <li>Payload / BIP 70 data (e.g., tx id or other context; think Coin Dance supporters section)</li>
-                </ul>
+                Options:
               </p>
+              <ul>
+                <li>buttonName</li>
+                <li>paymentAddress</li>
+                <li>currency</li>
+                <li>amount</li>
+                <li>Datetime</li>
+                <li>Payload / BIP 70 data (e.g., tx id or other context; think Coin Dance supporters section)</li>
+              </ul>
             </div>
             {/* Tooltip */}
             <div >

--- a/components/Paybutton/PaybuttonTrigger.tsx
+++ b/components/Paybutton/PaybuttonTrigger.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react'
+import style from './paybutton.module.css'
+import style_w from '../Wallet/wallet.module.css'
+import { PaybuttonTriggerPOSTParameters } from 'utils/validators'
+import { useForm } from 'react-hook-form'
+import axios from 'axios'
+
+interface IProps {
+  paybuttonId: string
+}
+export default ({ paybuttonId }: IProps): JSX.Element => {
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+  const { register, handleSubmit, reset } = useForm<PaybuttonTriggerPOSTParameters>()
+
+  async function onSubmit (params: PaybuttonTriggerPOSTParameters): Promise<void> {
+    try {
+      const response = await axios.post(`/api/paybutton/trigger/${paybuttonId}`, params)
+      if (response.status === 200) {
+        setSuccess(true)
+        reset()
+      }
+    } catch (err: any) {
+      setError(err.response.data.message)
+    }
+  }
+
+  return (
+    <div>
+      <div>
+        <h4>Set triggers</h4>
+        {success
+          ? <p>Trigger set successfully</p>
+          : <div className={style.form_ctn}>
+          <form onSubmit={(e) => { void handleSubmit(onSubmit)(e) }} method='post'>
+            {/* Checkbox */}
+            <div className={style_w.input_field} key="sendEmail">
+              <input {...register('sendEmail')} type="checkbox" id="sendEmail" name="sendEmail" />
+              <label htmlFor="sendEmail">Receive email</label>
+            </div>
+
+            {/* Input Fields */}
+            <div>
+              <label htmlFor="postURL">URL:</label>
+              <input {...register('postURL')} type="text" id="postURL" name="postURL" />
+            </div>
+
+            <div>
+              <label htmlFor="postData">Text Area:</label>
+              <textarea {...register('postData')} id="postData" name="postData" placeholder="{
+                name: <buttonName>,
+              ...
+              }"></textarea>
+              <p >
+                Possible placeholders:
+                <ul>
+                  <li>buttonName</li>
+                  <li>paymentAddress</li>
+                  <li>currency</li>
+                  <li>amount</li>
+                  <li>Datetime</li>
+                  <li>Payload / BIP 70 data (e.g., tx id or other context; think Coin Dance supporters section)</li>
+                </ul>
+              </p>
+            </div>
+            {/* Tooltip */}
+            <div >
+              <div className={style.tip}>
+                Only triggers if payment &gt; X
+              </div>
+                <div className={style.btn_row2}>
+                  {(error === undefined || error === '') ? null : <div className={style.error_message}>{error}</div>}
+                  <div>
+                    <button type='submit' className='button_main'>Submit</button>
+                  </div>
+                </div>
+            </div>
+          </form>
+        </div>
+        }
+      </div>
+    </div>
+  )
+}

--- a/pages/api/paybutton/trigger/[id].ts
+++ b/pages/api/paybutton/trigger/[id].ts
@@ -1,0 +1,50 @@
+import { parseError, parsePaybuttonPOSTRequest } from 'utils/validators'
+import { setSession } from 'utils/setSession'
+import { RESPONSE_MESSAGES } from 'constants/index'
+
+export default async (req: any, res: any): Promise<void> => {
+  if (req.method === 'POST') {
+    // WIP
+    await setSession(req, res)
+    const values = req.body
+    const paybuttonId = req.query.id as string
+    console.log('values', values)
+    console.log('pb id', paybuttonId)
+    res.status(200).json({ success: true })
+    /*
+    values.userId = req.session.userId
+    try {
+      const createPaybuttonInput = parsePaybuttonPOSTRequest(values)
+      const paybutton = await paybuttonService.createPaybutton(createPaybuttonInput)
+      res.status(200).json(paybutton)
+    } catch (err: any) {
+      const parsedErr = parseError(err)
+      switch (parsedErr.message) {
+        case RESPONSE_MESSAGES.INVALID_ADDRESS_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.INVALID_ADDRESS_400)
+          break
+        case RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.ADDRESSES_NOT_PROVIDED_400)
+          break
+        case RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.USER_ID_NOT_PROVIDED_400)
+          break
+        case RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.NAME_NOT_PROVIDED_400)
+          break
+        case RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.PAYBUTTON_NAME_ALREADY_EXISTS_400)
+          break
+        case RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.INVALID_BUTTON_DATA_400)
+          break
+        case RESPONSE_MESSAGES.WALLET_ID_NOT_PROVIDED_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.WALLET_ID_NOT_PROVIDED_400)
+          break
+        default:
+          res.status(500).json({ statusCode: 500, message: parsedErr.message })
+      }
+    }
+     */
+  }
+}

--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -134,9 +134,9 @@ export default function Button (props: PaybuttonProps): React.ReactElement {
       <>
         <div className='back_btn' onClick={() => router.back()}>Back</div>
         <PaybuttonDetail paybutton={paybutton} refreshPaybutton={refreshPaybutton}/>
-        <PaybuttonTrigger paybuttonId={paybutton.id}/>
         <h4>Transactions</h4>
         <AddressTransactions addressTransactions={transactions} addressSynced={isSynced}/>
+        <PaybuttonTrigger paybuttonId={paybutton.id}/>
       </>
     )
   }

--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -13,6 +13,7 @@ import { KeyValueT, ResponseMessage } from 'constants/index'
 import { TransactionWithAddressAndPrices } from 'services/transactionService'
 import config from 'config'
 import io from 'socket.io-client'
+import PaybuttonTrigger from 'components/Paybutton/PaybuttonTrigger'
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   // this runs on the backend, so we must call init on supertokens-node SDK
@@ -133,6 +134,7 @@ export default function Button (props: PaybuttonProps): React.ReactElement {
       <>
         <div className='back_btn' onClick={() => router.back()}>Back</div>
         <PaybuttonDetail paybutton={paybutton} refreshPaybutton={refreshPaybutton}/>
+        <PaybuttonTrigger paybuttonId={paybutton.id}/>
         <h4>Transactions</h4>
         <AddressTransactions addressTransactions={transactions} addressSynced={isSynced}/>
       </>

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -232,3 +232,9 @@ export const validatePriceAPIUrlAndToken = function (): void {
 export interface WSGETParameters {
   addresses: string[]
 }
+
+export interface PaybuttonTriggerPOSTParameters {
+  sendEmail?: boolean
+  postURL?: string
+  postData?: string
+}


### PR DESCRIPTION
Related to #613

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Adds a skeleton for the frontend that sets up the triggers.



Test plan
---
For now, the submitted info will be logged in the backend, nothing else.
The following PRs will validate, commit the trigger to the the database and do the actual trigger activation upon payment

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
