### PR TITLE
[UI] Prevent sidebar when not logged in 

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -193,7 +193,12 @@ export const TERTIARY_BCH_COLOR = '#231f20'
 export const BLOCKED_ADDRESSES: string[] = []
 
 export const NO_LAYOUT_ROUTES = [
-  '/'
+  '/',
+  '/signin',
+  '/signup',
+  '/reset-password',
+  '/auth/reset-password',
+  '/verify'
 ]
 
 export const COOKIE_NAMES = {


### PR DESCRIPTION
Related to #860
<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Preventing the sidebar from showing on sign in pages when navigating around 


Test plan
---
preview the site and check you cant cause the issue. It stopped happening for me all together so not sure if this solves it or not

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
