### PR TITLE
[#328] feat: refresh addresses on button edit

### DIFF
--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -10,6 +10,7 @@ import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import { BroadcastTxData } from 'ws-service/types'
 import { KeyValueT, ResponseMessage } from 'constants/index'
+import { arraysAreEqual } from 'utils/index'
 import { TransactionWithAddressAndPrices } from 'services/transactionService'
 import config from 'config'
 import io from 'socket.io-client'
@@ -92,7 +93,14 @@ export default function Button (props: PaybuttonProps): React.ReactElement {
   }
 
   const refreshPaybutton = (): void => {
-    void fetchPaybutton()
+    if (
+      transactions !== undefined &&
+      paybutton !== undefined &&
+      !arraysAreEqual(paybutton?.addresses.map(a => a.address.address), Object.keys(transactions))
+    ) {
+      setTransactions({})
+    }
+    void getDataAndSetUpSocket()
   }
 
   const setUpSocket = async (addresses: string[]): Promise<void> => {

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -195,3 +195,17 @@ export function parseWebsiteURL (url: string): string {
 
   throw new Error(RESPONSE_MESSAGES.INVALID_WEBSITE_URL_400.message)
 }
+
+export function arraysAreEqual (a: any[], b: any[]): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false
+    }
+  }
+
+  return true
+}


### PR DESCRIPTION
Related to #328

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Solves #328.



Test plan
---
When editing a button, make sure that:
- Editing **out** an address immediately **removes** its transactions from the button detail page,
- Editing **in** an address immediately **adds** its transactions to the button detail page,
- Editing some other paybutton detail (such as the name, for example) doesn't change the transactions (nor does it makes it flash/blink/refresh to the same thing).


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
