### PR TITLE
[#747] fix: don't try to access browser storage when SSR

### DIFF
--- a/components/TableContainer/TableContainer.tsx
+++ b/components/TableContainer/TableContainer.tsx
@@ -6,8 +6,9 @@ interface IProps {
 
 const TableContainer = ({ columns, data, opts, ssr }: IProps): JSX.Element => {
   const sortColumn = opts?.sortColumn
-  const localPageSize = localStorage.getItem('pageSize')
-  const localStoragePageSize = ssr ? 10 : localPageSize !== null ? +localPageSize : 10
+  const localPageSize = ssr ? 10 : localStorage.getItem('pageSize')
+  const localStoragePageSize = localPageSize === null ? 10 : +localPageSize
+
   const {
     getTableProps,
     getTableBodyProps,


### PR DESCRIPTION
Related to #747

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes #747


Test plan
---
Reproduce #747 in master, switch to this and make sure its gone. Make sure also that the page size is saved on the browser (not only for this admin table, but for all tables that use TableContainer, such as Payments, for example): switch for example to 25 items per page and make sure it still shows 25 items per page after refreshing the page.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
