### PR TITLE
feat: only show page selector if > 1 pages

### DIFF
--- a/components/TableContainer.tsx
+++ b/components/TableContainer.tsx
@@ -69,42 +69,44 @@ const TableContainer = ({ columns, data }): JSX.Element => {
       </table>
     </div>
 
-<div className='table-navigation-ctn'>
-    <button
-      onClick={() => gotoPage(0)}
-      disabled={!(canPreviousPage as boolean)}
-    >
-      {'<<'}
-    </button>
-    <button
-      onClick={previousPage}
-      disabled={!(canPreviousPage as boolean)}
-    >
-      {'<'}
-    </button>
-    <div className='pageof-table'>Page {(pageIndex as number) + 1} of {pageOptions.length}</div>
-    <button color="primary" onClick={nextPage} disabled={!(canNextPage as boolean)}>
-      {'>'}
-    </button>
-    <button
-      color="primary"
-      onClick={() => gotoPage(pageCount - 1)}
-      disabled={!(canNextPage as boolean)}
-    >
-      {'>>'}
-    </button>
+    {pageOptions.length > 1 &&
+    <div className='table-navigation-ctn'>
+      <button
+        onClick={() => gotoPage(0)}
+        disabled={!(canPreviousPage as boolean)}
+      >
+        {'<<'}
+      </button>
+      <button
+        onClick={previousPage}
+        disabled={!(canPreviousPage as boolean)}
+      >
+        {'<'}
+      </button>
+      <div className='pageof-table'>Page {(pageIndex as number) + 1} of {pageOptions.length}</div>
+      <button color="primary" onClick={nextPage} disabled={!(canNextPage as boolean)}>
+        {'>'}
+      </button>
+      <button
+        color="primary"
+        onClick={() => gotoPage(pageCount - 1)}
+        disabled={!(canNextPage as boolean)}
+      >
+        {'>>'}
+      </button>
 
-   <div className='table-select-ctn'>
-      <select value={pageSize} onChange={onChangeInSelect}>
-        {[10, 25, 50, 100].map(pageSize => (
-          <option key={pageSize} value={pageSize}>
-            Show {pageSize}
-          </option>
-        ))}
-      </select>
+      <div className='table-select-ctn'>
+        <select value={pageSize} onChange={onChangeInSelect}>
+          {[10, 25, 50, 100].map(pageSize => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
     </div>
-  </div>
-  </>
+      }
+    </>
   )
 }
 


### PR DESCRIPTION



<!-- Non-technical -->
Description
---

Minor change.

Table page selector:
![image](https://github.com/PayButton/paybutton-server/assets/21281174/02059c5e-1008-46e8-8c58-7f0fe7761b06)


... only appears if total pages is greater than 1.

Test plan
---
Check some tables (payments, button transactions, button leaaderboard if #692 is merged) and see if the page selector appears if and only if there is more than only the first page.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
