### PR TITLE
feat: add preferredCurrencyId field

### DIFF
--- a/prisma/migrations/20240924181742_/migration.sql
+++ b/prisma/migrations/20240924181742_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `UserProfile` ADD COLUMN `preferredCurrencyId` INTEGER NOT NULL DEFAULT 1;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -166,6 +166,7 @@ model UserProfile {
   lastSentVerificationEmailAt DateTime?
   wallets   WalletsOnUserProfile[]
   addresses AddressesOnUserProfiles[]
+  preferredCurrencyId Int @default(1)
 }
 
 model PaybuttonTrigger {

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -522,7 +522,8 @@ export const mockedUserProfile: UserProfile = {
   createdAt: new Date(),
   updatedAt: new Date(),
   isAdmin: false,
-  lastSentVerificationEmailAt: null
+  lastSentVerificationEmailAt: null,
+  preferredCurrencyId: 1
 }
 
 export const mockedUserProfileWithPublicKey: UserProfile = {
@@ -531,7 +532,8 @@ export const mockedUserProfileWithPublicKey: UserProfile = {
   createdAt: new Date(),
   updatedAt: new Date(),
   isAdmin: false,
-  lastSentVerificationEmailAt: null
+  lastSentVerificationEmailAt: null,
+  preferredCurrencyId: 1
 }
 
 export const mockedAddressesOnButtons: AddressesOnButtons[] = [


### PR DESCRIPTION
Related to #619 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Added `preferredCurrencyId` field to `UserProfile` scheme and generated a new migration
The `default` value for this field is 1 the id for **USD** quote.

Test plan
---
Make sure the field was added to the UserProfile entity with default 1

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
