### PR TITLE
chore: don't seed in prod

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -25,6 +25,9 @@ export async function ignoreConflicts (callback: Function): Promise<void> {
 }
 
 async function main (): Promise<void> {
+  // don't seed in prod
+  if (process.env.NODE_ENV === 'production' || process.env.ENVIRONMENT === 'production') return
+
   // create networks
   if (await prisma.network.count() === 0) {
     await prisma.network.createMany({ data: networks })


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Prod has this as unstaged changes in order to avoid having the users being created again, this is just a simple fix to that.


Test plan
---
Shouldn't alter dev, shouldn't alter prod either because it is already running with this, unstaged.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
