### PR TITLE
fix: landing page should redirect to dashboard if logged in

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,6 +16,7 @@ if (typeof window !== 'undefined') {
 }
 
 const AUTHORIZED_UNLOGGED_URLS = [
+  '/',
   '/signin',
   '/signup',
   '/reset-password',


### PR DESCRIPTION
<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
When logged in, manually navigating to `/` would show the landing page with the Sidebar.

The PR fixes this and manually navigating to `/` redirects to `/dashboard`.


Test plan
---
After logging in, go to http://localhost:3000/ and make sure you get redirect to the dashboard.



 
Remarks
---


About the blinking landing page before, this is an issue with all `AUTHORIZED_UNLOGGED_URLS`. Currently, those are:
- `/`,
- `/signin`,
- `/signup`,
- `/reset-password`,
- `/auth/reset-password`

... and this is an issue with the current implementation for this redirect logic, that could be solved in a different PR.