### PR TITLE
[#774] feat: op return new specs

### DIFF
--- a/services/blockchainService.ts
+++ b/services/blockchainService.ts
@@ -64,7 +64,7 @@ function getBlockchainClient (networkSlug: string): BlockchainClient {
     case 'grpc' as BlockchainClientOptions:
       return new GrpcBlockchainClient()
     case 'chronik' as BlockchainClientOptions:
-      if (global.chronik === undefined) {
+      if (global.chronik === undefined && ChronikBlockchainClient !== undefined) {
         console.log('creating chronik instance...')
         global.chronik = new ChronikBlockchainClient()
         // Subscribe addresses & Sync lost transactions on DB upon client initialization

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -152,7 +152,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
 
     const ret: OpReturnData = {
       data: dataString,
-      token: ''
+      paymentId: ''
     }
 
     const noncePushDataIndex = dataStartIndex + dataPushData * 2
@@ -170,7 +170,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
       // we don't decode the hex for the nonce, since those are just random bytes.
       nonceString += hexByte
     }
-    ret.token = nonceString
+    ret.paymentId = nonceString
 
     return ret
   }

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -110,8 +110,8 @@ export class ChronikBlockchainClient implements BlockchainClient {
 
   private getNullDataScriptData (outputScript: string): string | null {
     const opReturnCode = '6a'
-    // hexadecimal representation of 'paybutton#'
-    const encodedPrefix = '706179627574746f6e23'
+    // hexadecimal representation of 'paybutton@'
+    const encodedPrefix = '706179627574746f6e40'
     // the +2 below represents the size of the byte representing the length
     // of the message following it (2 hex chars)
     const prefixLen = opReturnCode.length + 2 + encodedPrefix.length

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -110,8 +110,8 @@ export class ChronikBlockchainClient implements BlockchainClient {
 
   private getNullDataScriptData (outputScript: string): string | null {
     const opReturnCode = '6a'
-    // hexadecimal representation of 'paybutton$'
-    const encodedPrefix = '706179627574746f6e24'
+    // hexadecimal representation of 'paybutton#'
+    const encodedPrefix = '706179627574746f6e23'
     // the +2 below represents the size of the byte representing the length
     // of the message following it (2 hex chars)
     const prefixLen = opReturnCode.length + 2 + encodedPrefix.length

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -45,13 +45,17 @@ export function getNullDataScriptData (outputScript: string): OpReturnData | nul
     return null
   }
 
-  const dataStartIndex = prefixLen + 2
+  let dataStartIndex = prefixLen + 2
 
   if (outputScript.length < dataStartIndex) {
     return null
   }
 
-  const dataPushDataHex = outputScript.slice(prefixLen, dataStartIndex)
+  let dataPushDataHex = outputScript.slice(prefixLen, dataStartIndex)
+  if (dataPushDataHex.toLowerCase() === '4c') {
+    dataStartIndex = dataStartIndex + 2
+    dataPushDataHex = outputScript.slice(prefixLen + 2, dataStartIndex)
+  }
   const dataPushData = parseInt(dataPushDataHex, 16)
   if (outputScript.length < dataStartIndex + dataPushData * 2) {
     return null

--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -2,7 +2,7 @@ import { PaybuttonTrigger, Prisma } from '@prisma/client'
 import axios from 'axios'
 import { RESPONSE_MESSAGES, NETWORK_TICKERS_FROM_ID } from 'constants/index'
 import prisma from 'prisma/clientInstance'
-import { OpReturnData, parseOpReturnData, parseTriggerPostData } from 'utils/validators'
+import { EMPTY_OP_RETURN, OpReturnData, parseTriggerPostData } from 'utils/validators'
 import { BroadcastTxData } from 'ws-service/types'
 import { fetchPaybuttonById, fetchPaybuttonWithTriggers } from './paybuttonService'
 import config from 'config'
@@ -183,7 +183,11 @@ export async function executeAddressTriggers (broadcastTxData: BroadcastTxData):
   const currency = NETWORK_TICKERS_FROM_ID[tx.address.networkId]
   const txId = tx.hash
   const timestamp = tx.timestamp
-  const opReturn = parseOpReturnData(tx.opReturn)
+  let opReturn: OpReturnData = EMPTY_OP_RETURN
+
+  if (tx.opReturn !== '') {
+    opReturn = JSON.parse(tx.opReturn)
+  }
 
   const addressTriggers = await fetchTriggersForAddress(address)
   await Promise.all(addressTriggers.map(async (trigger) => {

--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -2,7 +2,7 @@ import { PaybuttonTrigger, Prisma } from '@prisma/client'
 import axios from 'axios'
 import { RESPONSE_MESSAGES, NETWORK_TICKERS_FROM_ID } from 'constants/index'
 import prisma from 'prisma/clientInstance'
-import { parseTriggerPostData } from 'utils/validators'
+import { OpReturnData, parseOpReturnData, parseTriggerPostData } from 'utils/validators'
 import { BroadcastTxData } from 'ws-service/types'
 import { fetchPaybuttonById, fetchPaybuttonWithTriggers } from './paybuttonService'
 import config from 'config'
@@ -183,7 +183,7 @@ export async function executeAddressTriggers (broadcastTxData: BroadcastTxData):
   const currency = NETWORK_TICKERS_FROM_ID[tx.address.networkId]
   const txId = tx.hash
   const timestamp = tx.timestamp
-  const opReturn = tx.opReturn
+  const opReturn = parseOpReturnData(tx.opReturn)
 
   const addressTriggers = await fetchTriggersForAddress(address)
   await Promise.all(addressTriggers.map(async (trigger) => {
@@ -212,7 +212,7 @@ export interface PostDataParameters {
   txId: string
   buttonName: string
   address: string
-  opReturn: any
+  opReturn: OpReturnData
 }
 
 export interface PostDataParametersHashed {
@@ -222,7 +222,7 @@ export interface PostDataParametersHashed {
   txId: string
   buttonName: string
   address: string
-  opReturn: any
+  opReturn: OpReturnData
   hmac: string
 }
 

--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -212,7 +212,7 @@ export interface PostDataParameters {
   txId: string
   buttonName: string
   address: string
-  opReturn: string
+  opReturn: any
 }
 
 export interface PostDataParametersHashed {
@@ -222,7 +222,7 @@ export interface PostDataParametersHashed {
   txId: string
   buttonName: string
   address: string
-  opReturn: string
+  opReturn: any
   hmac: string
 }
 

--- a/tests/unittests/chronikService.test.ts
+++ b/tests/unittests/chronikService.test.ts
@@ -1,0 +1,107 @@
+import { EMPTY_OP_RETURN } from 'utils/validators'
+import { getNullDataScriptData } from '../../services/chronikService'
+
+describe('getNullDataScriptData tests', () => {
+  it('Null for empty OP_RETURN', async () => {
+    const script = '6a' + ''
+    const data = getNullDataScriptData(script)
+    expect(data).toBe(null)
+  })
+  it('Null for protocol only', async () => {
+    const script = '6a' + '04' + '50415900' + ''
+    const data = getNullDataScriptData(script)
+    expect(data).toBe(null)
+  })
+  it('Null for protocol and version only', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + ''
+    const data = getNullDataScriptData(script)
+    expect(data).toBe(null)
+  })
+  it('Null for protocol, version, pushdata but no data', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '08'
+    const data = getNullDataScriptData(script)
+    expect(data).toBe(null)
+  })
+  it('Null for protocol, version, pushdata but truncated data', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '08' + '00010203040506'
+    const data = getNullDataScriptData(script)
+    expect(data).toBe(null)
+  })
+  it('Empty if data explicitly empty', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '00'
+    const data = getNullDataScriptData(script)
+    expect(data).toStrictEqual(EMPTY_OP_RETURN)
+  })
+  it('Empty if data explicitly empty and nonce too', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '00' + '00'
+    const data = getNullDataScriptData(script)
+    expect(data).toStrictEqual(EMPTY_OP_RETURN)
+  })
+  it('Null if wrong protocol', async () => {
+    const script = '6a' + '04' + '50415901' + '00' + '02' + 'aabb'
+    const data = getNullDataScriptData(script)
+    expect(data).toStrictEqual(null)
+  })
+  it('Simple string data', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '08' + '5051525354555657'
+    const data = getNullDataScriptData(script)
+    expect(data).toStrictEqual({
+      paymentId: '',
+      data: 'PQRSTUVW'
+    })
+  })
+  it('Simple array data', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '0b' + '6974656d317c6974656d32'
+    const data = getNullDataScriptData(script)
+    expect(data).toStrictEqual({
+      paymentId: '',
+      data: ['item1', 'item2']
+    })
+  })
+  it('Simple dict data', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '14' + '6b65793d76616c756520736f6d653d6f74686572'
+    const data = getNullDataScriptData(script)
+    expect(data).toStrictEqual({
+      paymentId: '',
+      data: {
+        key: 'value',
+        some: 'other'
+      }
+    })
+  })
+  it('Simple dict with array', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '1c' + '6b65793d76616c756520736f6d653d76616c7565317c76616c756532'
+    const data = getNullDataScriptData(script)
+    expect(data).toStrictEqual({
+      paymentId: '',
+      data: {
+        key: 'value',
+        some: ['value1', 'value2']
+      }
+    })
+  })
+  it('Simple string data with nonce', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '08' + '505152535455565703010203'
+    const data = getNullDataScriptData(script)
+    expect(data).toStrictEqual({
+      paymentId: '010203',
+      data: 'PQRSTUVW'
+    })
+  })
+  it('Simple string data with explicitly empty nonce', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '08' + '5051525354555657' + '00'
+    const data = getNullDataScriptData(script)
+    expect(data).toStrictEqual({
+      paymentId: '',
+      data: 'PQRSTUVW'
+    })
+  })
+  it('Ignore incomplete nonce', async () => {
+    const script = '6a' + '04' + '50415900' + '00' + '08' + '5051525354555657' + '03' + 'aabb'
+    const data = getNullDataScriptData(script)
+    expect(data).toStrictEqual({
+      paymentId: '',
+      data: 'PQRSTUVW'
+    })
+  })
+})

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -252,3 +252,149 @@ describe('parsePaybuttonTriggerPOSTRequest', () => {
     }).toThrow(RESPONSE_MESSAGES.POST_URL_AND_DATA_MUST_BE_SET_TOGETHER_400.message)
   })
 })
