### PR TITLE
UI: Remove alt currencies from button generator

### DIFF
--- a/components/ButtonGenerator/index.tsx
+++ b/components/ButtonGenerator/index.tsx
@@ -35,7 +35,7 @@ export default function ButtonGenerator(): JSX.Element {
       },
     },
     validAddress: '',
-    currencies: ['XEC', 'USD', 'CAD', 'EUR', 'GBP', 'AUD'],
+    currencies: ['XEC', 'USD', 'CAD'],
   };
 
   const [button, setButton] = useState(initalState);


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Remove alt currencies, (EUR, GBP, and AUD) from button generator


Test plan
---
run the app and check the button generator. See if alt currencies are gone 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
