### PR TITLE
fix: subscribe db addresses

### DIFF
--- a/jobs/initJobs.ts
+++ b/jobs/initJobs.ts
@@ -2,7 +2,7 @@ import { XEC_NETWORK_ID, BCH_NETWORK_ID, CURRENT_PRICE_REPEAT_DELAY, SYNC_TXS_JO
 import { Queue, FlowProducer, FlowJob } from 'bullmq'
 import { redisBullMQ } from 'redis/clientInstance'
 import {
-  syncAndSubscribeAllAddressTransactionsForNetworkWorker,
+  syncAllAddressTransactionsForNetworkWorker,
   syncPricesWorker,
   connectAllTransactionsToPricesWorker
 } from './workers'
@@ -94,7 +94,7 @@ const main = async (): Promise<void> => {
   )
 
   await syncPricesWorker(pricesQueue.name)
-  await syncAndSubscribeAllAddressTransactionsForNetworkWorker(initTransactionsQueue.name)
+  await syncAllAddressTransactionsForNetworkWorker(initTransactionsQueue.name)
   await connectAllTransactionsToPricesWorker(connectPricesQueue.name)
 }
 

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -12,6 +12,7 @@ const syncAndSubscribeAllAddressTransactionsForNetworkJob = async (job: Job): Pr
   console.log(`job ${job.id as string}: syncing and subscribing all addresses for network ${job.data.networkId as string}...`)
   let failedAddressesWithErrors: KeyValueT<string> = {}
   try {
+    console.log('temp: vai puxar')
     let addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
     console.log(`found ${addresses.length} addresses...`)
     addresses = addresses.filter(addr => addr.lastSynced == null)

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -13,9 +13,9 @@ const syncAndSubscribeAllAddressTransactionsForNetworkJob = async (job: Job): Pr
   let failedAddressesWithErrors: KeyValueT<string> = {}
   try {
     console.log('temp: vai puxar')
-    let addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
+    const addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
     console.log(`found ${addresses.length} addresses...`)
-    addresses = addresses.filter(addr => addr.lastSynced == null)
+    // addresses = addresses.filter(addr => addr.lastSynced == null)
     console.log(`will subscribe ${addresses.length} addresses...`)
     failedAddressesWithErrors = (await transactionService.syncAndSubscribeAddresses(addresses)).failedAddressesWithErrors
   } catch (err: any) {

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -12,7 +12,6 @@ const syncAllAddressTransactionsForNetworkJob = async (job: Job): Promise<void> 
   console.log(`job ${job.id as string}: syncing all addresses for network ${job.data.networkId as string}...`)
   let failedAddressesWithErrors: KeyValueT<string> = {}
   try {
-    console.log('temp: vai puxar')
     let addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
     console.log(`found ${addresses.length} addresses...`)
     addresses = addresses.filter(addr => addr.lastSynced == null)

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -13,9 +13,9 @@ const syncAllAddressTransactionsForNetworkJob = async (job: Job): Promise<void> 
   let failedAddressesWithErrors: KeyValueT<string> = {}
   try {
     console.log('temp: vai puxar')
-    const addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
+    let addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
     console.log(`found ${addresses.length} addresses...`)
-    // addresses = addresses.filter(addr => addr.lastSynced == null)
+    addresses = addresses.filter(addr => addr.lastSynced == null)
     failedAddressesWithErrors = (await transactionService.syncAddresses(addresses)).failedAddressesWithErrors
   } catch (err: any) {
     const parsedError = parseError(err)

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -8,16 +8,15 @@ import * as addressService from 'services/addressService'
 import { parseError } from 'utils/validators'
 import { getSubbedAddresses } from 'services/chronikService'
 
-const syncAndSubscribeAllAddressTransactionsForNetworkJob = async (job: Job): Promise<void> => {
-  console.log(`job ${job.id as string}: syncing and subscribing all addresses for network ${job.data.networkId as string}...`)
+const syncAllAddressTransactionsForNetworkJob = async (job: Job): Promise<void> => {
+  console.log(`job ${job.id as string}: syncing all addresses for network ${job.data.networkId as string}...`)
   let failedAddressesWithErrors: KeyValueT<string> = {}
   try {
     console.log('temp: vai puxar')
     const addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
     console.log(`found ${addresses.length} addresses...`)
     // addresses = addresses.filter(addr => addr.lastSynced == null)
-    console.log(`will subscribe ${addresses.length} addresses...`)
-    failedAddressesWithErrors = (await transactionService.syncAndSubscribeAddresses(addresses)).failedAddressesWithErrors
+    failedAddressesWithErrors = (await transactionService.syncAddresses(addresses)).failedAddressesWithErrors
   } catch (err: any) {
     const parsedError = parseError(err)
     if (parsedError.message === RESPONSE_MESSAGES.TRANSACTION_ALREADY_EXISTS_FOR_ADDRESS_400.message) {
@@ -32,23 +31,23 @@ const syncAndSubscribeAllAddressTransactionsForNetworkJob = async (job: Job): Pr
   }
 }
 
-export const syncAndSubscribeAllAddressTransactionsForNetworkWorker = async (queueName: string): Promise<void> => {
+export const syncAllAddressTransactionsForNetworkWorker = async (queueName: string): Promise<void> => {
   const worker = new Worker(
     queueName,
-    syncAndSubscribeAllAddressTransactionsForNetworkJob,
+    syncAllAddressTransactionsForNetworkJob,
     {
       connection: redisBullMQ,
       lockDuration: DEFAULT_WORKER_LOCK_DURATION
     }
   )
   worker.on('completed', job => {
-    console.log(`initial syncing and subscribing finished for network ${job.data.networkId as string}`)
+    console.log(`initial syncing finished for network ${job.data.networkId as string}`)
   })
 
   worker.on('failed', (job, err) => {
     if (job !== undefined) {
-      console.log(`initial syncing and subscribing FAILED for network ${job.data.networkId as string}`)
-      console.log(`error for initial syncing and subscribing of network ${job.data.networkId as string}: ${err.message}`)
+      console.log(`initial syncing FAILED for network ${job.data.networkId as string}`)
+      console.log(`error for initial syncing of network ${job.data.networkId as string}: ${err.message}`)
     }
   })
 }

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -13,7 +13,9 @@ const syncAndSubscribeAllAddressTransactionsForNetworkJob = async (job: Job): Pr
   let failedAddressesWithErrors: KeyValueT<string> = {}
   try {
     let addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
+    console.log(`found ${addresses.length} addresses...`)
     addresses = addresses.filter(addr => addr.lastSynced == null)
+    console.log(`will subscribe ${addresses.length} addresses...`)
     failedAddressesWithErrors = (await transactionService.syncAndSubscribeAddresses(addresses)).failedAddressesWithErrors
   } catch (err: any) {
     const parsedError = parseError(err)

--- a/prisma/clientInstance.ts
+++ b/prisma/clientInstance.ts
@@ -7,11 +7,15 @@ interface CustomNodeJsGlobal extends NodeJS.Global {
 }
 declare const global: CustomNodeJsGlobal
 
-if (global.prisma === undefined) {
-  global.prisma = new PrismaClient()
-}
+if (process.env.NODE_ENV === 'production') {
+  prisma = new PrismaClient()
+} else {
+  if (global.prisma === undefined) {
+    global.prisma = new PrismaClient()
+  }
 
-prisma = global.prisma
+  prisma = global.prisma
+}
 
 export default prisma
 

--- a/prisma/clientInstance.ts
+++ b/prisma/clientInstance.ts
@@ -7,15 +7,11 @@ interface CustomNodeJsGlobal extends NodeJS.Global {
 }
 declare const global: CustomNodeJsGlobal
 
-if (process.env.NODE_ENV === 'production') {
-  prisma = new PrismaClient()
-} else {
-  if (global.prisma === undefined) {
-    global.prisma = new PrismaClient()
-  }
-
-  prisma = global.prisma
+if (global.prisma === undefined) {
+  global.prisma = new PrismaClient()
 }
+
+prisma = global.prisma
 
 export default prisma
 

--- a/scripts/docker-exec-shortcuts.sh
+++ b/scripts/docker-exec-shortcuts.sh
@@ -48,6 +48,9 @@ case "$command" in
     "databasedump" | "dbd")
         eval "$base_command_db" mariadb-dump -h "$MAIN_DB_HOST" -u root -p"$MAIN_DB_ROOT_PASSWORD" "$@"
         ;;
+    "databasedump" | "dbd")
+        eval "$base_command_db" mariadb-dump -u root -p"$MAIN_DB_ROOT_PASSWORD" "$@"
+        ;;
     "databaseshell" | "dbs")
         eval "$base_command_db" bash -l "$@"
         ;;
@@ -145,6 +148,7 @@ case "$command" in
         echo "  nl, nextlogs                [$node_container_name]     see the logs for the nextJS server"
         echo "  db, database                [$db_container_name]      enter the mariadb command-line using the main db"
         echo "  dbr, databaseroot           [$db_container_name]      enter the mariadb command-line as root"
+        echo "  dbd, databasedump           [$db_container_name]      dump all db tables as root"
         echo "  dbs, databaseshell          [$db_container_name]      enter the shell of the mariadb container"
         echo "  dbt, databasetest           [$db_container_name]      enter the mariadb command-line using the test db"
         echo "  dbu, databaseuser           [$db_container_name]      enter the mariadb command-line using the users db"

--- a/scripts/docker-exec-shortcuts.sh
+++ b/scripts/docker-exec-shortcuts.sh
@@ -77,6 +77,7 @@ case "$command" in
         yarn docker cbr && echo Cleaned jobs cache.
         ;;
     "jobsrestart" | "jr")
+        yarn docker js
         eval "$base_command_node" pm2 --time restart jobs
         ;;
     "serverlogs" | "sl")

--- a/scripts/docker-exec-shortcuts.sh
+++ b/scripts/docker-exec-shortcuts.sh
@@ -40,19 +40,22 @@ case "$command" in
         eval "$base_command_node" pm2 --time restart next
         ;;
     "database" | "db")
-        eval "$base_command_db" mariadb -u "$MAIN_DB_USER" -p"$MAIN_DB_PASSWORD" -D "$MAIN_DB_NAME" "$@"
+        eval "$base_command_db" mariadb -h "$MAIN_DB_HOST" -u "$MAIN_DB_USER" -p"$MAIN_DB_PASSWORD" -D "$MAIN_DB_NAME" "$@"
         ;;
     "databaseroot" | "dbr")
-        eval "$base_command_db" mariadb -u root -p"$MAIN_DB_ROOT_PASSWORD" "$@"
+        eval "$base_command_db" mariadb -h "$MAIN_DB_HOST" -u root -p"$MAIN_DB_ROOT_PASSWORD" "$@"
+        ;;
+    "databasedump" | "dbd")
+        eval "$base_command_db" mariadb-dump -h "$MAIN_DB_HOST" -u root -p"$MAIN_DB_ROOT_PASSWORD" "$@"
         ;;
     "databaseshell" | "dbs")
         eval "$base_command_db" bash -l "$@"
         ;;
     "databasetest" | "dbt")
