### PR TITLE
[#665] fix: don't ignore negative transactions

### DIFF
--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -255,8 +255,9 @@ export class ChronikBlockchainClient implements BlockchainClient {
         }
       }
     ))
+    const zero = new Prisma.Decimal(0)
     return addressesWithTransactions.filter(
-      addressWithTransaction => addressWithTransaction.transaction.amount > new Prisma.Decimal(0)
+      addressWithTransaction => !(zero.equals(addressWithTransaction.transaction.amount as Prisma.Decimal))
     )
   }
 


### PR DESCRIPTION
Related to #665

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes issue where arriving negative txs wouldn't be registered.


Test plan
---
Necessary to reset the containers (chronik processing message function doesn't update at runtime with Next).
1. Create two buttons with two of your addresses,
2. Send some XEC from one to the other,
3. Make sure the tx appears in both buttons.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
