### PR TITLE
[#774] feat: try to parse it as JSON

### DIFF
--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -350,4 +350,47 @@ describe('parseOpReturn', () => {
       key: 'value=othervalue'
     })
   })
+  it('Parses simple JSON', () => {
+    const opReturnData = '{"foo": "bar"}'
+    expect(v.parseOpReturnData(opReturnData)).toEqual({
+      foo: 'bar'
+    })
+  })
+  it('Parses nested JSON', () => {
+    const opReturnData = '{"foo": {"bar": {"baz": {"qux": "qix"}}}}'
+    const result = v.parseOpReturnData(opReturnData)
+    expect(result).toEqual({
+      foo: {
+        bar: {
+          baz: {
+            qux: 'qix'
+          }
+        }
+      }
+    })
+  })
+  it('Parses number string into string', () => {
+    // This large number, if interpreted as a number and not as a string,
+    // will come out as 9007199254740996 due to floating point approximation
+    const opReturnData = '9007199254740995'
+    const result = v.parseOpReturnData(opReturnData)
+    expect(result).toStrictEqual('9007199254740995')
+  })
+  it('Parses number string into string', () => {
+    // JSON.parse would consider this as `0`
+    const opReturnData = '-0'
+    const result = v.parseOpReturnData(opReturnData)
+    expect(result).toStrictEqual('-0')
+  })
+  it('Parses exponential number string into string', () => {
+    // JSON.parse would consider this as `100000`
+    const opReturnData = '10e5'
+    const result = v.parseOpReturnData(opReturnData)
+    expect(result).toStrictEqual('10e5')
+  })
+  it('Parses empty string into empty string', () => {
+    const opReturnData = ''
+    const result = v.parseOpReturnData(opReturnData)
+    expect(result).toStrictEqual('')
+  })
 })

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -366,6 +366,16 @@ function splitAtFirst (str: string, separator: string): string[] {
 // key has the unparsable string as value.
 export function parseOpReturnData (opReturnData: string): any {
   const dataObject: any = {}
+  // Try to parse it as JSON first, excluding simple numbers
+  try {
+    const jsonParsed = JSON.parse(opReturnData)
+    if (typeof jsonParsed === 'number') {
+      throw new Error()
+    }
+    return jsonParsed
+  } catch {}
+
+  // Try to parse it as k=v pairs
   try {
     const keyValuePairs = opReturnData.split(' ')
     for (const kvString of keyValuePairs) {


### PR DESCRIPTION
Related to #774

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Allows the parsing of JSON strings.


Test plan
---
- If a paybutton is constructed with e.g. `op-return='{"my": "customData"}"`; we should be able to parse that into an object; that will later be broadcasted as 
```
{
  my: 'customData'
}
```
... in a paybutton trigger.


- Also, I've added tests covering (what I thought to be) all the edge cases, if there is any weirdness missing from it please mention it.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
