### PR TITLE
feat: scripts waits for DB connection

### DIFF
--- a/scripts/paybutton-server-start.sh
+++ b/scripts/paybutton-server-start.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 . .env
 . .env.local
+
+echo Waiting for db...                                              
+while true; do                                                      
+  nc -z -p "$MAIN_DB_PORT" "$MAIN_DB_HOST" "$MAIN_DB_PORT" && break                             
+  sleep 1
+done                                                                
+echo Connected to the db.
+
 yarn || exit 1
 rm logs/*
 if [ "$ENVIRONMENT" = "production" ]; then


### PR DESCRIPTION
<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Right now the `paybutton-dev` container fails when trying to connect to the `paybutton-db` container the first times simply because the DB container takes longer to start.

This change makes it wait until it has started.


Test plan
---
Check that the containers start normally

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
