### PR TITLE
[#774] feat: broadcast parsed op return

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -77,7 +77,8 @@ export const RESPONSE_MESSAGES = {
   INVALID_DATA_JSON_WITH_VARIABLES_400: (variables: string[]) => { return { statusCode: 400, message: `Data is not valid. Make sure that ${variables.join(', ')} are not inside quotes.` } },
   PAGE_SIZE_LIMIT_EXCEEDED_400: { statusCode: 400, message: `Page size limit should be at most ${TX_PAGE_SIZE_LIMIT}.` },
   PAGE_SIZE_AND_PAGE_SHOULD_BE_NUMBERS_400: { statusCode: 400, message: 'pageSize and page parameters should be valid integers.' },
-  INVALID_OUTPUT_SCRIPT_LENGTH_500: (l: number) => { return { statusCode: 500, message: `Invalid outputScript length ${l}` } }
+  INVALID_OUTPUT_SCRIPT_LENGTH_500: (l: number) => { return { statusCode: 500, message: `Invalid outputScript length ${l}` } },
+  FAILED_TO_PARSE_TX_OP_RETURN_500: { statusCode: 500, message: 'Failed to parse OP_RETURN data in Tx.' }
 }
 
 export type KeyValueT<T> = Record<string, T>

--- a/prisma/seeds/triggers.ts
+++ b/prisma/seeds/triggers.ts
@@ -5,7 +5,7 @@ export const paybuttonTriggers = [
     sendEmail: false,
     postData: `{
       "env": "dev",
-      "OP_RETURN": <opReturn>,
+      "opReturn": <opReturn>,
       "name": <buttonName>,
       "address": <address>,
       "amount": <amount>,

--- a/ws-service/server.ts
+++ b/ws-service/server.ts
@@ -46,6 +46,18 @@ const addressRouteConnection = (socket: Socket): void => {
 
 const broadcastTxs = async (broadcastTxData: BroadcastTxData): Promise<void> => {
   console.log('broadcasting', broadcastTxData.txs.length, broadcastTxData.messageType, 'txs to', broadcastTxData.address)
+  try {
+    const parsedTxs = broadcastTxData.txs.map(
+      t => {
+        const parsedOpReturnData = t.opReturn === '' ? null : JSON.parse(t.opReturn)
+        t.opReturn = parsedOpReturnData
+        return t
+      })
+    broadcastTxData.txs = parsedTxs
+  } catch (err: any) {
+    console.error(RESPONSE_MESSAGES.FAILED_TO_PARSE_TX_OP_RETURN_500.message)
+    console.error('Error stack:', err.stack)
+  }
   if (broadcastTxData?.txs?.length === 0) {
     console.warn(RESPONSE_MESSAGES.BROADCAST_EMPTY_TX_400)
     return


### PR DESCRIPTION
Related to #774 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Parses the OP_RETURN JSON data saved in the DB as a string to JSON before broadcasting.

I added error handling just in case, but this error should never happen since we should always save the `Transaction.opReturn` field either as an empty string (no op return) or as a JSON containing the keys `data` and `paymentId`.


Test plan
---
When a TX with a PayButton OP_RETURN happens; the server should broadcast it this field as a JSON not a string. When a tx without an OP_RETURN happens, then it should broadcast it as `null`.

This can be tested using a PayButton with a trigger containing the `<opReturn>`  variable.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
