### PR TITLE
Feature/add csv util

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -74,6 +74,7 @@ export const RESPONSE_MESSAGES = {
   LIMIT_TRIGGERS_PER_BUTTON_400: { statusCode: 400, message: 'This paybutton already has a trigger.' },
   LIMIT_TRIGGERS_PER_BUTTON_ADDRESSES_400: { statusCode: 400, message: 'This paybutton addresses already have a trigger from another paybutton.' },
   COULD_NOT_EXECUTE_TRIGGER_500: { statusCode: 500, message: 'Failed to execute trigger for paybutton address.' },
+  COULD__NOT_DOWNLOAD_FILE_500: { statusCode: 500, message: 'Failed to download file.' },
   INVALID_DATA_JSON_WITH_VARIABLES_400: (variables: string[]) => { return { statusCode: 400, message: `Data is not valid. Make sure that ${variables.join(', ')} are not inside quotes.` } },
   PAGE_SIZE_LIMIT_EXCEEDED_400: { statusCode: 400, message: `Page size limit should be at most ${TX_PAGE_SIZE_LIMIT}.` },
   PAGE_SIZE_AND_PAGE_SHOULD_BE_NUMBERS_400: { statusCode: 400, message: 'pageSize and page parameters should be valid integers.' },

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -74,7 +74,7 @@ export const RESPONSE_MESSAGES = {
   LIMIT_TRIGGERS_PER_BUTTON_400: { statusCode: 400, message: 'This paybutton already has a trigger.' },
   LIMIT_TRIGGERS_PER_BUTTON_ADDRESSES_400: { statusCode: 400, message: 'This paybutton addresses already have a trigger from another paybutton.' },
   COULD_NOT_EXECUTE_TRIGGER_500: { statusCode: 500, message: 'Failed to execute trigger for paybutton address.' },
-  COULD__NOT_DOWNLOAD_FILE_500: { statusCode: 500, message: 'Failed to download file.' },
+  COULD_NOT_DOWNLOAD_FILE_500: { statusCode: 500, message: 'Failed to download file.' },
   INVALID_DATA_JSON_WITH_VARIABLES_400: (variables: string[]) => { return { statusCode: 400, message: `Data is not valid. Make sure that ${variables.join(', ')} are not inside quotes.` } },
   PAGE_SIZE_LIMIT_EXCEEDED_400: { statusCode: 400, message: `Page size limit should be at most ${TX_PAGE_SIZE_LIMIT}.` },
   PAGE_SIZE_AND_PAGE_SHOULD_BE_NUMBERS_400: { statusCode: 400, message: 'pageSize and page parameters should be valid integers.' },

--- a/tests/unittests/utils/file.test.ts
+++ b/tests/unittests/utils/file.test.ts
@@ -1,0 +1,155 @@
+import { Transform } from "stream";
+import { NextApiResponse } from "next";
+import { resolveHeaders, getDataFromValues, streamtoCSV, getTransform } from "utils/files";
+import { RESPONSE_MESSAGES } from "constants/index";
+
+const mockedJson = jest.fn();
+
+const mockedRes: jest.Mocked<NextApiResponse> = {
+  status: jest.fn().mockReturnValue({ json: mockedJson }),
+  write: jest.fn().mockReturnValue('ok'),
+} as unknown as jest.Mocked<NextApiResponse>;
+
+describe("resolveHeaders", () => {
+    it("should join headers with commas", () => {
+        const headers = ["header1", "header2", "header3"];
+        const result = resolveHeaders(headers);
+
+        expect(result).toBe("header1,header2,header3");
+    });
+});
+
+describe("getDataFromValues", () => {
+    it("should map data values to headers", () => {
+        const data = { header1: "value1", header2: "value2", header3: "value3" };
+        const headers = ["header1", "header2"];
+        const result = getDataFromValues(data, headers);
+
+        expect(result).toEqual({ header1: "value1", header2: "value2" });
+    });
+});
+
+describe("getTransform", () => {
+    it("should transform data chunks into CSV lines - with 1 columns", (done) => {
+        const headers = ["header1"];
+        const transform = getTransform(headers);
+
+        const dataChunk = { header1: "value1",};
+        transform.on('data', (chunk: { toString: () => any; }) => {
+            // test
+            expect(chunk.toString()).toBe("value1\n");
+            done();
+        });
+
+        transform.write(dataChunk);
+        transform.end();
+    });
+
+    it("should transform data chunks into CSV lines - with 2 columns", (done) => {
+        const headers = ["header1", "header2"];
+        const transform = getTransform(headers);
+
+        const dataChunk = { header1: "value1", header2: "value2" };
+        transform.on('data', (chunk: { toString: () => any; }) => {
+            // test
+            expect(chunk.toString()).toBe("value1,value2\n");
+            done();
+        });
+
+        transform.write(dataChunk);
+        transform.end();
+    });
+
+    it("should transform data chunks into CSV lines - with 3 columns", (done) => {
+        const headers = ["header1", "header2", "header3"];
+        const transform = getTransform(headers);
+        const dataChunk = { 
+            header1: "value1",
+            header2: "value2",
+            header3: "value3",
+        };
+        const { header1, header2, header3 } = dataChunk;
+
+        transform.on('data', (chunk: { toString: () => any; }) => {
+            // test
+            expect(chunk.toString()).toBe(`${header1},${header2},${header3}\n`);
+            done();
+        });
+
+        transform.write(dataChunk);
+        transform.end();
+    });
+
+});
+
+describe("streamtoCSV", () => {
+    it("should stream data to CSV and write to response", () => {
+        const sampleData = [
+            {
+                amount: '10.00',
+                date: '2024-06-04',
+                txId: 'b4c2db5e-22c5-11ef-a973-0242ac120002',
+                value: '0.00',
+                rate: '0.00004675000000'
+            },
+            {
+            amount: '10.00',
+            date: '2024-06-04',
+            txId: 'b4c44121-22c5-11ef-a973-0242ac120002',
+            value: '0.00',
+            rate: '0.00004675000000'
+            },
+            {
+            amount: '10.00',
+            date: '2024-06-04',
+            txId: 'b4c5833b-22c5-11ef-a973-0242ac120002',
+            value: '0.00',
+            rate: '0.00004675000000'
+            },
+            {
+            amount: '10.00',
+            date: '2024-06-04',
+            txId: 'b4c6ec02-22c5-11ef-a973-0242ac120002',
+            value: '0.00',
+            rate: '0.00004675000000'
+            },
+        ];
+        const headers = ['date', 'amount', 'value', 'rate', 'txId'];
+        
+        const res = mockedRes;
+        const getTransformSpy = jest.spyOn(require("utils/files"), 'getTransform');
+
+        const mockedTransform: jest.Mocked<Transform> = {
+            pipe: jest.fn().mockReturnValue({}),
+            end: jest.fn().mockReturnValue({}),
+            write: jest.fn().mockReturnValue({}),
+          } as unknown as jest.Mocked<Transform>;
+
+        getTransformSpy.mockImplementation((headers) => mockedTransform);
+
+
+        streamtoCSV(sampleData, headers, res);
+
+        expect(res.write).toHaveBeenCalledWith("date,amount,value,rate,txId\n");
+        expect(mockedTransform.write).toHaveBeenCalledWith(sampleData[0]);
+        expect(mockedTransform.write).toHaveBeenCalledWith(sampleData[1]);
+        expect(mockedTransform.write).toHaveBeenCalledWith(sampleData[2]);
+        expect(mockedTransform.write).toHaveBeenCalledWith(sampleData[3]);
+        expect(mockedTransform.end).toHaveBeenCalled()
+     });
+
+     it("should handle errors and throw a new error", () => {
+        const values = [
+            { header1: "value1", header2: "value2" },
+            { header1: "value3", header2: "value4" }
+        ];
+        const headers = ["header1", "header2"];
+        const res = mockedRes;
+
+        jest.spyOn(res, 'write').mockImplementation(() => {
+            throw new Error("Write error");
+        });
+
+        expect(() => streamtoCSV(values, headers, res)).toThrow(RESPONSE_MESSAGES.COULD__NOT_DOWNLOAD_FILE_500.message);
+    });
+});

--- a/tests/unittests/utils/files.test.ts
+++ b/tests/unittests/utils/files.test.ts
@@ -16,13 +16,13 @@ describe("valuesToCsvLine", () => {
         const headers = ["header1", "header2", "header3"];
         const result = valuesToCsvLine(headers, ",");
 
-        expect(result).toBe("header1,header2,header3");
+        expect(result).toBe("header1,header2,header3"+"\n");
     });
     it("should join headers with \t delimiter", () => {
         const headers = ["header1", "header2", "header3"];
         const result = valuesToCsvLine(headers, "\t");
 
-        expect(result).toBe("header1\theader2\theader3");
+        expect(result).toBe("header1\theader2\theader3"+"\n");
     });
 });
 

