### PR TITLE
fix(#801): close div properly

### DIFF
--- a/components/ButtonGenerator/CodeBlock.tsx
+++ b/components/ButtonGenerator/CodeBlock.tsx
@@ -110,7 +110,7 @@ export default function CodeBlock ({ button }): JSX.Element {
 <div
   class="paybutton${button.widget === true ? '-widget' : ''}"
   to="${button.to as string}"
-${generateCode(button, 'html')}/>`,
+${generateCode(button, 'html')}></div>`,
       javascript: `<script src="https://unpkg.com/@paybutton/paybutton/dist/paybutton.js"></script>
 
 <div id="my_button"></div>


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
- changed the example to close the div to avoid errors 
- added indentation to the code


Test plan
---
Open the project, run the build `docker-compose up` and check the button generator if the html example is closing the div properly 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
