### PR TITLE
[#601] fix: on mobile, PayButton logo goes to landing page too

### DIFF
--- a/components/Sidebar/index.tsx
+++ b/components/Sidebar/index.tsx
@@ -111,7 +111,7 @@ const Sidebar: React.FC = ({ chart, setChart, loggedUser }: IProps) => {
     : <>
   {isBreakpoint &&
     <div className={style.topmenu}>
-      <Link href='/dashboard' passHref>
+      <Link href='/' passHref>
         <Image className={style.image} src={logoImageSource} alt='PayButton' width={120} height={22} />
       </Link>
       <div className={style.menu_ctn_outer}>


### PR DESCRIPTION
Related to #601

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
On mobile the PayButton logo was not redirecting to the landing page. The PR fixes that.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
