### PR TITLE
[#732] feat: possibility to fully sync addresses

### DIFF
--- a/jobs/workers.ts
+++ b/jobs/workers.ts
@@ -13,8 +13,8 @@ const syncAllAddressTransactionsForNetworkJob = async (job: Job): Promise<void> 
   try {
     let addresses = await addressService.fetchAllAddressesForNetworkId(job.data.networkId)
     console.log(`found ${addresses.length} addresses...`)
-    addresses = addresses.filter(addr => addr.lastSynced == null)
-    failedAddressesWithErrors = (await transactionService.syncAddresses(addresses)).failedAddressesWithErrors
+    addresses = job.data.fully === true ? addresses : addresses.filter(addr => addr.lastSynced == null)
+    failedAddressesWithErrors = (await transactionService.syncAddresses(addresses, job.data.fully === true)).failedAddressesWithErrors
   } catch (err: any) {
     const parsedError = parseError(err)
     if (parsedError.message === RESPONSE_MESSAGES.TRANSACTION_ALREADY_EXISTS_FOR_ADDRESS_400.message) {


### PR DESCRIPTION
Related to #732

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Adds logic to run syncing job such that every tx is resynced.   This makes so that the one line diff:

```                      
--- a/jobs/initJobs.ts                                      
+++ b/jobs/initJobs.ts                                      
@@ -35,7 +35,7 @@ const main = async (): Promise<void> => { 
   }                                                        
   const flowJobSyncAndSubscribeXECAddresses: FlowJob = {   
     queueName: initTransactionsQueue.name,                 
-    data: { networkId: XEC_NETWORK_ID },                   
+    data: { networkId: XEC_NETWORK_ID, fully: true },      
     name: 'syncAndSubscribeXECAddressesFlow',              
     opts: {                                                
       removeOnFail: false,                                 
```
...is enough to rerun jobs in prod and resync all addresses.

Test plan
---


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