-        eval "$base_command_db" mariadb -u "$MAIN_DB_USER"-test -p"$MAIN_DB_PASSWORD" -D "$MAIN_DB_NAME"-test "$@"
+        eval "$base_command_db" mariadb -h "$MAIN_DB_HOST" -u "$MAIN_DB_USER"-test -p"$MAIN_DB_PASSWORD" -D "$MAIN_DB_NAME"-test "$@"
         ;;
     "databaseuser" | "dbu")
-        eval "$base_command_db" mariadb -u "$SUPERTOKENS_DB_USER" -p"$SUPERTOKENS_DB_PASSWORD" -D supertokens "$@"
+        eval "$base_command_db" mariadb -h "$MAIN_DB_HOST" -u "$SUPERTOKENS_DB_USER" -p"$SUPERTOKENS_DB_PASSWORD" -D supertokens "$@"
         ;;
     "test" | "t")
         eval "$base_command_node" yarn test "$@"

--- a/scripts/docker-exec-shortcuts.sh
+++ b/scripts/docker-exec-shortcuts.sh
@@ -48,9 +48,6 @@ case "$command" in
     "databasedump" | "dbd")
         eval "$base_command_db" mariadb-dump -h "$MAIN_DB_HOST" -u root -p"$MAIN_DB_ROOT_PASSWORD" "$@"
         ;;
