### PR TITLE
[#830] Fix: slow tx refresh

### DIFF
--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -374,24 +374,17 @@ export class ChronikBlockchainClient implements BlockchainClient {
           return
         }
         console.log(`${this.CHRONIK_MSG_PREFIX}: [${msg.msgType}] ${msg.txid}`)
-        console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will get tx ${msg.txid} from chronik`)
         const transaction = await this.chronik.tx(msg.txid)
-        console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will get addr ${msg.txid} from db`)
         const addressesWithTransactions = await this.getAddressesForTransaction(transaction)
         for (const addressWithTransaction of addressesWithTransactions) {
-          console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will create tx for ${msg.txid}`)
           const { created, tx } = await createTransaction(addressWithTransaction.transaction)
-          console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: created tx for ${msg.txid}`)
           if (tx !== undefined) {
             const broadcastTxData: BroadcastTxData = {} as BroadcastTxData
             broadcastTxData.address = addressWithTransaction.address.address
             broadcastTxData.messageType = 'NewTx'
-            console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will simplify tx for ${msg.txid}`)
             const newSimplifiedTransaction = getSimplifiedTrasaction(tx)
-            console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: simplified tx for ${msg.txid}`)
             broadcastTxData.txs = [newSimplifiedTransaction]
             try { // emit broadcast for both unconfirmed and confirmed txs
-              console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: emitting ${msg.txid} to ${broadcastTxData.address}`)
               this.wsEndpoint.emit(SOCKET_MESSAGES.TXS_BROADCAST, broadcastTxData)
             } catch (err: any) {
               console.error(RESPONSE_MESSAGES.COULD_NOT_BROADCAST_TX_TO_WS_SERVER_500.message, err.stack)
@@ -420,11 +413,8 @@ export class ChronikBlockchainClient implements BlockchainClient {
   }
 
   private async getAddressesForTransaction (transaction: Tx_InNode): Promise<AddressWithTransaction[]> {
-    console.log('WIP gettings subbedAddresses')
     const relatedAddresses = await this.getRelatedAddressesForTransaction(transaction)
-    console.log(`WIP got subbedAddresses ${relatedAddresses.length}, will fetch addresses`)
     const addressesFromStringArray = await fetchAddressesArray(relatedAddresses)
-    console.log(`WIP fetched ${addressesFromStringArray.length} addresses, will promise many`)
     const addressesWithTransactions: AddressWithTransaction[] = await Promise.all(addressesFromStringArray.map(
       async address => {
         return {
@@ -433,7 +423,6 @@ export class ChronikBlockchainClient implements BlockchainClient {
         }
       }
     ))
-    console.log('WIP finished all promises')
     const zero = new Prisma.Decimal(0)
     return addressesWithTransactions.filter(
       addressWithTransaction => !(zero.equals(addressWithTransaction.transaction.amount as Prisma.Decimal))

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -374,7 +374,9 @@ export class ChronikBlockchainClient implements BlockchainClient {
           return
         }
         console.log(`${this.CHRONIK_MSG_PREFIX}: [${msg.msgType}] ${msg.txid}`)
+        console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will get tx ${msg.txid} from chronik`)
         const transaction = await this.chronik.tx(msg.txid)
+        console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will get addr ${msg.txid} from db`)
         const addressesWithTransactions = await this.getAddressesForTransaction(transaction)
         for (const addressWithTransaction of addressesWithTransactions) {
           console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will create tx for ${msg.txid}`)

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -413,11 +413,17 @@ export class ChronikBlockchainClient implements BlockchainClient {
     }
   }
 
