### PR TITLE
[#732, #744] fix: new tx pipeline

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -178,3 +178,5 @@ export const COOKIE_NAMES = {
 }
 
 export const DEFAULT_EMPTY_TABLE_MESSAGE = 'No rows to show.'
+
+export const CHRONIK_MESSAGE_CACHE_DELAY = 3000

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -21,7 +21,7 @@ services:
     depends_on:
       - db
       - cache
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql:15.04
     restart: always
     ports:
       - 3567:3567

--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -87,7 +87,10 @@ export const connectAllTransactionsToPricesWorker = async (queueName: string): P
     queueName,
     async (job) => {
       console.log(`job ${job.id as string}: connecting prices to transactions...`)
-      const txs = await transactionService.fetchAllTransactionsWithNoPrices()
+      const txs = [
+        ...await transactionService.fetchAllTransactionsWithNoPrices(),
+        ...await transactionService.fetchAllTransactionsWithOnePrice()
+      ]
       void await transactionService.connectTransactionsListToPrices(txs)
     },
     {

--- a/pages/signin/index.tsx
+++ b/pages/signin/index.tsx
@@ -3,6 +3,15 @@ import Image from 'next/image'
 import logoImageSource from 'assets/logo.png'
 import SignIn from 'components/Auth/SignIn'
 import style from 'styles/signin.module.css'
+import * as SuperTokensConfig from '../../config/backendConfig'
+import supertokensNode from 'supertokens-node'
+import { GetServerSideProps } from 'next'
+
+export const getServerSideProps: GetServerSideProps = async (_) => {
+  // this runs on the backend, so we must call init on supertokens-node SDK
+  supertokensNode.init(SuperTokensConfig.backendConfig())
+  return { props: {} }
+}
 
 export default function Signin (): JSX.Element {
   return (

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -4,6 +4,15 @@ import Image from 'next/image'
 import logoImageSource from 'assets/logo.png'
 import SignUp from 'components/Auth/SignUp'
 import style from 'styles/signin.module.css'
+import * as SuperTokensConfig from '../../config/backendConfig'
+import supertokensNode from 'supertokens-node'
+import { GetServerSideProps } from 'next'
+
+export const getServerSideProps: GetServerSideProps = async (_) => {
+  // this runs on the backend, so we must call init on supertokens-node SDK
+  supertokensNode.init(SuperTokensConfig.backendConfig())
+  return { props: {} }
+}
 
 export default function Signup (): JSX.Element {
   return (

--- a/redis/dashboardCache.ts
+++ b/redis/dashboardCache.ts
@@ -20,8 +20,8 @@ const getChartRevenuePaymentData = function (n: number, periodString: string, pa
   const paymentsArray: number[] = []
   const _ = [...new Array(n)]
   _.forEach((_, idx) => {
-    const lowerThreshold = moment().startOf(periodString === 'months' ? 'month' : 'day').subtract(idx, periodString as DurationInputArg2)
-    const upperThreshold = moment().endOf(periodString === 'months' ? 'month' : 'day').subtract(idx, periodString as DurationInputArg2)
+    const lowerThreshold = moment().subtract(idx, periodString as DurationInputArg2).startOf(periodString === 'months' ? 'month' : 'day')
+    const upperThreshold = moment().subtract(idx, periodString as DurationInputArg2).endOf(periodString === 'months' ? 'month' : 'day')
     const periodTransactionAmountArray = filterLastPayments(lowerThreshold, upperThreshold, paymentList).map((p) => p.value)
     const revenue = periodTransactionAmountArray.reduce((a, b) => {
       return a.plus(b)

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -2,7 +2,7 @@ import { ChronikClient, ScriptType, SubscribeMsg, Tx, Utxo, WsConfig, WsEndpoint
 import { encode, decode } from 'ecashaddrjs'
 import bs58 from 'bs58'
 import { AddressWithTransaction, BlockchainClient, BlockchainInfo, BlockInfo, NodeJsGlobalChronik, TransactionDetails } from './blockchainService'
-import { NETWORK_SLUGS, RESPONSE_MESSAGES, XEC_TIMESTAMP_THRESHOLD, XEC_NETWORK_ID, BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N, KeyValueT } from 'constants/index'
+import { NETWORK_SLUGS, CHRONIK_MESSAGE_CACHE_DELAY, RESPONSE_MESSAGES, XEC_TIMESTAMP_THRESHOLD, XEC_NETWORK_ID, BCH_NETWORK_ID, BCH_TIMESTAMP_THRESHOLD, FETCH_DELAY, FETCH_N, KeyValueT } from 'constants/index'
 import { TransactionWithAddressAndPrices, createManyTransactions, deleteTransactions, fetchUnconfirmedTransactions, createTransaction, syncAddresses } from './transactionService'
 import { Address, Prisma } from '@prisma/client'
 import xecaddr from 'xecaddrjs'
@@ -12,8 +12,14 @@ import * as ws from 'ws'
 import { BroadcastTxData } from 'ws-service/types'
 import config from 'config'
 import io, { Socket } from 'socket.io-client'
+import moment from 'moment'
 import { parseError } from 'utils/validators'
 import { executeAddressTriggers } from './triggerService'
+
+interface ProcessedMessages {
+  confirmed: KeyValueT<number>
+  unconfirmed: KeyValueT<number>
+}
 
 export class ChronikBlockchainClient implements BlockchainClient {
   chronik: ChronikClient
@@ -21,6 +27,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
   subscribedAddresses: KeyValueT<Address>
   chronikWSEndpoint: WsEndpoint
   wsEndpoint: Socket
+  lastProcessedMessages: ProcessedMessages
 
   constructor () {
     if (process.env.WS_AUTH_KEY === '' || process.env.WS_AUTH_KEY === undefined) {
@@ -30,11 +37,49 @@ export class ChronikBlockchainClient implements BlockchainClient {
     this.availableNetworks = [NETWORK_SLUGS.ecash]
     this.subscribedAddresses = {}
     this.chronikWSEndpoint = this.chronik.ws(this.getWsConfig())
+    this.lastProcessedMessages = { confirmed: {}, unconfirmed: {} }
     this.wsEndpoint = io(`${config.wsBaseURL}/broadcast`, {
       query: {
         key: process.env.WS_AUTH_KEY
       }
     })
+  }
+
+  private clearOldMessages (): void {
+    const now = moment()
+    for (const key of Object.keys(this.lastProcessedMessages.unconfirmed)) {
+      const diff = moment.unix(this.lastProcessedMessages.unconfirmed[key]).diff(now)
+      if (diff > CHRONIK_MESSAGE_CACHE_DELAY) {
+        const { [key]: _, ...newConfirmed } = this.lastProcessedMessages.confirmed
+        this.lastProcessedMessages.confirmed = newConfirmed
+      }
+    }
+    for (const key of Object.keys(this.lastProcessedMessages.confirmed)) {
+      const diff = moment.unix(this.lastProcessedMessages.confirmed[key]).diff(now)
+      if (diff > CHRONIK_MESSAGE_CACHE_DELAY) {
+        const { [key]: _, ...newConfirmed } = this.lastProcessedMessages.confirmed
+        this.lastProcessedMessages.confirmed = newConfirmed
+      }
+    }
+  }
+
+  private isAlreadyBeingProcessed (txid: string, confirmed: boolean): boolean {
+    this.clearOldMessages()
+    if (confirmed) {
+      const lt = this.lastProcessedMessages.confirmed[txid]
+      if (lt === undefined) {
+        this.lastProcessedMessages.confirmed[txid] = moment().unix()
+        return false
+      }
+      return true
+    } else {
+      const lt = this.lastProcessedMessages.unconfirmed[txid]
+      if (lt === undefined) {
+        this.lastProcessedMessages.unconfirmed[txid] = moment().unix()
+        return false
+      }
+      return true
+    }
   }
 
   private validateNetwork (networkSlug: string): void {
@@ -211,6 +256,9 @@ export class ChronikBlockchainClient implements BlockchainClient {
       }
     } else if (msg.type === 'AddedToMempool' || msg.type === 'Confirmed') {
       // create unconfirmed or confirmed transaction
+      if (this.isAlreadyBeingProcessed(msg.txid, msg.type === 'Confirmed')) {
+        return
+      }
       console.log(`[${msg.type}] ${msg.txid}`)
       const transaction = await this.chronik.tx(msg.txid)
       const addressesWithTransactions = await this.getAddressesForTransaction(transaction)

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -381,3 +381,16 @@ export async function fetchAllTransactionsWithNoPrices (): Promise<Transaction[]
   })
   return x
 }
+export async function fetchAllTransactionsWithOnePrice (): Promise<Transaction[]> {
+  const txs = await prisma.transaction.findMany({
+    where: {
+      prices: {
+        some: {}
+      }
+    },
+    include: {
+      prices: true
+    }
+  })
+  return txs.filter(t => t.prices.length === 1)
+}


### PR DESCRIPTION
Related to #732, #744

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---

Solves some bugs related to chronik and tx sync:
- Avoid duplicate calls when txs that are related to more than one address arrive.
For example, if a tx from address A to B is broadcasted and both addresses A and B are in our DB, the new tx pipeline will trigger twice and therefore run for both addresses twice. This PR introduces a 3s delay where txs that are already being processed won't be processed again. This won't conflict with other incoming transactions or arriving confirmations.

- Upon deploy connect transactions with one price to the missing second price

- Don't take the current month into account to consider the monthly time windows. This was accidentally done, such that in months with less than 31 days, payments that happened in the 31st of any month  wouldn't be considered in the dashboard. 


Test plan
---

- Some addresses (those with payments in the 31st) are having a divergence in the dashboard "Lifetime payments" numbers, in the main top display and in the top of the rightside chart. That shouldn't happen anymore. Note that this can only be tested today, since tomorrow will be December 1st, a month with 31 days.

- When a TX from A to B happens and both A and B are in our DB, we shouldn't get prisma errors anymore.
<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
