### PR TITLE
[#695] fix: tx confirmation doesn't create another cache entry

### DIFF
--- a/redis/dashboardCache.ts
+++ b/redis/dashboardCache.ts
@@ -189,8 +189,12 @@ const cacheGroupedPaymentsAppend = async (paymentsGroupedByKey: KeyValueT<Paymen
     Object.keys(paymentsGroupedByKey).map(async key => {
       const paymentsString = await redis.get(key)
       let cachedPayments: Payment[] = (paymentsString === null) ? [] : JSON.parse(paymentsString)
-      cachedPayments = cachedPayments.concat(paymentsGroupedByKey[key])
-        .filter((el, idx, array) => array.indexOf(el) === idx)
+      const newHashes = paymentsGroupedByKey[key].map(p => p.hash)
+      cachedPayments = cachedPayments
+        .filter(p => !newHashes.includes(p.hash))
+        .concat(
+          paymentsGroupedByKey[key]
+        )
       await redis.set(key, JSON.stringify(cachedPayments))
     })
   )


### PR DESCRIPTION
Related to #695

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes #695. Confirmation of txs would create a second Payment.


Test plan
---
It's necessary to reset the main container (paybutton-dev).

1. Send some XEC to some of your addresses and verify it appeared in the button detail and also in the Payments tab.
2. After the payment is confirmed, refresh the Payments tab and check that it doesn't have a duplicated entry for this payment.

In master the behavior is that it should create a second redundant payment for the confirmation.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