+  private async getRelatedAddressesForTransaction (transaction: Tx_InNode): Promise<string[]> {
+    const inputAddresses = transaction.inputs.map(inp => outputScriptToAddress(this.networkSlug, inp.outputScript))
+    const outputAddresses = transaction.outputs.map(out => outputScriptToAddress(this.networkSlug, out.outputScript))
+    return [...inputAddresses, ...outputAddresses].filter(a => a !== undefined) as string[]
+  }
+
   private async getAddressesForTransaction (transaction: Tx_InNode): Promise<AddressWithTransaction[]> {
     console.log('WIP gettings subbedAddresses')
-    const subbedAddresses = this.getSubscribedAddresses()
-    console.log(`WIP got subbedAddresses ${subbedAddresses.length}, will fetch addresses`)
-    const addressesFromStringArray = await fetchAddressesArray(subbedAddresses)
+    const relatedAddresses = await this.getRelatedAddressesForTransaction(transaction)
+    console.log(`WIP got subbedAddresses ${relatedAddresses.length}, will fetch addresses`)
+    const addressesFromStringArray = await fetchAddressesArray(relatedAddresses)
     console.log(`WIP fetched ${addressesFromStringArray.length} addresses, will promise many`)
     const addressesWithTransactions: AddressWithTransaction[] = await Promise.all(addressesFromStringArray.map(
       async address => {

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -381,7 +381,6 @@ export class ChronikBlockchainClient implements BlockchainClient {
         for (const addressWithTransaction of addressesWithTransactions) {
           console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will create tx for ${msg.txid}`)
           const { created, tx } = await createTransaction(addressWithTransaction.transaction)
-          console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will create tx for ${msg.txid}`)
           console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: created tx for ${msg.txid}`)
           if (tx !== undefined) {
             const broadcastTxData: BroadcastTxData = {} as BroadcastTxData
@@ -415,7 +414,11 @@ export class ChronikBlockchainClient implements BlockchainClient {
   }
 
   private async getAddressesForTransaction (transaction: Tx_InNode): Promise<AddressWithTransaction[]> {
-    const addressesFromStringArray = await fetchAddressesArray(this.getSubscribedAddresses())
+    console.log('WIP gettings subbedAddresses')
+    const subbedAddresses = this.getSubscribedAddresses()
+    console.log(`WIP got subbedAddresses ${subbedAddresses.length}, will fetch addresses`)
+    const addressesFromStringArray = await fetchAddressesArray(subbedAddresses)
+    console.log(`WIP fetched ${addressesFromStringArray.length} addresses, will promise many`)
     const addressesWithTransactions: AddressWithTransaction[] = await Promise.all(addressesFromStringArray.map(
       async address => {
         return {
@@ -424,6 +427,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
         }
       }
     ))
+    console.log('WIP finished all promises')
     const zero = new Prisma.Decimal(0)
     return addressesWithTransactions.filter(
       addressWithTransaction => !(zero.equals(addressWithTransaction.transaction.amount as Prisma.Decimal))

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -377,14 +377,20 @@ export class ChronikBlockchainClient implements BlockchainClient {
         const transaction = await this.chronik.tx(msg.txid)
         const addressesWithTransactions = await this.getAddressesForTransaction(transaction)
         for (const addressWithTransaction of addressesWithTransactions) {
+          console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will create tx for ${msg.txid}`)
           const { created, tx } = await createTransaction(addressWithTransaction.transaction)
+          console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will create tx for ${msg.txid}`)
+          console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: created tx for ${msg.txid}`)
           if (tx !== undefined) {
             const broadcastTxData: BroadcastTxData = {} as BroadcastTxData
             broadcastTxData.address = addressWithTransaction.address.address
             broadcastTxData.messageType = 'NewTx'
+            console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: will simplify tx for ${msg.txid}`)
             const newSimplifiedTransaction = getSimplifiedTrasaction(tx)
+            console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: simplified tx for ${msg.txid}`)
             broadcastTxData.txs = [newSimplifiedTransaction]
             try { // emit broadcast for both unconfirmed and confirmed txs
+              console.log(`WIP ${this.CHRONIK_MSG_PREFIX}: emitting ${msg.txid} to ${broadcastTxData.address}`)
               this.wsEndpoint.emit(SOCKET_MESSAGES.TXS_BROADCAST, broadcastTxData)
             } catch (err: any) {
               console.error(RESPONSE_MESSAGES.COULD_NOT_BROADCAST_TX_TO_WS_SERVER_500.message, err.stack)

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -12,6 +12,7 @@ import { SimplifiedTransaction } from 'ws-service/types'
 import { OpReturnData } from 'utils/validators'
 
 export async function getTransactionValue (transaction: TransactionWithPrices): Promise<QuoteValues> {
+  console.log('will depend on tx', transaction.hash, 'having prices set')
   const ret: QuoteValues = {
     usd: new Prisma.Decimal(0),
     cad: new Prisma.Decimal(0)
@@ -298,6 +299,7 @@ export async function connectTransactionToPrices (tx: Transaction, prisma: Prism
     },
     update: {}
   })
+  console.log('finished connecting tx', tx.hash, 'to prices')
 }
 
 export async function connectTransactionsListToPrices (txList: Transaction[]): Promise<void> {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -17,7 +17,7 @@ export async function getTransactionValue (transaction: TransactionWithPrices): 
     cad: new Prisma.Decimal(0)
   }
   if (transaction.prices.length !== N_OF_QUOTES) {
-    throw new Error(`Error: ${RESPONSE_MESSAGES.MISSING_PRICE_FOR_TRANSACTION_400.message} found in ${transaction.prices.length}. txId: ${transaction.id}, at ${transaction.timestamp}`)
+    throw new Error(`Error: ${RESPONSE_MESSAGES.MISSING_PRICE_FOR_TRANSACTION_400.message} found ${transaction.prices.length}. txId: ${transaction.hash}, at ${transaction.timestamp}`)
   }
   for (const p of transaction.prices) {
     if (p.price.quoteId === USD_QUOTE_ID) {
@@ -504,7 +504,7 @@ export const getTransactionValueInCurrency = (transaction: TransactionWithAddres
   const {
     prices,
     amount,
-    id,
+    hash,
     timestamp
   } = transaction
 
@@ -514,7 +514,7 @@ export const getTransactionValueInCurrency = (transaction: TransactionWithAddres
   }
 
   if (prices.length !== N_OF_QUOTES) {
-    throw new Error(`${RESPONSE_MESSAGES.MISSING_PRICE_FOR_TRANSACTION_400.message}, txId ${id}, at ${timestamp}`)
+    throw new Error(`${RESPONSE_MESSAGES.MISSING_PRICE_FOR_TRANSACTION_400.message}, txId ${hash}, at ${timestamp}`)
   }
 
   for (const p of prices) {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -12,7 +12,6 @@ import { SimplifiedTransaction } from 'ws-service/types'
 import { OpReturnData } from 'utils/validators'
 
 export async function getTransactionValue (transaction: TransactionWithPrices): Promise<QuoteValues> {
-  console.log('will depend on tx', transaction.hash, 'having prices set')
   const ret: QuoteValues = {
     usd: new Prisma.Decimal(0),
     cad: new Prisma.Decimal(0)
@@ -299,7 +298,6 @@ export async function connectTransactionToPrices (tx: Transaction, prisma: Prism
     },
     update: {}
   })
-  console.log('finished connecting tx', tx.hash, 'to prices')
 }
 
 export async function connectTransactionsListToPrices (txList: Transaction[]): Promise<void> {


### PR DESCRIPTION
Related to #830

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes the slowness of inserting an upcoming tx in the db.


Test plan
---
In localhost this was not perceptible because there isn't that many addresses and txs, but if one were to add some big addresses, then it would become perceptible. In any case, prod is running this branch already, so this can be tested there.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
