### PR TITLE
[#687] fix: disallow empty string for post data

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -68,7 +68,7 @@ export const RESPONSE_MESSAGES = {
   WRONG_PASSWORD_400: { statusCode: 400, message: 'Wrong password.' },
   INVALID_URL_400: { statusCode: 400, message: 'Invalid URL.' },
   INVALID_WEBSITE_URL_400: { statusCode: 400, message: 'Invalid website URL.' },
-  POST_URL_AND_DATA_MUST_BE_SET_TOGETHER_400: { statusCode: 400, message: 'URL and post data must neither or both be set.' },
+  POST_URL_AND_DATA_MUST_BE_SET_TOGETHER_400: { statusCode: 400, message: 'URL and post data must both be set.' },
   LIMIT_TRIGGERS_PER_BUTTON_400: { statusCode: 400, message: 'This paybutton already has a trigger.' },
   LIMIT_TRIGGERS_PER_BUTTON_ADDRESSES_400: { statusCode: 400, message: 'This paybutton addresses already have a trigger from another paybutton.' },
   COULD_NOT_EXECUTE_TRIGGER_500: { statusCode: 500, message: 'Failed to execute trigger for paybutton address.' },

--- a/prisma/seeds/users.ts
+++ b/prisma/seeds/users.ts
@@ -1,13 +1,13 @@
 export const createDevUsersRawQueryList = [
   'USE supertokens;',
-  'INSERT INTO app_id_to_user_id VALUES (\'public\', \'dev-uid\', \'emailpassword\') ON DUPLICATE KEY UPDATE user_id=user_id;',
-  'INSERT INTO app_id_to_user_id VALUES (\'public\', \'dev2-uid\', \'emailpassword\') ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO app_id_to_user_id VALUES (\'public\', \'dev-uid\', \'dev-uid\', 0, \'emailpassword\') ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO app_id_to_user_id VALUES (\'public\', \'dev2-uid\', \'dev2-uid\', 0, \'emailpassword\') ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO emailpassword_users VALUES (\'public\', \'dev-uid\', \'dev@paybutton.org\', \'$2a$11$AGppTnFU3HBeHuH1z3kPb.A1WFUxHVVNmAmiMaHJ3QvVkWT58jxBO\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO emailpassword_users VALUES (\'public\', \'dev2-uid\', \'dev2@paybutton.org\', \'$2a$11$AGppTnFU3HBeHuH1z3kPb.A1WFUxHVVNmAmiMaHJ3QvVkWT58jxBO\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO emailverification_verified_emails VALUES (\'public\', \'dev-uid\', \'dev@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO emailverification_verified_emails VALUES (\'public\', \'dev2-uid\', \'dev2@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;',
-  'INSERT INTO all_auth_recipe_users VALUES (\'public\', \'public\', \'dev-uid\', \'emailpassword\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
-  'INSERT INTO all_auth_recipe_users VALUES (\'public\', \'public\', \'dev2-uid\', \'emailpassword\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO all_auth_recipe_users VALUES (\'public\', \'public\', \'dev-uid\', \'dev-uid\', 0, \'emailpassword\', 1652220489244, 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO all_auth_recipe_users VALUES (\'public\', \'public\', \'dev2-uid\', \'dev2-uid\', 0, \'emailpassword\', 1652220489244, 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO emailpassword_user_to_tenant VALUES (\'public\', \'public\', \'dev-uid\', \'dev@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO emailpassword_user_to_tenant VALUES (\'public\', \'public\', \'dev2-uid\', \'dev2@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;'
 ]
@@ -30,10 +30,10 @@ export const createAdminUserRawQueryList = [
   // create the dashboard user
   'INSERT INTO dashboard_users VALUES (\'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'admin@paybutton.org\', \'$2a$11$/QAw1kqTCkOXDlBLE2McMu70zFkGJdlX..PDI4BqDYEOgpYyTxCn.\', 1692381805105) ON DUPLICATE KEY UPDATE user_id=user_id;',
   // create the actual user, which is not related, but with the same data
-  'INSERT INTO app_id_to_user_id VALUES (\'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'emailpassword\') ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO app_id_to_user_id VALUES (\'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', 0, \'emailpassword\') ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO emailpassword_users VALUES (\'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'admin@paybutton.org\', \'$2a$11$/QAw1kqTCkOXDlBLE2McMu70zFkGJdlX..PDI4BqDYEOgpYyTxCn.\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO emailverification_verified_emails VALUES (\'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'admin@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;',
-  'INSERT INTO all_auth_recipe_users VALUES (\'public\', \'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'emailpassword\', 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
+  'INSERT INTO all_auth_recipe_users VALUES (\'public\', \'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', 0, \'emailpassword\', 1652220489244, 1652220489244) ON DUPLICATE KEY UPDATE user_id=user_id;',
   'INSERT INTO emailpassword_user_to_tenant VALUES (\'public\', \'public\', \'085211a0-215f-4f3f-bf07-68f55bb6c7ed\', \'admin@paybutton.org\') ON DUPLICATE KEY UPDATE user_id=user_id;'
 ]
 

--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -54,12 +54,17 @@ export async function createTrigger (paybuttonId: string, values: CreatePaybutto
   if ((await fetchTriggersForPaybuttonAddresses(paybutton.id)).length > 0) {
     throw new Error(RESPONSE_MESSAGES.LIMIT_TRIGGERS_PER_BUTTON_ADDRESSES_400.message)
   }
+  const postURL = values.postURL ?? ''
+  const postData = values.postData ?? ''
+  if (postURL === '' || postData === '') {
+    throw new Error(RESPONSE_MESSAGES.POST_URL_AND_DATA_MUST_BE_SET_TOGETHER_400.message)
+  }
   return await prisma.paybuttonTrigger.create({
     data: {
       paybuttonId,
       sendEmail: values.sendEmail,
-      postURL: values.postURL ?? '',
-      postData: values.postData ?? ''
+      postURL,
+      postData
     }
   })
 }

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -246,9 +246,9 @@ describe('parsePaybuttonTriggerPOSTRequest', () => {
     }).toThrow(RESPONSE_MESSAGES.POST_URL_AND_DATA_MUST_BE_SET_TOGETHER_400.message)
   })
 
-  it('Allow no postURL and no postData', () => {
+  it('Invalid if no postURL and no postData', () => {
     expect(() => {
       v.parsePaybuttonTriggerPOSTRequest({ ...data })
-    }).not.toThrow()
+    }).toThrow(RESPONSE_MESSAGES.POST_URL_AND_DATA_MUST_BE_SET_TOGETHER_400.message)
   })
 })

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -280,7 +280,7 @@ export const parsePaybuttonTriggerPOSTRequest = function (params: PaybuttonTrigg
     postData = params.postData
   }
 
-  if ((postData === undefined && postURL !== undefined) || (postData !== undefined && postURL === undefined)) {
+  if ((postData === undefined || postURL === undefined)) {
     throw new Error(RESPONSE_MESSAGES.POST_URL_AND_DATA_MUST_BE_SET_TOGETHER_400.message)
   }
 


### PR DESCRIPTION
Related to #687

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes #687. Don't allow the creation of empty triggers, which were resulting in error logs since there is nothing to execute.

Test plan
---
Try to create a trigger without setting an URL and a postData, should not be possible.

Remarks
---
This should be changed when we implementing receiving emails as a functionality of the trigger, but for now makes no sense allowing to create a trigger that does nothing.