### PR TITLE
[#772] feat: delete triggers & better UX

### DIFF
--- a/components/Paybutton/PaybuttonTrigger.tsx
+++ b/components/Paybutton/PaybuttonTrigger.tsx
@@ -152,9 +152,9 @@ export default ({ paybuttonId }: IProps): JSX.Element => {
         ? (
           <div className={style.form_ctn_outer}>
             <div className={style.form_ctn_inner}>
-              <h4>Clear trigger?</h4>
+              <h4>Clear Payment Trigger?</h4>
               <div className={`${style.form_ctn} ${style.delete_button_form_ctn}`}>
-                <label htmlFor='name'>Are you sure you want to clear the trigger action?<br />This action cannot be undone.</label>
+                <label htmlFor='name'>Are you sure you want to clear this payment trigger?<br />This action cannot be undone.</label>
                 <div className={style.btn_row}>
                   <div>
 

--- a/components/Paybutton/paybutton.module.css
+++ b/components/Paybutton/paybutton.module.css
@@ -283,13 +283,24 @@ body[data-theme='dark'] .form_ctn select:not([multiple]) {
   justify-content: space-between;
 }
 
+.success_message {
+  color: green;
+  font-size: 14px;
+  top: -20px;
+  left: 0;
+  background-color: rgba(0, 255, 0, 0.1);
+  position: absolute;
+  padding: 1px 10px;
+  border-radius: 5px;
+}
+
 .error_message {
   color: red;
   font-size: 14px;
-  position: absolute;
   top: -20px;
   left: 0;
   background-color: rgba(255, 0, 0, 0.1);
+  position: absolute;
   padding: 1px 10px;
   border-radius: 5px;
 }

--- a/pages/api/paybutton/triggers/[id].ts
+++ b/pages/api/paybutton/triggers/[id].ts
@@ -1,7 +1,7 @@
 import { parseError, parsePaybuttonTriggerPOSTRequest, PaybuttonTriggerPOSTParameters } from 'utils/validators'
 import { setSession } from 'utils/setSession'
 import { RESPONSE_MESSAGES } from 'constants/index'
-import { createTrigger, fetchTriggersForPaybutton, updateTrigger } from 'services/triggerService'
+import { createTrigger, deleteTrigger, fetchTriggersForPaybutton, updateTrigger } from 'services/triggerService'
 import { PaybuttonTrigger } from '@prisma/client'
 
 export default async (req: any, res: any): Promise<void> => {
@@ -63,6 +63,27 @@ export default async (req: any, res: any): Promise<void> => {
           break
         case RESPONSE_MESSAGES.INVALID_DATA_JSON_400.message:
           res.status(400).json(RESPONSE_MESSAGES.INVALID_DATA_JSON_400)
+          break
+        case RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400)
+          break
+        default:
+          res.status(500).json({ statusCode: 500, message: parsedErr.message })
+      }
+    }
+  } else if (req.method === 'DELETE') {
+    await setSession(req, res)
+    const values = req.body as PaybuttonTriggerPOSTParameters
+    values.userId = req.session.userId
+    const paybuttonId = req.query.id as string
+    try {
+      const trigger = await deleteTrigger(paybuttonId, values)
+      res.status(200).json(trigger)
+    } catch (err: any) {
+      const parsedErr = parseError(err)
+      switch (parsedErr.message) {
+        case RESPONSE_MESSAGES.INVALID_RESOURCE_UPDATE_400.message:
+          res.status(400).json(RESPONSE_MESSAGES.INVALID_RESOURCE_UPDATE_400)
           break
         case RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400.message:
           res.status(400).json(RESPONSE_MESSAGES.RESOURCE_DOES_NOT_BELONG_TO_USER_400)


### PR DESCRIPTION
Related to #772

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Implements the deletion of a trigger and improves the general trigger UX.


Test plan
---
Besides being able to delete triggers, the whole process of creating & updating them should be more clean and intuitive. Users can only update a trigger if in the form there is anything different than what was loaded; it also will refresh the form with the updated data instead of hiding it behind a success message (as it did before).

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
