### PR TITLE
[#751] UI: Add get address link to button generator

### DIFF
--- a/components/ButtonGenerator/button-generator.module.css
+++ b/components/ButtonGenerator/button-generator.module.css
@@ -362,6 +362,14 @@ input:checked + .slider:before {
   text-decoration: underline;
 }
 
+.form_ctn .get_address_link {
+  margin-right: 5px;
+  margin-left: auto;
+  opacity: 0.7;
+  font-size: 10px;
+  text-decoration: underline;
+}
+
 body[data-theme='dark'] .picker_ctn input {
   background-color: #fff !important;
 }

--- a/components/ButtonGenerator/index.tsx
+++ b/components/ButtonGenerator/index.tsx
@@ -295,6 +295,16 @@ export default function ButtonGenerator (): JSX.Element {
                               <p>{field.helpText}</p>
                             </div>
                           }
+                          {field.key === 'to' && (
+                            <a
+                              href="https://cashtab.com/"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={s.get_address_link}>
+                                Get an address
+                            </a>
+                          )
+                        }
                         </div>
                       </label>
                       {fieldComponent}


### PR DESCRIPTION
Related to #751

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Adding the get address link back in to the button generator


Test plan
---
preview the site and check the link on the 'to' field works and looks good 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
