### PR TITLE
[#657] feat: use latest paybutton version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
-    "@paybutton/react": "^2.0.0",
+    "@paybutton/react": "latest",
     "@prisma/client": "^4.11.0",
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,7 +1272,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@paybutton/react@^2.0.0":
+"@paybutton/react@latest":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@paybutton/react/-/react-2.0.0.tgz#38ab65cc55393a2cbee977e07cd982c9e9c6f1af"
   integrity sha512-aoCHZag5QF7yhtBp3PBLkBQ6bw7Kc9kcZGeohs0M0s9HEE+kOPAS4BN9X7M3dn13C/w1yFHz3WaS+iwYmqumHA==


### PR DESCRIPTION
Related to #657

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Sets `package.json` to always fetch the latest version of `@paybutton/react`.


Test plan
---


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
