### PR TITLE
[#613] feat: payment triggers hide send email

### DIFF
--- a/components/Paybutton/PaybuttonTrigger.tsx
+++ b/components/Paybutton/PaybuttonTrigger.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import style from './paybutton.module.css'
-import style_w from '../Wallet/wallet.module.css'
+// import style_w from '../Wallet/wallet.module.css'
 import { PaybuttonTriggerPOSTParameters } from 'utils/validators'
 import { useForm } from 'react-hook-form'
 import axios from 'axios'
@@ -52,10 +52,12 @@ export default ({ paybuttonId }: IProps): JSX.Element => {
           : <div className={style.form_ctn}>
           <form onSubmit={(e) => { void handleSubmit(onSubmit)(e) }} method='post'>
             {/* Checkbox */}
+            {/* TODO: send email logic
             <div className={style_w.input_field} key="sendEmail">
               <input {...register('sendEmail')} type="checkbox" id="sendEmail" name="sendEmail" />
               <label htmlFor="sendEmail">Receive email</label>
             </div>
+              *}
 
             {/* Input Fields */}
             <div>


### PR DESCRIPTION
Related to #613

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Hides "Receive email" checkbox on trigger form.


Test plan
---
Nothing should change, just shouldn't be possible to set this option on triggers, until we implement actually doing the email alert.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
