### PR TITLE
chore: don't spin DB container on prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,17 @@ git_diff_to_master = git diff --name-only --diff-filter=ACMRTUXB origin/master >
 create_test_paybutton_json = echo { \"priceAPIURL\": \"foo\", \"networkBlockchainClients\": { \"ecash\": \"chronik\", \"bitcoincash\": \"grpc\" }, \"chronikClientURL\": \"https://chronik.be.cash/xec\", \"wsBaseURL\": \"localhost:5000\" } > paybutton-config.json
 touch_local_env = touch .env.local
 
+prod:
+	$(git_hook_setup)
+	$(touch_local_env)
+	docker-compose -f docker-compose-prod.yml --env-file .env --env-file .env.local up --build -d
+
+stop-prod:
+	docker-compose -f docker-compose-prod.yml down
+
+reset-prod:
+	make stop-prod && make prod
+
 dev:
 	$(git_hook_setup)
 	$(touch_local_env)

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,28 @@
+version: "3.9"
+services:
+  paybutton:
+    container_name: paybutton-dev
+    restart: always
+    depends_on:
+      - db
+      - users-service
+      - cache
+    build: .
+    ports:
+      - "3000:3000"
+      - "5000:5000"
+    volumes:
+      - .:/home/node/src
+      - ./logs:/home/node/.pm2/logs
+    command: bash ./scripts/paybutton-server-start.sh
+
+  cache:
+    container_name: paybutton-cache
+    image: redis:6.2-alpine
+    restart: always
+    ports:
+      - 6379:6379
+    volumes:
+      - ./redis:/data/redis:z
+      - ./scripts:/data/scripts
+    command: sh -c "sed -i 's/\\r//g' ./scripts/redis-start.sh && sh ./scripts/redis-start.sh"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -16,6 +16,22 @@ services:
       - ./logs:/home/node/.pm2/logs
     command: bash ./scripts/paybutton-server-start.sh
 
+  users-service:
+    container_name: paybutton-users-service
+    depends_on:
+      - db
+      - cache
+    image: registry.supertokens.io/supertokens/supertokens-mysql
+    restart: always
+    ports:
+      - 3567:3567
+    environment:
+      MYSQL_DATABASE_NAME: supertokens
+      MYSQL_USER: ${SUPERTOKENS_DB_USER}
+      MYSQL_PASSWORD: ${SUPERTOKENS_DB_PASSWORD}
+      MYSQL_HOST: ${MAIN_DB_HOST}
+      MYSQL_PORT: ${MAIN_DB_PORT}
+
   cache:
     container_name: paybutton-cache
     image: redis:6.2-alpine

--- a/scripts/paybutton-server-start.sh
+++ b/scripts/paybutton-server-start.sh
@@ -2,14 +2,17 @@
 . .env
 . .env.local
 yarn || exit 1
-yarn prisma migrate dev || exit 1
-yarn prisma db seed || exit 1
 rm logs/*
-pm2 start yarn --time --interpreter ash --name jobs -- initJobs || exit 1
-pm2 start yarn --time --interpreter ash --name WSServer -- initWSServer || exit 1
 if [ "$ENVIRONMENT" = "production" ]; then
+    yarn prisma migrate deploy || exit 1
+    pm2 start yarn --time --interpreter ash --name jobs -- initJobs || exit 1
+    pm2 start yarn --time --interpreter ash --name WSServer -- initWSServer || exit 1
     pm2 start yarn --time --interpreter ash --name next -- prod || exit 1
 else
+    yarn prisma migrate dev || exit 1
+    yarn prisma db seed || exit 1
+    pm2 start yarn --time --interpreter ash --name jobs -- initJobs || exit 1
+    pm2 start yarn --time --interpreter ash --name WSServer -- initWSServer || exit 1
     pm2 start yarn --time --interpreter ash --name next -- dev || exit 1
 fi
 pm2 logs next


### PR DESCRIPTION
<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
On production, we should not spin up the container, since we use a remote db.


Test plan
---
Hard to test it thoroughly, one could manually create a remote DB and then configure `.env.local` with its credentials and run `make prod`. But running `make prod` without doing that should not create the 4 containers, only 3, and should then show an error about not being able to find the DB to connect. 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
