### PR TITLE
[#706] feat: filter info on leaderboard

### DIFF
--- a/components/Dashboard/Leaderboard.tsx
+++ b/components/Dashboard/Leaderboard.tsx
@@ -11,9 +11,10 @@ import { formatQuoteValue } from 'utils'
 
 interface IProps {
   buttons: PaymentDataByButton
+  totalString: string
 }
 
-export default ({ buttons }: IProps): JSX.Element => {
+export default ({ buttons, totalString }: IProps): JSX.Element => {
   const columns = useMemo(
     () => [
       {
@@ -44,7 +45,7 @@ export default ({ buttons }: IProps): JSX.Element => {
         }
       },
       {
-        Header: () => (<div style={{ textAlign: 'right' }}>Total Revenue</div>),
+        Header: () => (<div style={{ textAlign: 'right' }}>{totalString} Revenue</div>),
         accessor: 'total.revenue',
         id: 'revenue',
         Cell: (cellProps) => {
@@ -54,14 +55,14 @@ export default ({ buttons }: IProps): JSX.Element => {
         }
       },
       {
-        Header: () => (<div style={{ textAlign: 'right' }}>Total Payments</div>),
+        Header: () => (<div style={{ textAlign: 'right' }}>{totalString} Payments</div>),
         accessor: 'total.payments',
         Cell: (cellProps) => {
           return <div style={{ textAlign: 'right', fontWeight: '600' }}>{cellProps.cell.value}</div>
         }
       }
     ],
-    []
+    [totalString]
   )
   const buttonList = Object.keys(buttons).map(k => buttons[k])
   return (

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -103,7 +103,7 @@ export default function Dashboard ({ userId }: PaybuttonsProps): React.ReactElem
         <div className={`${style.full_width} ${style.chart_inner_ctn}`}>
           <div className={style.chart_title_ctn}>
             <h5>Button Leaderboard</h5>
-            <h5>{activePeriod === dashboardData.all ? 'Lifetime' : activePeriod === dashboardData.year ? 'Year' : activePeriod === dashboardData.thirtyDays ? '30 Day' : '7 Day'} Total: ${formatQuoteValue(activePeriod.totalRevenue, USD_QUOTE_ID)}</h5>
+            <div></div>
           </div>
             <Leaderboard buttons={activePeriod.buttons}/>
         </div>

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -55,6 +55,7 @@ interface PaybuttonsProps {
 export default function Dashboard ({ userId }: PaybuttonsProps): React.ReactElement {
   const [dashboardData, setDashboardData] = useState<DashboardData>()
   const [activePeriod, setActivePeriod] = useState<PeriodData>()
+  const [totalString, setTotalString] = useState<string>()
   useEffect(() => {
     const fetchData = async (): Promise<void> => {
       const res = await fetch('api/dashboard')
@@ -64,6 +65,17 @@ export default function Dashboard ({ userId }: PaybuttonsProps): React.ReactElem
     }
     fetchData().catch(console.error)
   }, [])
+
+  useEffect(() => {
+    if (dashboardData !== undefined) {
+      setTotalString(
+        (activePeriod === dashboardData.all ? 'Lifetime' : activePeriod === dashboardData.year ? 'Year' : activePeriod === dashboardData.thirtyDays ? '30 Day' : '7 Day') +
+        ' Total'
+      )
+    } else {
+      setTotalString('Total')
+    }
+  }, [activePeriod])
 
   if (dashboardData === undefined || activePeriod === undefined) return <></>
 
@@ -85,7 +97,7 @@ export default function Dashboard ({ userId }: PaybuttonsProps): React.ReactElem
         <div className={style.chart_inner_ctn}>
           <div className={style.chart_title_ctn}>
             <h5>Revenue</h5>
-            <h5>{activePeriod === dashboardData.all ? 'Lifetime' : activePeriod === dashboardData.year ? 'Year' : activePeriod === dashboardData.thirtyDays ? '30 Day' : '7 Day'} Total: ${formatQuoteValue(activePeriod.totalRevenue, USD_QUOTE_ID)}</h5>
+            <h5>{totalString}: ${formatQuoteValue(activePeriod.totalRevenue, USD_QUOTE_ID)}</h5>
           </div>
           <div className={style.chart_ctn}>
             <Chart data={activePeriod.revenue} usd={true} />
@@ -94,7 +106,7 @@ export default function Dashboard ({ userId }: PaybuttonsProps): React.ReactElem
         <div className={style.chart_inner_ctn}>
           <div className={style.chart_title_ctn}>
             <h5>Payments</h5>
-            <h5>{activePeriod === dashboardData.all ? 'Lifetime' : activePeriod === dashboardData.year ? 'Year' : activePeriod === dashboardData.thirtyDays ? '30 Day' : '7 Day'} Total: {formatQuoteValue(activePeriod.totalPayments)}</h5>
+            <h5>{totalString}: {formatQuoteValue(activePeriod.totalPayments)}</h5>
           </div>
           <div className={style.chart_ctn}>
             <Chart data={activePeriod.payments} />
@@ -105,7 +117,7 @@ export default function Dashboard ({ userId }: PaybuttonsProps): React.ReactElem
             <h5>Button Leaderboard</h5>
             <div></div>
           </div>
-            <Leaderboard buttons={activePeriod.buttons}/>
+            <Leaderboard totalString={totalString} buttons={activePeriod.buttons}/>
         </div>
       </div>
     </>


### PR DESCRIPTION
Related to #706

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Show filter info in leaderboard and remove redundant info.


Test plan
---
Make sure that the filter info is being shown in the leaderboard (**red**), and that the total revenue info (**yellow**) is not being redundantly shown in the **blue** area. 
![image](https://github.com/PayButton/paybutton-server/assets/21281174/b139f631-452e-423f-9b74-9b7803918420)


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
