### PR TITLE
Fix/expected res for prices

### DIFF
--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -111,7 +111,13 @@ export async function getPriceForDayAndNetworkTicker (day: moment.Moment, networ
 }
 
 function isResponseAsExpected (data: any): boolean {
-  return data.Price_in_CAD !== undefined && data.Price_in_USD !== undefined
+  const isExpectedObj = data.Price_in_CAD !== undefined && data.Price_in_USD !== undefined
+  if (isExpectedObj) return true
+  if (data.length > 0) {
+    const firstElementIsExpectedObj = data[0].Price_in_CAD !== undefined && data[0].Price_in_USD !== undefined
+    if (firstElementIsExpectedObj) return true
+  }
+  return false
 }
 
 export async function getAllPricesByNetworkTicker (networkTicker: string, attempt: number = 1): Promise<IResponseDataDaily[]> {

--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -113,9 +113,10 @@ export async function getPriceForDayAndNetworkTicker (day: moment.Moment, networ
 function isResponseAsExpected (data: any): boolean {
   const isExpectedObj = data.Price_in_CAD !== undefined && data.Price_in_USD !== undefined
   if (isExpectedObj) return true
-  if (data.length > 0) {
-    const firstElementIsExpectedObj = data[0].Price_in_CAD !== undefined && data[0].Price_in_USD !== undefined
-    if (firstElementIsExpectedObj) return true
+  const values = Object.values(data)
+  if (values.length > 0) {
+    const firstValueIsExpectedObj = values[0].Price_in_CAD !== undefined && values[0].Price_in_USD !== undefined
+    if (firstValueIsExpectedObj) return true
   }
   return false
 }

--- a/services/priceService.ts
+++ b/services/priceService.ts
@@ -113,7 +113,7 @@ export async function getPriceForDayAndNetworkTicker (day: moment.Moment, networ
 function isResponseAsExpected (data: any): boolean {
   const isExpectedObj = data.Price_in_CAD !== undefined && data.Price_in_USD !== undefined
   if (isExpectedObj) return true
-  const values = Object.values(data)
+  const values = Object.values(data) as unknown as any[]
   if (values.length > 0) {
     const firstValueIsExpectedObj = values[0].Price_in_CAD !== undefined && values[0].Price_in_USD !== undefined
     if (firstValueIsExpectedObj) return true


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
When testing the response from coin.dance to check it's validity, we weren't considering that prices may be values in the response object.


Test plan
---
Price sync should be failing before and working now.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