+
+describe('parseStringToArray', () => {
+  it('Divides simple three items', () => {
+    const str = 'one|two|three'
+    expect(v.parseStringToArray(str)).toEqual(['one', 'two', 'three'])
+  })
+  it('Returns string if backslashed', () => {
+    const str = 'one\\|two'
+    expect(v.parseStringToArray(str)).toEqual('one|two')
+  })
+  it('Returns Array with backslashed string at beginning', () => {
+    const str = 'one\\|two|three|four'
+    expect(v.parseStringToArray(str)).toEqual(['one|two', 'three', 'four'])
+  })
+  it('Returns Array with backslashed string at end', () => {
+    const str = 'one|two|three\\|four'
+    expect(v.parseStringToArray(str)).toEqual(['one', 'two', 'three|four'])
+  })
+  it('Returns Array with backslashed string at middle', () => {
+    const str = 'one|two\\|three|four'
+    expect(v.parseStringToArray(str)).toEqual(['one', 'two|three', 'four'])
+  })
+})
+
+describe('parseOpReturn', () => {
+  it('Cant parse equal sign at end', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: 'justreandomakjds='
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: 'justreandomakjds='
+    })
+  })
+  it('Cant parse equal sign at end and beginning', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: '=justreandomakjds='
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: '=justreandomakjds='
+    })
+  })
+  it('Cant parse equal sign at beginning', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: '=justreandomakjds'
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: '=justreandomakjds'
+    })
+  })
+  it('Cant parse equal sign as value', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: 'justreandomakjds=='
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: 'justreandomakjds=='
+    })
+  })
+  it('Cant parse equal sign as key', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: '==justreandomakjds'
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: '==justreandomakjds'
+    })
+  })
+  it('Cant parse if not ALL parsable', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: 'so=far so=good but=then notparsable'
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: 'so=far so=good but=then notparsable'
+    })
+  })
+  it('Simple parse', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: 'sofar=sogood'
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: {
+        sofar: 'sogood'
+      }
+    })
+  })
+  it('Parses case sensitively', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: 'soFar=soGood'
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: {
+        soFar: 'soGood'
+      }
+    })
+  })
+  it('Parses key=value and array', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: 'sofar=sogood many=item1|item2|item3'
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: {
+        sofar: 'sogood',
+        many: ['item1', 'item2', 'item3']
+      }
+    })
+  })
+  it('Parses array with backslash', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: 'sofar=sogood many=item1|item2\\|item3'
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: {
+        sofar: 'sogood',
+        many: ['item1', 'item2|item3']
+      }
+    })
+  })
+  it('Parses array', () => {
+    const opReturn = {
+      paymentId: '66c682719fb0e45e',
+      data: 'item1|item2|item3'
+    }
+    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
+      paymentId: '66c682719fb0e45e',
+      data: ['item1', 'item2', 'item3']
+    })
+  })
+})

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -278,28 +278,27 @@ describe('parseStringToArray', () => {
 
 describe('parseOpReturn', () => {
   it('Cant parse equal sign at end', () => {
-    const opReturnData = 'justreandomakjds='
-    expect(v.parseOpReturnData(opReturnData)).toEqual('justreandomakjds=')
+    const opReturnData = 'key=value something='
+    expect(v.parseOpReturnData(opReturnData)).toEqual('key=value something=')
   })
   it('Cant parse equal sign at end and beginning', () => {
-    const opReturnData = '=justreandomakjds='
-    expect(v.parseOpReturnData(opReturnData)).toEqual('=justreandomakjds=')
+    const opReturnData = '=something key=value='
+    expect(v.parseOpReturnData(opReturnData)).toEqual('=something key=value=')
   })
   it('Cant parse equal sign at beginning', () => {
-    const opReturnData = '=justreandomakjds'
-    expect(v.parseOpReturnData(opReturnData)).toEqual('=justreandomakjds')
+    const opReturnData = '=something key=value'
+    expect(v.parseOpReturnData(opReturnData)).toEqual('=something key=value')
   })
-  it('Cant parse equal sign as value', () => {
-    const opReturnData = 'justreandomakjds=='
-    expect(v.parseOpReturnData(opReturnData)).toEqual('justreandomakjds==')
+  it('Can parse equal sign as value', () => {
+    const opReturnData = 'key=value something=='
+    expect(v.parseOpReturnData(opReturnData)).toEqual({
+      key: 'value',
+      something: '='
+    })
   })
   it('Cant parse equal sign as key', () => {
-    const opReturnData = '==justreandomakjds'
-    expect(v.parseOpReturnData(opReturnData)).toEqual('==justreandomakjds')
-  })
-  it('Cant parse equal sign not in pairs', () => {
-    const opReturnData = 'key=value=othervalue'
-    expect(v.parseOpReturnData(opReturnData)).toEqual('key=value=othervalue')
+    const opReturnData = '==something key=value'
+    expect(v.parseOpReturnData(opReturnData)).toEqual('==something key=value')
   })
   it('Cant parse if not ALL parsable', () => {
     const opReturnData = 'so=far so=good but=then notparsable'
@@ -344,5 +343,11 @@ describe('parseOpReturn', () => {
     expect(v.parseOpReturnData(opReturnData)).toEqual(
       ['item1', 'item2', 'item3']
     )
+  })
+  it('Consider only first equal sign on key=value', () => {
+    const opReturnData = 'key=value=othervalue'
+    expect(v.parseOpReturnData(opReturnData)).toEqual({
+      key: 'value=othervalue'
+    })
   })
 })

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -278,123 +278,71 @@ describe('parseStringToArray', () => {
 
 describe('parseOpReturn', () => {
   it('Cant parse equal sign at end', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: 'justreandomakjds='
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: 'justreandomakjds='
-    })
+    const opReturnData = 'justreandomakjds='
+    expect(v.parseOpReturnData(opReturnData)).toEqual('justreandomakjds=')
   })
   it('Cant parse equal sign at end and beginning', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: '=justreandomakjds='
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: '=justreandomakjds='
-    })
+    const opReturnData = '=justreandomakjds='
+    expect(v.parseOpReturnData(opReturnData)).toEqual('=justreandomakjds=')
   })
   it('Cant parse equal sign at beginning', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: '=justreandomakjds'
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: '=justreandomakjds'
-    })
+    const opReturnData = '=justreandomakjds'
+    expect(v.parseOpReturnData(opReturnData)).toEqual('=justreandomakjds')
   })
   it('Cant parse equal sign as value', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: 'justreandomakjds=='
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: 'justreandomakjds=='
-    })
+    const opReturnData = 'justreandomakjds=='
+    expect(v.parseOpReturnData(opReturnData)).toEqual('justreandomakjds==')
   })
   it('Cant parse equal sign as key', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: '==justreandomakjds'
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: '==justreandomakjds'
-    })
+    const opReturnData = '==justreandomakjds'
+    expect(v.parseOpReturnData(opReturnData)).toEqual('==justreandomakjds')
+  })
+  it('Cant parse equal sign not in pairs', () => {
+    const opReturnData = 'key=value=othervalue'
+    expect(v.parseOpReturnData(opReturnData)).toEqual('key=value=othervalue')
   })
   it('Cant parse if not ALL parsable', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: 'so=far so=good but=then notparsable'
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: 'so=far so=good but=then notparsable'
-    })
+    const opReturnData = 'so=far so=good but=then notparsable'
+    expect(v.parseOpReturnData(opReturnData)).toEqual('so=far so=good but=then notparsable')
   })
   it('Simple parse', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: 'sofar=sogood'
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: {
+    const opReturnData = 'sofar=sogood'
+    expect(v.parseOpReturnData(opReturnData)).toEqual(
+      {
         sofar: 'sogood'
       }
-    })
+    )
   })
   it('Parses case sensitively', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: 'soFar=soGood'
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: {
+    const opReturnData = 'soFar=soGood'
+    expect(v.parseOpReturnData(opReturnData)).toEqual(
+      {
         soFar: 'soGood'
       }
-    })
+    )
   })
   it('Parses key=value and array', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: 'sofar=sogood many=item1|item2|item3'
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: {
+    const opReturnData = 'sofar=sogood many=item1|item2|item3'
+    expect(v.parseOpReturnData(opReturnData)).toEqual(
+      {
         sofar: 'sogood',
         many: ['item1', 'item2', 'item3']
       }
-    })
+    )
   })
   it('Parses array with backslash', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: 'sofar=sogood many=item1|item2\\|item3'
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: {
+    const opReturnData = 'sofar=sogood many=item1|item2\\|item3'
+    expect(v.parseOpReturnData(opReturnData)).toEqual(
+      {
         sofar: 'sogood',
         many: ['item1', 'item2|item3']
       }
-    })
+    )
   })
   it('Parses array', () => {
-    const opReturn = {
-      paymentId: '66c682719fb0e45e',
-      data: 'item1|item2|item3'
-    }
-    expect(v.parseOpReturnData(JSON.stringify(opReturn))).toEqual({
-      paymentId: '66c682719fb0e45e',
-      data: ['item1', 'item2', 'item3']
-    })
+    const opReturnData = 'item1|item2|item3'
+    expect(v.parseOpReturnData(opReturnData)).toEqual(
+      ['item1', 'item2', 'item3']
+    )
   })
 })

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -388,7 +388,10 @@ export function parseOpReturnData (opReturn: string): OpReturnBroadcastData {
       // (parse value as array)
       dataObject[key] = value
     }
