### PR TITLE
chore: commit logs dir, empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,5 @@ yarn-error.log*
 
 /prisma/seeds/prices.csv
 redis/dump.rdb
-logs/
 prisma/seeds/productionTxs.csv
 paybutton-config.json

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION



<!-- Non-technical -->
Description
---
Instead of ignoring the `logs/` directory and risking getting permission issues when docker creates it; we simply ignore everything inside it while committing the dir itself, making sure its permissions are tracked by git. 



