### PR TITLE
Fix:  separate migration, postURL size

### DIFF
--- a/prisma/migrations/20220715134600_init/migration.sql
+++ b/prisma/migrations/20220715134600_init/migration.sql
@@ -17,7 +17,7 @@ CREATE TABLE `Paybutton` (
     `id` VARCHAR(191) NOT NULL DEFAULT (uuid()),
     `name` VARCHAR(255) NOT NULL,
     `buttonData` LONGTEXT NOT NULL,
-    `providerUserId` VARCHAR(255) NOT NULL,
+    `providerUserId` VARCHAR(255) NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
 
@@ -69,7 +69,7 @@ CREATE TABLE `Wallet` (
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `updatedAt` DATETIME(3) NOT NULL,
     `name` VARCHAR(255) NOT NULL,
-    `providerUserId` VARCHAR(255) NOT NULL,
+    `providerUserId` VARCHAR(255) NULL,
 
     UNIQUE INDEX `Wallet_name_providerUserId_unique_constraint`(`name`, `providerUserId`),
     PRIMARY KEY (`id`)

--- a/prisma/migrations/20230905163432_nullable_provider_user_id/migration.sql
+++ b/prisma/migrations/20230905163432_nullable_provider_user_id/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Made the column `providerUserId` on table `Paybutton` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `providerUserId` on table `Wallet` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE `Paybutton` MODIFY `providerUserId` VARCHAR(255) NOT NULL;
+
+-- AlterTable
+ALTER TABLE `Wallet` MODIFY `providerUserId` VARCHAR(255) NOT NULL;

--- a/prisma/migrations/20230905163536_post_url_bigger/migration.sql
+++ b/prisma/migrations/20230905163536_post_url_bigger/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `PaybuttonTrigger` MODIFY `postURL` VARCHAR(255) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -170,7 +170,7 @@ model PaybuttonTrigger {
   updatedAt      DateTime                  @updatedAt
   sendEmail      Boolean
   postData       String               @db.LongText
-  postURL        String
+  postURL        String               @db.VarChar(255)
   logs           TriggerLog[]
 
   paybutton      Paybutton @relation(fields: [paybuttonId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
Related to  #640

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fix migration history: since we won't be resetting the DB anymore, I shouldn't had modified existent migrations.
Also solves  #640


Test plan
---
- `postURL` should hold more chars (255 instead of 191 max)
- Prod is running this branch, should be working normally

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