-    return dataObject
+    return {
+      paymentId,
+      data: dataObject
+    }
   } catch (err: any) {
     return getSimpleOpReturnObject(paymentId, data)
   }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -344,26 +344,26 @@ export function parseStringToArray (str: string): string | string[] {
   }
   return str.replace('\\|', '|')
 }
-function getSimpleOpReturnObject (token: string, data: string): OpReturnBroadcastData {
+function getSimpleOpReturnObject (paymentId: string, data: string): OpReturnBroadcastData {
   return {
-    token,
+    paymentId,
     data: parseStringToArray(data)
   }
 }
 
 export interface OpReturnData {
   data: string
-  token: string
+  paymentId: string
 }
 
 export const EMPTY_OP_RETURN: OpReturnData = {
   data: '',
-  token: ''
+  paymentId: ''
 }
 
 interface OpReturnBroadcastData {
   data: any
-  token: string
+  paymentId: string
 }
 
 // We try to parse the opReturn string from k=v space-separated
@@ -374,14 +374,14 @@ export function parseOpReturnData (opReturn: string): OpReturnBroadcastData {
     return EMPTY_OP_RETURN
   }
 
-  const { token, data }: OpReturnData = JSON.parse(opReturn)
+  const { paymentId, data }: OpReturnData = JSON.parse(opReturn)
   const dataObject: any = {}
   try {
     const keyValuePairs = data.split(' ')
     for (const kvString of keyValuePairs) {
       const splitted = kvString.split('=')
       if (splitted[1] === undefined || splitted[1] === '' || splitted[0] === '') {
-        return getSimpleOpReturnObject(token, data)
+        return getSimpleOpReturnObject(paymentId, data)
       }
       const key = splitted[0]
       const value = parseStringToArray(splitted[1])
@@ -390,6 +390,6 @@ export function parseOpReturnData (opReturn: string): OpReturnBroadcastData {
     }
     return dataObject
   } catch (err: any) {
-    return getSimpleOpReturnObject(token, data)
+    return getSimpleOpReturnObject(paymentId, data)
   }
 }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -355,6 +355,12 @@ export const EMPTY_OP_RETURN: OpReturnData = {
   paymentId: ''
 }
 
+function splitAtFirst (str: string, separator: string): string[] {
+  const index = str.indexOf(separator)
+  if (index === -1) { return [str] };
+  return [str.slice(0, index), str.slice(index + separator.length)]
+}
+
 // We try to parse the opReturn string from k=v space-separated
 // pairs to  { [k] = v} . We also try to parse each
 // key has the unparsable string as value.
@@ -363,7 +369,7 @@ export function parseOpReturnData (opReturnData: string): any {
   try {
     const keyValuePairs = opReturnData.split(' ')
     for (const kvString of keyValuePairs) {
-      const splitted = kvString.split('=')
+      const splitted = splitAtFirst(kvString, '=')
       if (splitted[1] === undefined || splitted[1] === '' || splitted[0] === '') {
         return parseStringToArray(opReturnData)
       }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -344,12 +344,6 @@ export function parseStringToArray (str: string): string | string[] {
   }
   return str.replace('\\|', '|')
 }
-function getSimpleOpReturnObject (paymentId: string, data: string): OpReturnBroadcastData {
-  return {
-    paymentId,
-    data: parseStringToArray(data)
-  }
-}
 
 export interface OpReturnData {
   data: string
@@ -361,38 +355,25 @@ export const EMPTY_OP_RETURN: OpReturnData = {
   paymentId: ''
 }
 
-interface OpReturnBroadcastData {
-  data: any
-  paymentId: string
-}
-
 // We try to parse the opReturn string from k=v space-separated
 // pairs to  { [k] = v} . We also try to parse each
 // key has the unparsable string as value.
-export function parseOpReturnData (opReturn: string): OpReturnBroadcastData {
-  if (opReturn === '') {
-    return EMPTY_OP_RETURN
-  }
-
-  const { paymentId, data }: OpReturnData = JSON.parse(opReturn)
+export function parseOpReturnData (opReturnData: string): any {
   const dataObject: any = {}
   try {
-    const keyValuePairs = data.split(' ')
+    const keyValuePairs = opReturnData.split(' ')
     for (const kvString of keyValuePairs) {
       const splitted = kvString.split('=')
       if (splitted[1] === undefined || splitted[1] === '' || splitted[0] === '') {
-        return getSimpleOpReturnObject(paymentId, data)
+        return parseStringToArray(opReturnData)
       }
       const key = splitted[0]
       const value = parseStringToArray(splitted[1])
       // (parse value as array)
       dataObject[key] = value
     }
-    return {
-      paymentId,
-      data: dataObject
-    }
+    return dataObject
   } catch (err: any) {
-    return getSimpleOpReturnObject(paymentId, data)
+    return parseStringToArray(opReturnData)
   }
 }


### PR DESCRIPTION
Related to #774 

Depends on
---
- [ ] https://github.com/PayButton/paybutton/pull/332



<!-- Non-technical -->
Description
---
Parses the `opReturn` string conforming to the specs defined in https://reviews.bitcoinabc.org/D15176, and
adds the variable to the paybutton triggers.

Test plan
---

As discussed in https://github.com/PayButton/paybutton/issues/302; I've added a basic support for JSON and arrays.


If a PayButton, created using the branch in the linked dependency, is created with `op-return="key=value separated=by spaces=and arrays=are|done|this|way"`
This will should result in:
```
{
  paymentId: '66c682719fb0e45e',
  data: {
    key: 'value',
    separated: 'by',
    spaces: 'and',
    arrays: ['are', 'done', 'this', 'way']
  }
}
```
Something not parsable such as `op-return="mySimpleText with an equal sign at the end to add confusion="` should then return:
```
{
  paymentId: '66c682719fb0e45e',
  data: "mySimpleText with an equal sign at the end to add confusion="
}
```

**In other words:** 
When using this PayButton to make a payment, this is what should be saved to the database and also what should be POST requested by the trigger in place of the `<opReturn>` variable.
 


Remarks
---

- To see what is relevant in the DB, one could do `SELECT hash, amount,  opReturn from Transaction where not opReturn='';`

- Make sure also there isn't edge cases not covered by the unittests and that the results there established are indeed the expected ones.