### PR TITLE
[#774] feat: basic OP_RETURN parsing

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -76,7 +76,8 @@ export const RESPONSE_MESSAGES = {
   COULD_NOT_EXECUTE_TRIGGER_500: { statusCode: 500, message: 'Failed to execute trigger for paybutton address.' },
   INVALID_DATA_JSON_WITH_VARIABLES_400: (variables: string[]) => { return { statusCode: 400, message: `Data is not valid. Make sure that ${variables.join(', ')} are not inside quotes.` } },
   PAGE_SIZE_LIMIT_EXCEEDED_400: { statusCode: 400, message: `Page size limit should be at most ${TX_PAGE_SIZE_LIMIT}.` },
-  PAGE_SIZE_AND_PAGE_SHOULD_BE_NUMBERS_400: { statusCode: 400, message: 'pageSize and page parameters should be valid integers.' }
+  PAGE_SIZE_AND_PAGE_SHOULD_BE_NUMBERS_400: { statusCode: 400, message: 'pageSize and page parameters should be valid integers.' },
+  INVALID_OUTPUT_SCRIPT_LENGTH_500: (l: number) => { return { statusCode: 500, message: `Invalid outputScript length ${l}` } }
 }
 
 export type KeyValueT<T> = Record<string, T>

--- a/prisma/migrations/20240111230813_tx_extra_data/migration.sql
+++ b/prisma/migrations/20240111230813_tx_extra_data/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE `Transaction` ADD COLUMN `extraData` LONGTEXT NOT NULL DEFAULT '';
+ALTER TABLE `Transaction` ADD COLUMN `opReturn` LONGTEXT NOT NULL DEFAULT '';

--- a/prisma/migrations/20240111230813_tx_extra_data/migration.sql
+++ b/prisma/migrations/20240111230813_tx_extra_data/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Transaction` ADD COLUMN `extraData` LONGTEXT NOT NULL DEFAULT '';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,7 +71,7 @@ model Transaction {
   confirmed Boolean                @default(false)
   timestamp Int
   addressId String
-  extraData String                @db.LongText @default("")
+  opReturn String                @db.LongText @default("")
   address   Address                @relation(fields: [addressId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   prices    PricesOnTransactions[]
   createdAt DateTime                  @default(now())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,7 @@ model Transaction {
   confirmed Boolean                @default(false)
   timestamp Int
   addressId String
+  extraData String                @db.LongText @default("")
   address   Address                @relation(fields: [addressId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   prices    PricesOnTransactions[]
   createdAt DateTime                  @default(now())

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -404,6 +404,7 @@ export const mockedUSDPriceOnTransaction = {
 export const mockedTransaction = {
   id: 'mocked-uuid',
   hash: 'Yh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
+  extraData: '',
   addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
   confirmed: true,
   address: {
@@ -428,6 +429,7 @@ export const mockedTransactionList = [
   {
     id: 'mocked-uuid',
     hash: 'Yh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
+    extraData: '',
     confirmed: true,
     addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
     createdAt: new Date('2022-11-02T15:18:42.000Z'),
@@ -438,6 +440,7 @@ export const mockedTransactionList = [
   {
     id: 'mocked-uuid2',
     hash: 'hh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
+    extraData: '',
     confirmed: true,
     addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
     createdAt: new Date('2022-11-02T15:18:42.000Z'),
@@ -448,6 +451,7 @@ export const mockedTransactionList = [
   {
     id: 'mocked-uuid3',
     hash: '5h5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
+    extraData: '',
     confirmed: true,
     addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
     createdAt: new Date('2022-11-02T15:18:42.000Z'),

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -404,7 +404,7 @@ export const mockedUSDPriceOnTransaction = {
 export const mockedTransaction = {
   id: 'mocked-uuid',
   hash: 'Yh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
-  extraData: '',
+  opReturn: '',
   addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
   confirmed: true,
   address: {
@@ -429,7 +429,7 @@ export const mockedTransactionList = [
   {
     id: 'mocked-uuid',
     hash: 'Yh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
-    extraData: '',
+    opReturn: '',
     confirmed: true,
     addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
     createdAt: new Date('2022-11-02T15:18:42.000Z'),
@@ -440,7 +440,7 @@ export const mockedTransactionList = [
   {
     id: 'mocked-uuid2',
     hash: 'hh5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
-    extraData: '',
+    opReturn: '',
     confirmed: true,
     addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
     createdAt: new Date('2022-11-02T15:18:42.000Z'),
@@ -451,7 +451,7 @@ export const mockedTransactionList = [
   {
     id: 'mocked-uuid3',
     hash: '5h5DRDjd3AarAvQA1nwpPI4daDihY6hQfnMV6UKFqZc=',
-    extraData: '',
+    opReturn: '',
     confirmed: true,
     addressId: '0a03a880-86fe-4d82-9aa2-8df270cf032d',
     createdAt: new Date('2022-11-02T15:18:42.000Z'),


### PR DESCRIPTION
Related to #774

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Implements the parsing of  [NULL DATA](https://learnmeabitcoin.com/technical/nulldata) (OP_RETURN) scripts on transactions.


Test plan
---
1. Restart the containers. Necessary to reload chronik.

2. Send a TX with ElectrumABC OP_RETURN field as `paybutton$anypieceofdatayouwant` to any address you have on the running app,

3. Use `yarn docker db` and then `select createdAt, hash, amount, extraData from Transaction where not extraData='';` to see which txs have some data on it. Besides the data for the just sent tx, there should  be some data for txs I already sent when developing this feature.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
