### PR TITLE
[#673] fix: update timestamp when tx is confirmed

### DIFF
--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -134,7 +134,8 @@ export async function createTransaction (
       }
     },
     update: {
-      confirmed: transactionData.confirmed
+      confirmed: transactionData.confirmed,
+      timestamp: transactionData.timestamp
     }
   })
   // only return if it was created, if it was updated return undefined


### PR DESCRIPTION
Related to  #673

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Tx confirmation now also updates the timestamp.


Test plan
---
Necessary to reset the containers.
Create a button with one of your addresses and send some XEC to it. See the timestamp when it's unconfirmed and check it again when confirmed, it should have updated (unlike in master)


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
