### PR TITLE
[#732] fix: avoid tx holes

### DIFF
--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -89,7 +89,7 @@ export const connectAllTransactionsToPricesWorker = async (queueName: string): P
       console.log(`job ${job.id as string}: connecting prices to transactions...`)
       const txs = [
         ...await transactionService.fetchAllTransactionsWithNoPrices(),
-        ...await transactionService.fetchAllTransactionsWithOnePrice()
+        ...await transactionService.fetchAllTransactionsWithIrregularPrices()
       ]
       void await transactionService.connectTransactionsListToPrices(txs)
     },

--- a/services/addressService.ts
+++ b/services/addressService.ts
@@ -242,7 +242,8 @@ export async function generateAddressPaymentInfo (addressString: string): Promis
 export async function getLatestTxTimestampForAddress (addressId: string): Promise<number | undefined> {
   const tx = await prisma.transaction.findFirst({
     where: {
-      addressId
+      addressId,
+      confirmed: true
     },
     orderBy: {
       timestamp: 'desc'

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -330,7 +330,10 @@ export class ChronikBlockchainClient implements BlockchainClient {
   public async syncMissedTransactions (): Promise<void> {
     const addresses = await fetchAllAddressesForNetworkId(XEC_NETWORK_ID)
     try {
-      await syncAddresses(addresses)
+      const { failedAddressesWithErrors } = await syncAddresses(addresses)
+      Object.keys(failedAddressesWithErrors).forEach((addr) => {
+        console.error(`When syncing missing addresses for address ${addr} encountered error: ${failedAddressesWithErrors[addr]}`)
+      })
     } catch (err: any) {
       console.error(`ERROR: (skipping anyway) initial missing transactions sync failed: ${err.message as string} ${err.stack as string}`)
     }

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -330,9 +330,12 @@ export class ChronikBlockchainClient implements BlockchainClient {
   public async syncMissedTransactions (): Promise<void> {
     const addresses = await fetchAllAddressesForNetworkId(XEC_NETWORK_ID)
     try {
-      const { failedAddressesWithErrors } = await syncAddresses(addresses)
+      const { failedAddressesWithErrors, successfulAddressesWithCount } = await syncAddresses(addresses)
       Object.keys(failedAddressesWithErrors).forEach((addr) => {
         console.error(`When syncing missing addresses for address ${addr} encountered error: ${failedAddressesWithErrors[addr]}`)
+      })
+      Object.keys(successfulAddressesWithCount).forEach((addr) => {
+        console.log(`Successful synced ${successfulAddressesWithCount[addr]} txs for ${addr}`)
       })
     } catch (err: any) {
       console.error(`ERROR: (skipping anyway) initial missing transactions sync failed: ${err.message as string} ${err.stack as string}`)

--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -68,6 +68,8 @@ export async function upsertPricesForNetworkId (responseData: IResponseData, net
 
 export async function upsertCurrentPricesForNetworkId (responseData: IResponseData, networkId: number): Promise<void> {
   await upsertPricesForNetworkId(responseData, networkId, 0)
+  const todaysTimestamp = flattenTimestamp(moment().unix())
+  await upsertPricesForNetworkId(responseData, networkId, todaysTimestamp)
 }
 
 function getPriceURLForDayAndNetworkTicker (day: moment.Moment, networkTicker: string): string {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -3,7 +3,7 @@ import { Address, Prisma, Transaction } from '@prisma/client'
 import { syncTransactionsForAddress, subscribeAddresses } from 'services/blockchainService'
 import { fetchAddressBySubstring, fetchAddressById } from 'services/addressService'
 import { QuoteValues, fetchPricesForNetworkAndTimestamp } from 'services/priceService'
-import { RESPONSE_MESSAGES, USD_QUOTE_ID, CAD_QUOTE_ID, N_OF_QUOTES, KeyValueT } from 'constants/index'
+import { RESPONSE_MESSAGES, USD_QUOTE_ID, CAD_QUOTE_ID, N_OF_QUOTES, KeyValueT, UPSERT_TRANSACTION_PRICES_ON_DB_TIMEOUT } from 'constants/index'
 import { productionAddresses } from 'prisma/seeds/addresses'
 import { appendTxsToFile } from 'prisma/seeds/transactions'
 import _ from 'lodash'
@@ -272,7 +272,11 @@ export async function createManyTransactions (
         isCreated: upsertedTx.createdAt.getTime() === upsertedTx.updatedAt.getTime()
       })
     }
-  })
+  },
+  {
+    timeout: UPSERT_TRANSACTION_PRICES_ON_DB_TIMEOUT
+  }
+  )
   const insertedTransactions = insertedTransactionsDistinguished
     .filter(txD => txD.isCreated)
     .map(txD => txD.tx)

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -403,7 +403,8 @@ export async function fetchAllTransactionsWithNoPrices (): Promise<Transaction[]
   })
   return x
 }
-export async function fetchAllTransactionsWithOnePrice (): Promise<Transaction[]> {
+
+export async function fetchAllTransactionsWithIrregularPrices (): Promise<Transaction[]> {
   const txs = await prisma.transaction.findMany({
     where: {
       prices: {
@@ -414,5 +415,5 @@ export async function fetchAllTransactionsWithOnePrice (): Promise<Transaction[]
       prices: true
     }
   })
-  return txs.filter(t => t.prices.length === 1)
+  return txs.filter(t => t.prices.length !== 2)
 }

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -265,7 +265,10 @@ export async function createManyTransactions (
             addressId: tx.addressId
           }
         },
-        update: {}
+        update: {
+          confirmed: tx.confirmed,
+          timestamp: tx.timestamp
+        }
       })
       insertedTransactionsDistinguished.push({
         tx: upsertedTx,


### PR DESCRIPTION
Related to #732

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Make so we sync the missed transactions one address by one, and log the errors in case there are any.


Test plan
---
This can be tested in local dev by:
1. Have the containers running with `make dev` and some of your addresses in the database.
2. Stop all containers but the database one with `make stop-prod`
3. Make sure the database is up and running with `yarn docker db` and check how many txs you have on that address of yours with `SELECT count(*) FROM Address where address='ecash:youraddresshere';`
4. Transfer some XEC to that address
5. Build the project with `make prod` and make sure that after it is up the newly arrived tx is synced, that same counting query should return one more entry. 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
