### PR TITLE
[#207] Add explorer link to address label

### DIFF
--- a/components/Transaction/AddressTransactions.tsx
+++ b/components/Transaction/AddressTransactions.tsx
@@ -79,7 +79,14 @@ export default ({ addressTransactions, addressSynced }: IProps): FunctionCompone
     <>
       {Object.keys(addressTransactions).map(transactionAddress => (
         <div key={transactionAddress} className='address-transactions-ctn'>
-          <div className={style.tablelabel}>{transactionAddress}</div>
+          <div className={style.tablelabel}>
+            <div>{transactionAddress}</div>
+            <a href={transactionAddress.slice(0, 5) === 'ecash' ? `https://explorer.e.cash/address/${transactionAddress}` : `https://blockchair.com/bitcoin-cash/address/${transactionAddress}`} target="_blank" rel="noopener noreferrer" className="table-eye-ctn">
+              <div className="table-eye">
+                <Image src={EyeIcon} alt='View on explorer' />
+              </div>
+            </a>
+          </div>
           { addressTransactions[transactionAddress].length === 0
             ? <div className={style.transaction_ctn}> {
               addressSynced[transactionAddress] ? 'No transactions yet' : 'Syncing address...'

--- a/components/Transaction/transaction.module.css
+++ b/components/Transaction/transaction.module.css
@@ -67,6 +67,13 @@
   background-color: var(--secondary-bg-color);
   border-radius: 10px 10px 0 0;
   padding: 20px;
+  display: flex;
+  justify-content: space-between;
+  word-break: break-all;
+}
+
+.tablelabel a {
+ margin-left: 20px;
 }
 
 /*********************** COPY BUTTON  **************************/


### PR DESCRIPTION
Related to #207

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Adding an explorer link to the addresses at the top of the transaction tables on the button detail page


Test plan
---
Run the app and check out a button detail view. you should see the eye icon next to the address that should link to the explorer 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
