### PR TITLE
[#613] feat: payment trigger logs

### DIFF
--- a/config/example-config.json
+++ b/config/example-config.json
@@ -16,5 +16,6 @@
   },
   "networksUnderMaintenance": {
     "bitcoincash": true
-  }
+  },
+  "triggerPOSTTimeout": 3000
 }

--- a/config/index.ts
+++ b/config/index.ts
@@ -19,6 +19,7 @@ interface Config {
   redisURL: string
   networkBlockchainClients: KeyValueT<BlockchainClientOptions>
   networksUnderMaintenance: KeyValueT<boolean>
+  triggerPOSTTimeout: number
 }
 
 const readConfig = (): Config => {

--- a/prisma/migrations/20230831194209_trigger_logs/migration.sql
+++ b/prisma/migrations/20230831194209_trigger_logs/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE `TriggerLog` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `triggerId` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `isError` BOOLEAN NOT NULL,
+    `actionType` VARCHAR(191) NOT NULL,
+    `data` LONGTEXT NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `TriggerLog` ADD CONSTRAINT `TriggerLog_triggerId_fkey` FOREIGN KEY (`triggerId`) REFERENCES `PaybuttonTrigger`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20230831194209_trigger_logs/migration.sql
+++ b/prisma/migrations/20230831194209_trigger_logs/migration.sql
@@ -12,4 +12,4 @@ CREATE TABLE `TriggerLog` (
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- AddForeignKey
-ALTER TABLE `TriggerLog` ADD CONSTRAINT `TriggerLog_triggerId_fkey` FOREIGN KEY (`triggerId`) REFERENCES `PaybuttonTrigger`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE `TriggerLog` ADD CONSTRAINT `TriggerLog_triggerId_fkey` FOREIGN KEY (`triggerId`) REFERENCES `PaybuttonTrigger`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20230831194209_trigger_logs/migration.sql
+++ b/prisma/migrations/20230831194209_trigger_logs/migration.sql
@@ -1,7 +1,7 @@
 -- CreateTable
 CREATE TABLE `TriggerLog` (
     `id` INTEGER NOT NULL AUTO_INCREMENT,
-    `triggerId` VARCHAR(191) NOT NULL,
+    `triggerId` VARCHAR(191) NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
     `isError` BOOLEAN NOT NULL,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -171,6 +171,18 @@ model PaybuttonTrigger {
   sendEmail      Boolean
   postData       String               @db.LongText
   postURL        String
+  logs           TriggerLog[]
 
   paybutton      Paybutton @relation(fields: [paybuttonId], references: [id], onDelete: Cascade)
+}
+
+model TriggerLog {
+  id        Int       @id @default(autoincrement())
+  triggerId String
+  trigger   PaybuttonTrigger @relation(fields: [triggerId], references: [id], onDelete: Restrict)
+  createdAt      DateTime                  @default(now())
+  updatedAt      DateTime                  @updatedAt
+  isError   Boolean
+  actionType   String
+  data       String               @db.LongText
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,7 +179,7 @@ model PaybuttonTrigger {
 model TriggerLog {
   id        Int       @id @default(autoincrement())
   triggerId String
-  trigger   PaybuttonTrigger @relation(fields: [triggerId], references: [id], onDelete: Restrict)
+  trigger   PaybuttonTrigger @relation(fields: [triggerId], references: [id], onDelete: SetNull)
   createdAt      DateTime                  @default(now())
   updatedAt      DateTime                  @updatedAt
   isError   Boolean

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,8 +178,8 @@ model PaybuttonTrigger {
 
 model TriggerLog {
   id        Int       @id @default(autoincrement())
-  triggerId String
-  trigger   PaybuttonTrigger @relation(fields: [triggerId], references: [id], onDelete: SetNull)
+  triggerId String?
+  trigger   PaybuttonTrigger? @relation(fields: [triggerId], references: [id], onDelete: SetNull)
   createdAt      DateTime                  @default(now())
   updatedAt      DateTime                  @updatedAt
   isError   Boolean

--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -182,7 +182,7 @@ async function postDataForTrigger (trigger: TriggerWithPaybutton, postDataParame
   let isError = false
   try {
     const parsedPostDataParameters = parseTriggerPostData(trigger.postData, postDataParameters)
-    const response = await axios.post('https://httpbin.org/post', parsedPostDataParameters)
+    const response = await axios.post(trigger.postURL, parsedPostDataParameters)
     const responseData = JSON.stringify(await response.data, undefined, 2)
     logData = {
       responseData

--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -154,13 +154,17 @@ export async function fetchTriggersForAddress (addressString: string): Promise<T
 
 type TriggerLogActionType = 'SendEmail' | 'PostData'
 
-interface TriggerLogErrorData {
+interface PostDataTriggerLogError {
   errorName: string
   errorMessage: string
   errorStack: string
+  triggerPostData: string
+  triggerPostURL: string
 }
 
-interface TriggerLogData {
+interface PostDataTriggerLog {
+  postedData: string
+  postedURL: string
   responseData: string
 }
 
@@ -188,13 +192,15 @@ export async function executeAddressTriggers (broadcastTxData: BroadcastTxData):
 
 async function postDataForTrigger (trigger: TriggerWithPaybutton, postDataParameters: PostDataParameters): Promise<void> {
   const actionType: TriggerLogActionType = 'PostData'
-  let logData: TriggerLogData | TriggerLogErrorData
+  let logData: PostDataTriggerLog | PostDataTriggerLogError
   let isError = false
   try {
     const parsedPostDataParameters = parseTriggerPostData(trigger.postData, postDataParameters)
     const response = await axios.post(trigger.postURL, parsedPostDataParameters)
     const responseData = await response.data
     logData = {
+      postedData: parsedPostDataParameters,
+      postedURL: trigger.postURL,
       responseData
     }
   } catch (err: any) {
@@ -202,7 +208,9 @@ async function postDataForTrigger (trigger: TriggerWithPaybutton, postDataParame
     logData = {
       errorName: err.name,
       errorMessage: err.message,
-      errorStack: err.stack
+      errorStack: err.stack,
+      triggerPostData: trigger.postData,
+      triggerPostURL: trigger.postURL
     }
   } finally {
     await prisma.triggerLog.create({

--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -5,6 +5,7 @@ import prisma from 'prisma/clientInstance'
 import { parseTriggerPostData, PostDataParameters } from 'utils/validators'
 import { BroadcastTxData } from 'ws-service/types'
 import { fetchPaybuttonById, fetchPaybuttonWithTriggers } from './paybuttonService'
+import config from 'config'
 
 const triggerWithPaybutton = Prisma.validator<Prisma.PaybuttonTriggerArgs>()({
   include: { paybutton: true }
@@ -196,7 +197,13 @@ async function postDataForTrigger (trigger: TriggerWithPaybutton, postDataParame
   let isError = false
   try {
     const parsedPostDataParameters = parseTriggerPostData(trigger.postData, postDataParameters)
-    const response = await axios.post(trigger.postURL, parsedPostDataParameters)
+    const response = await axios.post(
+      trigger.postURL,
+      parsedPostDataParameters,
+      {
+        timeout: config.triggerPOSTTimeout
+      }
+    )
     const responseData = await response.data
     logData = {
       postedData: parsedPostDataParameters,

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -209,7 +209,7 @@ export interface PaybuttonTriggerPOSTParameters {
   currentTriggerId?: string
 }
 
-interface PostDataParameters {
+export interface PostDataParameters {
   amount: Prisma.Decimal
   currency: string
   timestamp: number


### PR DESCRIPTION
Related to #613 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Logs every trigger execution, regardless of if it failed or not.
Also makes so that the URL defined by the user is the one used.


Test plan
---
1. Add the line `  "triggerPOSTTimeout": 3000` to your `paybutton-config.json`. See the example in `config/example-config.json`. This will make the trigger post wait at most 3 seconds for an answer.


2. Create a trigger, for example, with URL `https://httpbin.org/post` and data `{ "myThing": <amount>, "other": <buttonName> }`.
3. Send a payment to that button
4.  Enter the docker db container  (`yarn docker db`) and run `SELECT * FROM TriggerLog;`, and see if it was all logged alright.

5. Then change that trigger URL, to e.g: `https://sitethatdefinitelydoesnotexist.com`, send another payment to some of the button addresses and see if the error was logged correctly too.



<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
