### PR TITLE
Feat/return raw opreturn

### DIFF
--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -79,6 +79,7 @@ export function getNullDataScriptData (outputScript: string): OpReturnData | nul
   const dataString = decoder.decode(dataHexBuffer)
 
   const ret: OpReturnData = {
+    rawMessage: dataString,
     message: parseOpReturnData(dataString),
     paymentId: ''
   }

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -61,7 +61,8 @@ export function getSimplifiedTrasaction (tx: TransactionWithAddressAndPrices): S
     confirmed,
     address: address.address,
     timestamp,
-    message: parsedOpReturn?.message ?? ''
+    message: parsedOpReturn?.message ?? '',
+    rawMessage: parsedOpReturn?.rawMessage ?? ''
   }
 
   return simplifiedTransaction

--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -183,7 +183,8 @@ export async function executeAddressTriggers (broadcastTxData: BroadcastTxData, 
     hash,
     timestamp,
     paymentId,
-    message
+    message,
+    rawMessage
   } = tx
 
   const addressTriggers = await fetchTriggersForAddress(address)
@@ -195,7 +196,11 @@ export async function executeAddressTriggers (broadcastTxData: BroadcastTxData, 
       buttonName: trigger.paybutton.name,
       address,
       timestamp,
-      opReturn: { paymentId, message } ?? EMPTY_OP_RETURN
+      opReturn: { 
+        paymentId, 
+        message, 
+        rawMessage  
+      } ?? EMPTY_OP_RETURN
     }
     await postDataForTrigger(trigger, postDataParameters)
   }))

--- a/tests/unittests/chronikService.test.ts
+++ b/tests/unittests/chronikService.test.ts
@@ -47,7 +47,8 @@ describe('getNullDataScriptData tests', () => {
     const data = getNullDataScriptData(script)
     expect(data).toStrictEqual({
       paymentId: '',
-      message: 'PQRSTUVW'
+      message: 'PQRSTUVW',
+      rawMessage: 'PQRSTUVW'
     })
   })
   it('Array data', async () => {
@@ -55,7 +56,8 @@ describe('getNullDataScriptData tests', () => {
     const data = getNullDataScriptData(script)
     expect(data).toStrictEqual({
       paymentId: '',
-      message: ['item1', 'item2']
+      message: ['item1', 'item2'],
+      rawMessage: 'item1|item2'
     })
   })
   it('Dict data', async () => {
@@ -66,7 +68,8 @@ describe('getNullDataScriptData tests', () => {
       message: {
         key: 'value',
         some: 'other'
-      }
+      },
+      rawMessage: "key=value some=other"
     })
   })
   it('Dict with array', async () => {
@@ -77,7 +80,8 @@ describe('getNullDataScriptData tests', () => {
       message: {
         key: 'value',
         some: ['value1', 'value2']
-      }
+      },
+      rawMessage: "key=value some=value1|value2"
     })
   })
   it('Non-ASCII data', async () => {
@@ -88,7 +92,8 @@ describe('getNullDataScriptData tests', () => {
     const data = getNullDataScriptData(script)
     expect(data).toStrictEqual({
       paymentId: '',
-      message: '😂👍©ĸðМжЪы% ŋæPßđĸł„»“æ}¹↓£³→²'
+      message: '😂👍©ĸðМжЪы% ŋæPßđĸł„»“æ}¹↓£³→²',
+      rawMessage: "😂👍©ĸðМжЪы% ŋæPßđĸł„»“æ}¹↓£³→²",
     })
   })
   it('Non-ASCII data with paymentId', async () => {
@@ -99,7 +104,8 @@ describe('getNullDataScriptData tests', () => {
     const data = getNullDataScriptData(script)
     expect(data).toStrictEqual({
       paymentId: 'ab192bcafd745acd',
-      message: '😂👍©ĸðМжЪы% ŋæPßđĸł„»“æ}¹↓£³→²'
+      message: '😂👍©ĸðМжЪы% ŋæPßđĸł„»“æ}¹↓£³→²',
+      rawMessage: '😂👍©ĸðМжЪы% ŋæPßđĸł„»“æ}¹↓£³→²'
     })
   })
   it('String data with paymentId', async () => {
@@ -107,7 +113,8 @@ describe('getNullDataScriptData tests', () => {
     const data = getNullDataScriptData(script)
     expect(data).toStrictEqual({
       paymentId: '010203',
-      message: 'PQRSTUVW'
+      message: 'PQRSTUVW',
+      rawMessage: 'PQRSTUVW'
     })
   })
   it('String data with explicitly empty paymentId', async () => {
@@ -115,7 +122,8 @@ describe('getNullDataScriptData tests', () => {
     const data = getNullDataScriptData(script)
     expect(data).toStrictEqual({
       paymentId: '',
-      message: 'PQRSTUVW'
+      message: 'PQRSTUVW',
+      rawMessage: 'PQRSTUVW',
     })
   })
   it('Ignore incomplete paymentId', async () => {
@@ -123,7 +131,8 @@ describe('getNullDataScriptData tests', () => {
     const data = getNullDataScriptData(script)
     expect(data).toStrictEqual({
       paymentId: '',
-      message: 'PQRSTUVW'
+      message: 'PQRSTUVW',
+      rawMessage: 'PQRSTUVW',
     })
   })
 })

--- a/tests/unittests/validators.test.ts
+++ b/tests/unittests/validators.test.ts
@@ -406,7 +406,8 @@ describe('Signature payload', () => {
     address: 'ecash:mockedhexaddr',
     opReturn: {
       message: 'my custom opReturn data',
-      paymentId: '123paymentId'
+      paymentId: '123paymentId',
+      rawMessage: 'my custom opReturn data'
     }
   }
   it('Gets payload for single variable', () => {
@@ -449,7 +450,8 @@ describe('Signature payload', () => {
       address: 'ecash:mockedhexaddr',
       opReturn: {
         message: '',
-        paymentId: ''
+        paymentId: '',
+        rawMessage: ''
       }
     }
     const postData = '{"id": <txId>, "coin": <currency>, "myVar": 3, "OP_RETURN": <opReturn>, "name": <buttonName>, "amount": <amount>, "ts": <timestamp>}'
@@ -473,7 +475,8 @@ describe('Sign post data', () => {
     address: 'ecash:mockedhexaddr',
     opReturn: {
       message: 'my custom opReturn data',
-      paymentId: '123paymentId'
+      paymentId: '123paymentId',
+      rawMessage: 'my custom opReturn data'
     }
   }
   it('Sign full payload', () => {

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -385,11 +385,13 @@ export function parseStringToArray (str: string): string | string[] {
 }
 
 export interface OpReturnData {
+  rawMessage: string
   message: string
   paymentId: string
 }
 
 export const EMPTY_OP_RETURN: OpReturnData = {
+  rawMessage: '',
   message: '',
   paymentId: ''
 }

--- a/ws-service/types.ts
+++ b/ws-service/types.ts
@@ -16,4 +16,5 @@ export interface SimplifiedTransaction {
   message: string
   timestamp: number
   address: string
+  rawMessage: string
 }


### PR DESCRIPTION
<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Added raw opReturn data to SimplifiedTransaction response.
It will help us compare the transaction opReturn with the Paybutton opReturn set in the client

Test plan
---
Run the server with docker-compose up make a transaction and check the data if the rawMessage is being sent as expected. Run yarn docker test to make sure tests are covering the change. 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
