### PR TITLE
[#811] feat: address as string and remove redundant opreturn

### DIFF
--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -378,7 +378,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
           }
           if (created) { // only execute trigger for unconfirmed tx arriving
             try {
-              await executeAddressTriggers(broadcastTxData)
+              await executeAddressTriggers(broadcastTxData, tx.address.networkId)
             } catch (err: any) {
               console.error(RESPONSE_MESSAGES.COULD_NOT_EXECUTE_TRIGGER_500.message, err.stack)
             }

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -271,7 +271,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
         [...confirmedTransactions, ...unconfirmedTransactions].map(async tx => await this.getTransactionFromChronikTransaction(tx, address))
       )
       const persistedTransactions = await createManyTransactions(transactionsToPersist)
-      const simplifiedTransactions = await getSimplifiedTransactions(persistedTransactions)
+      const simplifiedTransactions = getSimplifiedTransactions(persistedTransactions)
 
       console.log(`added ${simplifiedTransactions.length} txs to ${addressString}`)
 

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -57,7 +57,7 @@ export function getSimplifiedTrasaction (tx: TransactionWithAddressAndPrices): S
   const simplifiedTransaction: SimplifiedTransaction = {
     hash,
     amount,
-    paymentId: parsedOpReturn?.paymentId,
+    paymentId: parsedOpReturn?.paymentId ?? '',
     confirmed,
     address: address.address,
     timestamp,

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -59,10 +59,9 @@ export function getSimplifiedTrasaction (tx: TransactionWithAddressAndPrices): S
     amount,
     paymentId: parsedOpReturn?.paymentId,
     confirmed,
-    address,
+    address: address.address,
     timestamp,
-    message: parsedOpReturn?.message ?? '',
-    opReturn: parsedOpReturn ?? undefined
+    message: parsedOpReturn?.message ?? ''
   }
 
   return simplifiedTransaction

--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -176,17 +176,16 @@ interface PostDataTriggerLog {
   responseData: string
 }
 
-export async function executeAddressTriggers (broadcastTxData: BroadcastTxData): Promise<void> {
+export async function executeAddressTriggers (broadcastTxData: BroadcastTxData, networkId: number): Promise<void> {
   const address = broadcastTxData.address
   const tx = broadcastTxData.txs[0]
-  const currency = NETWORK_TICKERS_FROM_ID[tx.address.networkId]
+  const currency = NETWORK_TICKERS_FROM_ID[networkId]
   const {
     amount,
     hash,
     timestamp,
     paymentId,
-    message,
-    opReturn
+    message
   } = tx
 
   const addressTriggers = await fetchTriggersForAddress(address)
@@ -198,9 +197,7 @@ export async function executeAddressTriggers (broadcastTxData: BroadcastTxData):
       buttonName: trigger.paybutton.name,
       address,
       timestamp,
-      paymentId: paymentId ?? '',
-      message,
-      opReturn: opReturn ?? EMPTY_OP_RETURN
+      opReturn: { paymentId, message } ?? EMPTY_OP_RETURN
     }
     const hmac = await hashPostData(trigger.paybutton.providerUserId, postDataParameters)
     await postDataForTrigger(trigger, {
@@ -218,8 +215,6 @@ export interface PostDataParameters {
   txId: string
   buttonName: string
   address: string
-  paymentId: string
-  message: string
   opReturn: OpReturnData
 }
 
@@ -230,8 +225,6 @@ export interface PostDataParametersHashed {
   txId: string
   buttonName: string
   address: string
-  paymentId: string
-  message: string
   hmac: string
   opReturn: OpReturnData
 }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -230,8 +230,6 @@ export function parseTriggerPostData (postData: string, postDataParametersHashed
       buttonName: '',
       address: '',
       timestamp: 0,
-      paymentId: '',
-      message: '',
       opReturn: EMPTY_OP_RETURN,
       hmac: ''
     }

--- a/ws-service/types.ts
+++ b/ws-service/types.ts
@@ -11,7 +11,7 @@ export interface BroadcastTxData {
 export interface SimplifiedTransaction {
   hash: string
   amount: Prisma.Decimal
-  paymentId?: string
+  paymentId: string
   confirmed?: boolean
   message: string
   timestamp: number

--- a/ws-service/types.ts
+++ b/ws-service/types.ts
@@ -1,5 +1,4 @@
-import { Address, Prisma } from '@prisma/client'
-import { OpReturnData } from 'utils/validators'
+import { Prisma } from '@prisma/client'
 
 type TxBroadcastType = 'NewTx' | 'OldTx'
 
@@ -15,7 +14,6 @@ export interface SimplifiedTransaction {
   paymentId?: string
   confirmed?: boolean
   message: string
-  opReturn?: OpReturnData
   timestamp: number
-  address: Address
+  address: string
 }


### PR DESCRIPTION
Related to #811

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Some minor fixes to `SimplifiedTransaction`:
- `paymentId` is made mandatory, as is `message`. It will just be empty if it doesn't exist.
- redundant `opReturn` removed
- address is sent as a string, not full address object.


Test plan
---
Build the client using https://github.com/PayButton/paybutton/pull/387. Test if:
- Triggers execute without erroring,
- The client receives a tx and executes onSuccess /onTransaction without erroring.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