-    "databasedump" | "dbd")
-        eval "$base_command_db" mariadb-dump -u root -p"$MAIN_DB_ROOT_PASSWORD" "$@"
-        ;;
     "databaseshell" | "dbs")
         eval "$base_command_db" bash -l "$@"
         ;;

--- a/services/blockchainService.ts
+++ b/services/blockchainService.ts
@@ -67,6 +67,8 @@ function getBlockchainClient (networkSlug: string): BlockchainClient {
       if (global.chronik === undefined) {
         console.log('creating chronik instance...')
         global.chronik = new ChronikBlockchainClient()
+        console.log('subscribing existent addresses...')
+        void global.chronik.subscribeInitialAddresses()
       }
       return global.chronik
     default:

--- a/services/blockchainService.ts
+++ b/services/blockchainService.ts
@@ -69,7 +69,7 @@ function getBlockchainClient (networkSlug: string): BlockchainClient {
         console.log('creating chronik instance...')
         global.chronik = new ChronikBlockchainClient()
         // Subscribe addresses on DB upon client initialization
-        if (process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD) {
+        if (process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD && process.env.NODE_ENV !== 'test') {
           console.log('subscribing existent addresses...')
           void global.chronik.subscribeInitialAddresses()
         }

--- a/services/blockchainService.ts
+++ b/services/blockchainService.ts
@@ -5,6 +5,7 @@ import { RESPONSE_MESSAGES, KeyValueT, NETWORK_IDS, NETWORK_TICKERS } from '../c
 import { TransactionWithAddressAndPrices } from './transactionService'
 import { Address, Prisma } from '@prisma/client'
 import config, { BlockchainClientOptions } from 'config'
+import { PHASE_PRODUCTION_BUILD } from 'next/dist/shared/lib/constants'
 
 export interface BlockchainInfo {
   height: number
@@ -67,8 +68,11 @@ function getBlockchainClient (networkSlug: string): BlockchainClient {
       if (global.chronik === undefined) {
         console.log('creating chronik instance...')
         global.chronik = new ChronikBlockchainClient()
-        console.log('subscribing existent addresses...')
-        void global.chronik.subscribeInitialAddresses()
+        // Subscribe addresses on DB upon client initialization
+        if (process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD) {
+          console.log('subscribing existent addresses...')
+          void global.chronik.subscribeInitialAddresses()
+        }
       }
       return global.chronik
     default:

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -7,7 +7,7 @@ import { TransactionWithAddressAndPrices, createManyTransactions, deleteTransact
 import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
 import { groupAddressesByNetwork, satoshisToUnit } from 'utils'
-import { fetchAddressBySubstring, getLatestTxTimestampForAddress } from './addressService'
+import { fetchAddressBySubstring, fetchAllAddressesForNetworkId, getLatestTxTimestampForAddress } from './addressService'
 import * as ws from 'ws'
 import { BroadcastTxData } from 'ws-service/types'
 import config from 'config'
@@ -273,6 +273,16 @@ export class ChronikBlockchainClient implements BlockchainClient {
         this.chronikWSEndpoint.subscribe(type, hash160)
         this.subscribedAddresses[address.address] = address
       })
+    }
+  }
+
+  public async subscribeInitialAddresses (): Promise<void> {
+    const addresses = await fetchAllAddressesForNetworkId(XEC_NETWORK_ID)
+    try {
+      console.log(`will subscribe ${addresses.length} addresses...`)
+      await this.subscribeAddressesAddTransactions(addresses)
+    } catch (err: any) {
+      console.error(`ERROR: (skipping anyway) initial chronik subscription failed: ${err.message as string} ${err.stack as string}`)
     }
   }
 }

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -191,7 +191,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
       onMessage: (msg: SubscribeMsg) => { void this.processWsMessage(msg) },
       onError: (e: ws.ErrorEvent) => { console.log(`Chronik webSocket error, type: ${e.type} | message: ${e.message} | error: ${e.error as string}`) },
       onReconnect: (_: ws.Event) => { console.log('Chronik webSocket unexpectedly closed.') },
-      onConnect: (_: ws.Event) => { console.log('Chronik webSocket connection (re)established.') },
+      onConnect: (_: ws.Event) => { console.log(`Chronik webSocket connection (re)established. ${getSubbedAddresses().currentSubscriptions.join(',')}`) },
       onEnd: (e: ws.Event) => { console.log(`Chronik WebSocket ended, type: ${e.type}.`) },
       autoReconnect: true
     }

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -191,7 +191,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
       onMessage: (msg: SubscribeMsg) => { void this.processWsMessage(msg) },
       onError: (e: ws.ErrorEvent) => { console.log(`Chronik webSocket error, type: ${e.type} | message: ${e.message} | error: ${e.error as string}`) },
       onReconnect: (_: ws.Event) => { console.log('Chronik webSocket unexpectedly closed.') },
-      onConnect: (_: ws.Event) => { console.log(`Chronik webSocket connection (re)established. ${getSubbedAddresses().currentSubscriptions.join(',')}`) },
+      onConnect: (_: ws.Event) => { console.log('Chronik webSocket connection (re)established.') },
       onEnd: (e: ws.Event) => { console.log(`Chronik WebSocket ended, type: ${e.type}.`) },
       autoReconnect: true
     }


### PR DESCRIPTION


<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fix the problem where resetting the prod app would lose the subscriptions of addresses already in the DB (since the DB is not being reset)


Test plan
---
- Prod is already running this, so receiving live info about txs of any address that was subscribed before (or not) should work now.
- https://api.paybutton.org/status should list  all subscribed addresses, and this should be all `ecash` addresses in the DB.


One other test would be resetting prod and still having all addresses that were subscribed before subscribed now.



 
Remarks
---
This PR brings a variety of technical changes, so I'll list them here:
-  Jobs don't subscribe addresses, only sync their txs
- Fixes `yarn docker` commands to access remote DB
- Add `yarn docker` command to create dump of DB (this was unstaged on the remote server, so I brought and commited it) 
- The chronik instance initialization also subscribe addresses