### PR TITLE
Increased max CSV row count from 2k to 10k.

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -240,7 +240,7 @@ export const PAYBUTTON_TRANSACTIONS_FILE_HEADERS = {
 }
 
 export const DEFAULT_PAYBUTTON_CSV_FILE_DELIMITER = ','
-export const MAX_RECORDS_PER_FILE = 2000
+export const MAX_RECORDS_PER_FILE = 10000
 
 export const DECIMALS: Record<string, number> = {
   BCH: 8,


### PR DESCRIPTION
Related to #870

Description
---
CSV max row count increased from 2k -> 10k.


Test plan
---
1. Create a button with the following addresses: `ecash:qp0g6tty4re6cqtttgus34s7ht80xvqndqtynvfhd9`, `ecash:qr6mxvfp2hlr0qg5phhqapqz8ajv7uaxk55z9332rl`, `ecash:qzgyg3llme32kpru03ff7dq7lz8087ma6glfxngvp2`, `ecash:qqhe60kagdq6fftrd2m2j62ygeyd7w26fvwlv0ntjk`, `ecash:qpp6zklxvwrqynkhlp75qszgcw0mdu8uuu55gjkvax`
2. Generate a CSV and see that it has >6000 txs.