### PR TITLE
[#774] feat: op return variable on triggers

### DIFF
--- a/components/Paybutton/PaybuttonTrigger.tsx
+++ b/components/Paybutton/PaybuttonTrigger.tsx
@@ -123,6 +123,7 @@ export default ({ paybuttonId }: IProps): JSX.Element => {
                 <li>&lt;amount&gt;</li>
                 <li>&lt;timestamp&gt;</li>
                 <li>&lt;txId&gt;</li>
+                <li>&lt;opReturn&gt;</li>
                 <li>&lt;hmac&gt;</li>
               </ul>
             </div>

--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -183,6 +183,7 @@ export async function executeAddressTriggers (broadcastTxData: BroadcastTxData):
   const currency = NETWORK_TICKERS_FROM_ID[tx.address.networkId]
   const txId = tx.hash
   const timestamp = tx.timestamp
+  const opReturn = tx.opReturn
 
   const addressTriggers = await fetchTriggersForAddress(address)
   await Promise.all(addressTriggers.map(async (trigger) => {
@@ -192,7 +193,8 @@ export async function executeAddressTriggers (broadcastTxData: BroadcastTxData):
       txId,
       buttonName: trigger.paybutton.name,
       address,
-      timestamp
+      timestamp,
+      opReturn
     }
     const hmac = await hashPostData(trigger.paybutton.providerUserId, postDataParameters)
     await postDataForTrigger(trigger, {
@@ -210,6 +212,7 @@ export interface PostDataParameters {
   txId: string
   buttonName: string
   address: string
+  opReturn: string
 }
 
 export interface PostDataParametersHashed {
@@ -219,6 +222,7 @@ export interface PostDataParametersHashed {
   txId: string
   buttonName: string
   address: string
+  opReturn: string
   hmac: string
 }
 

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -217,7 +217,7 @@ export interface PaybuttonTriggerPOSTParameters {
   currentTriggerId?: string
 }
 
-const triggerPostVariables = ['<amount>', '<currency>', '<txId>', '<buttonName>', '<address>', '<timestamp>', '<hmac>']
+const triggerPostVariables = ['<amount>', '<currency>', '<txId>', '<buttonName>', '<address>', '<timestamp>', '<opReturn>', '<hmac>']
 
 export function parseTriggerPostData (postData: string, postDataParametersHashed?: PostDataParametersHashed): any {
   let resultingData: string
@@ -230,6 +230,7 @@ export function parseTriggerPostData (postData: string, postDataParametersHashed
       buttonName: '',
       address: '',
       timestamp: 0,
+      opReturn: '',
       hmac: ''
     }
   }
@@ -242,10 +243,12 @@ export function parseTriggerPostData (postData: string, postDataParametersHashed
       .replace('<buttonName>', buttonName)
       .replace('<address>', `"${postDataParametersHashed.address}"`)
       .replace('<timestamp>', postDataParametersHashed.timestamp.toString())
+      .replace('<opReturn>', `"${postDataParametersHashed.opReturn}"`)
       .replace('<hmac>', `"${postDataParametersHashed.hmac}"`)
     const parsedResultingData = JSON.parse(resultingData)
     return parsedResultingData
   } catch (err: any) {
+    console.log('cathing err', err.name, err.message, err.stack)
     const includedVariables = triggerPostVariables.filter(v => postData.includes(v))
     if (includedVariables.length > 0) {
       throw new Error(RESPONSE_MESSAGES.INVALID_DATA_JSON_WITH_VARIABLES_400(includedVariables).message)


### PR DESCRIPTION
Related to #774


Depends on
---
- [x] #782 



<!-- Non-technical -->
Description
---
Adds <opReturn>  as a valid variable for setting up triggers.


Test plan
---
1. Create your trigger, use a website you control or a dummy one such as https://httpbin.org/post.
2. Make sure to include the variable in the trigger body, such as ` {"op": <opReturn> }` 
3. Send a tx to the address with OP_RETURN=`paybutton$anyDataYouWant` and make sure it appears in the receiving end of the POST request e.g. `{"op": 'anyDataYouWant'}`

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
