### PR TITLE
chore: openssl1.1 was deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM  --platform=linux/amd64 node:lts-alpine
-RUN apk add --no-cache python3 make g++ openssl1.1-compat bash
+RUN apk add --no-cache python3 make g++  bash
 SHELL ["/bin/bash", "-c"]
 USER node
 RUN yarn global add pm2


### PR DESCRIPTION

<!-- Non-technical -->
Description
---
Fixes missing package error.