--- a/utils/files.ts
+++ b/utils/files.ts
@@ -3,14 +3,14 @@ import { NextApiResponse } from "next";
 import { Transform } from "stream";
 
 export function valuesToCsvLine(values: string[], delimiter: string): string {
-    return values.join(delimiter);
+    return values.join(delimiter) + '\n';
 }
 interface DataObject {
     [key: string]: any;
 }
 
-export function getDataFromValues(data: DataObject, headers: string[]): Partial<DataObject> {
-    const result: Partial<DataObject> = {};
+export function getDataFromValues(data: DataObject, headers: string[]): DataObject {
+    const result: DataObject = {};
     headers.forEach(header => {
         result[header] = data[header];
     });
@@ -21,7 +21,7 @@ export function getDataFromValues(data: DataObject, headers: string[]): Partial<
 export const getTransform = (headers: string[], delimiter: string) => new Transform({
     objectMode: true,
     transform(chunk: any, encoding: BufferEncoding, callback: () => void) {
-        const csvLine = valuesToCsvLine(headers.map(header => chunk[header]), delimiter) + '\n';
+        const csvLine = valuesToCsvLine(headers.map(header => chunk[header]), delimiter);
         this.push(csvLine);
         callback();
     },
@@ -33,7 +33,7 @@ export function streamToCSV(values: object[], headers: string[], delimiter: stri
     const transform = getTransform(headers, delimiter);
 
     try {
-        res.write(csvLineHeaders + '\n');
+        res.write(csvLineHeaders);
         values.slice(0, maxRecords).forEach((data: object) => {
             const formattedData = getDataFromValues(data, headers);
             transform.write(formattedData);

--- a/utils/files.ts
+++ b/utils/files.ts
@@ -5,12 +5,9 @@ import { Transform } from "stream";
 export function valuesToCsvLine(values: string[], delimiter: string): string {
     return values.join(delimiter) + '\n';
 }
-interface DataObject {
-    [key: string]: any;
-}
 
-export function getDataFromValues(data: DataObject, headers: string[]): DataObject {
-    const result: DataObject = {};
+export function getDataFromValues(data: Record<string, any>, headers: string[]):  Record<string, any> {
+    const result: Record<string, any> = {};
     headers.forEach(header => {
         result[header] = data[header];
     });

--- a/utils/files.ts
+++ b/utils/files.ts
@@ -1,0 +1,46 @@
+import { RESPONSE_MESSAGES } from "../constants/index";
+import { NextApiResponse } from "next";
+import { Transform } from "stream";
+
+export function resolveHeaders(headers:string[]): string {
+    return headers.join(',');
+}
+
+export function getDataFromValues(data:any, headers: string[]): any {
+    const result: any = {};
+    headers.forEach(header => {
+        result[header] = data[header];
+    });
+
+    return result;
+}
+
+export const getTransform = (headers:string[]) => new Transform({
+    objectMode: true,
+    transform(chunk: any, encoding: BufferEncoding, callback: () => void) {
+        const csvLine = headers.map(header => chunk[header]).join(',') + '\n';
+        this.push(csvLine);
+        callback();
+    },
+});
+
+export function streamtoCSV(values: object[], headers: string[], res: NextApiResponse | any) {
+    const maxRecords = 10; 
+    const formattedHeaders = resolveHeaders(headers);
+    const transform = getTransform(headers)
+
+    try {
+        res.write(formattedHeaders + '\n');
+        values.slice(0, maxRecords).forEach((data: object) => {
+            const formattedData = getDataFromValues(data, headers);
+            transform.write(formattedData);
+        });
+
+        transform.end();
+        transform.pipe(res);
+    } catch (error: any) {
+        console.log(error.message)
+        
+        throw new Error(RESPONSE_MESSAGES.COULD__NOT_DOWNLOAD_FILE_500.message)
+    }
+}

--- a/utils/files.ts
+++ b/utils/files.ts
@@ -2,12 +2,15 @@ import { RESPONSE_MESSAGES } from "../constants/index";
 import { NextApiResponse } from "next";
 import { Transform } from "stream";
 
-export function resolveHeaders(headers:string[]): string {
-    return headers.join(',');
+export function valuesToCsvLine(values: string[], delimiter: string): string {
+    return values.join(delimiter);
+}
+interface DataObject {
+    [key: string]: any;
 }
 
-export function getDataFromValues(data:any, headers: string[]): any {
-    const result: any = {};
+export function getDataFromValues(data: DataObject, headers: string[]): Partial<DataObject> {
+    const result: Partial<DataObject> = {};
     headers.forEach(header => {
         result[header] = data[header];
     });
@@ -15,22 +18,22 @@ export function getDataFromValues(data:any, headers: string[]): any {
     return result;
 }
 
-export const getTransform = (headers:string[]) => new Transform({
+export const getTransform = (headers: string[], delimiter: string) => new Transform({
     objectMode: true,
     transform(chunk: any, encoding: BufferEncoding, callback: () => void) {
-        const csvLine = headers.map(header => chunk[header]).join(',') + '\n';
+        const csvLine = valuesToCsvLine(headers.map(header => chunk[header]), delimiter) + '\n';
         this.push(csvLine);
         callback();
     },
 });
 
-export function streamtoCSV(values: object[], headers: string[], res: NextApiResponse | any) {
-    const maxRecords = 10; 
-    const formattedHeaders = resolveHeaders(headers);
-    const transform = getTransform(headers)
+export function streamToCSV(values: object[], headers: string[], delimiter: string, res: NextApiResponse) {
+    const maxRecords = 10;
+    const csvLineHeaders = valuesToCsvLine(headers, delimiter);
+    const transform = getTransform(headers, delimiter);
 
     try {
-        res.write(formattedHeaders + '\n');
+        res.write(csvLineHeaders + '\n');
         values.slice(0, maxRecords).forEach((data: object) => {
             const formattedData = getDataFromValues(data, headers);
             transform.write(formattedData);
@@ -39,8 +42,7 @@ export function streamtoCSV(values: object[], headers: string[], res: NextApiRes
         transform.end();
         transform.pipe(res);
     } catch (error: any) {
-        console.log(error.message)
-        
-        throw new Error(RESPONSE_MESSAGES.COULD__NOT_DOWNLOAD_FILE_500.message)
+        console.error(error.message);
+        throw new Error(RESPONSE_MESSAGES.COULD_NOT_DOWNLOAD_FILE_500.message);
     }
 }


### PR DESCRIPTION
Related to #803 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Added a new util that receives headers and data and writes it in a CSV file using a stream, in this case the stream will be the NextResponse. 
This will be used in the new endpoint to download the txs in a csv 

Test plan
---
Run yarn docker test 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
