### PR TITLE
[#675] fix: confirm transaction incoming without refreshing

### DIFF
--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -219,21 +219,23 @@ export class ChronikBlockchainClient implements BlockchainClient {
       const addressesWithTransactions = await this.getAddressesForTransaction(transaction)
       await Promise.all(
         addressesWithTransactions.map(async addressWithTransaction => {
-          const tx = await createTransaction(addressWithTransaction.transaction)
+          const { created, tx } = await createTransaction(addressWithTransaction.transaction)
           if (tx !== undefined) {
             const broadcastTxData: BroadcastTxData = {} as BroadcastTxData
             broadcastTxData.address = addressWithTransaction.address.address
             broadcastTxData.messageType = 'NewTx'
             broadcastTxData.txs = [tx]
-            try {
+            try { // emit broadcast for both unconfirmed and confirmed txs
               this.wsEndpoint.emit('txs-broadcast', broadcastTxData)
             } catch (err: any) {
               console.error(RESPONSE_MESSAGES.COULD_NOT_BROADCAST_TX_TO_WS_SERVER_500.message, err.stack)
             }
-            try {
-              await executeAddressTriggers(broadcastTxData)
-            } catch (err: any) {
-              console.error(RESPONSE_MESSAGES.COULD_NOT_EXECUTE_TRIGGER_500.message, err.stack)
+            if (created) { // only execute trigger for unconfirmed tx arriving
+              try {
+                await executeAddressTriggers(broadcastTxData)
+              } catch (err: any) {
+                console.error(RESPONSE_MESSAGES.COULD_NOT_EXECUTE_TRIGGER_500.message, err.stack)
+              }
             }
           }
           return tx

--- a/services/grpcService.ts
+++ b/services/grpcService.ts
@@ -296,11 +296,12 @@ export class GrpcBlockchainClient implements BlockchainClient {
     const broadcastTxData: BroadcastTxData = {} as BroadcastTxData
     await Promise.all(
       [...addressWithUnconfirmedTransactions, ...addressWithConfirmedTransactions].map(async addressWithTransaction => {
-        const tx = await createTransaction(addressWithTransaction.transaction)
+        const { tx } = await createTransaction(addressWithTransaction.transaction)
         if (tx !== undefined) {
           broadcastTxData.address = addressWithTransaction.address.address
           broadcastTxData.messageType = 'NewTx'
           broadcastTxData.txs = [tx]
+          // TODO: implement triggers
         }
         return tx
       })

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -134,7 +134,8 @@ export async function createTransaction (
       }
     },
     update: {
-      confirmed: transactionData.confirmed
+      confirmed: transactionData.confirmed,
+      timestamp: transactionData.timestamp
     }
   })
   // only return if it was created, if it was updated return undefined


### PR DESCRIPTION
Related to #675


Depends on
---
- [x] #674
- [x] https://github.com/PayButton/paybutton/pull/264



<!-- Non-technical -->
Description
---
Broadcasts when txs are confirmed. Fixes #675  


Test plan
---
After rebuilding the app, make sure that when a new tx is confirmed the view at http://localhost:3000/button/[button-id]  is updated automatically without need for refreshing.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
