### PR TITLE
[348]ui: force decimals on amounts

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -83,11 +83,10 @@ const Chart: NextPage<Props> = ({ data, usd }) => {
         ticks: {
           color: cssvar('--primary-text-color'),
           callback: function (value: string) {
-            return usd ? '$' + value : value
+            return usd ? '$' + formatQuoteValue(value, USD_QUOTE_ID) : value
           }
         },
         position: 'right'
-        // beginAtZero: true,
       }
     }
   }

--- a/components/Transaction/AddressTransactions.tsx
+++ b/components/Transaction/AddressTransactions.tsx
@@ -41,7 +41,14 @@ export default ({ addressTransactions, addressSynced }: IProps): FunctionCompone
         Header: () => (<div style={{ textAlign: 'right' }}>Amount</div>),
         accessor: 'amount',
         Cell: (cellProps) => {
-          return <div style={{ textAlign: 'right', fontWeight: '600' }}>{formatQuoteValue(cellProps.cell.value)} {cellProps.row.values.address.networkId === 1 ? 'XEC' : 'BCH' }</div>
+          return <div style={{ textAlign: 'right', fontWeight: '600' }}>{parseFloat(cellProps.cell.value).toLocaleString(
+            undefined,
+            {
+              minimumFractionDigits: cellProps.row.values.address.networkId === 1 ? 2 : 8,
+              maximumFractionDigits: cellProps.row.values.address.networkId === 1 ? 2 : 8
+            }
+          )
+            } {cellProps.row.values.address.networkId === 1 ? 'XEC' : 'BCH' }</div>
         }
       },
       {


### PR DESCRIPTION
Related to #348 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Adding some formatting to the usd values on the dashboard chart, and on the XEC and BCH values on the button detail transaction table. XEC values should force to 2 decimals and BCH to 8


Test plan
---
Run the app and check the numbers in those place to see if they look good 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
