### PR TITLE
[#703] feat: save dashboard settings

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -173,3 +173,7 @@ export const IFP_ADDRESSES = [
 export const NO_LAYOUT_ROUTES = [
   '/'
 ]
+
+export const COOKIE_NAMES = {
+  DASHBOARD_FILTER: 'dashboardFilter'
+}

--- a/utils/cookies.ts
+++ b/utils/cookies.ts
@@ -1,0 +1,14 @@
+export const saveStateToCookie = (key: string, value?: string): void => {
+  if (value !== undefined) {
+    document.cookie = `${key}=${JSON.stringify(value)}; path=/`
+  }
+}
+
+export const loadStateFromCookie = (key: string, defaultValue: any): string | undefined => {
+  const matches = document.cookie.match(new RegExp(`(?:^|; )${key}=([^;]*)`))
+  const cookieValue = (matches != null) ? decodeURIComponent(matches[1]) : undefined
+  if (cookieValue !== undefined) {
+    return JSON.parse(cookieValue)
+  }
+  return defaultValue
+}


### PR DESCRIPTION
Related to #703

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Saves dashboard filter in cookie.


Test plan
---
Set some period on the dashboard. Refreshing the page, as well as logging out and back in, should not change the set period.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
