### PR TITLE
[UI] Add advanced button generator options

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,2 @@
 #!/bin/sh
-echo "PATH is: $PATH"
-which npx
 npx lint-staged

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,4 @@
 #!/bin/sh
+echo "PATH is: $PATH"
+which npx
 npx lint-staged

--- a/components/ButtonGenerator/data.js
+++ b/components/ButtonGenerator/data.js
@@ -161,4 +161,23 @@ export const generatorFormFields = [
     helpText: 'Allow changing the payment amount',
     advanced: true
   },
+  {
+    name: 'OP-Return',
+    placeholder: 'myCustomMessage',
+    key: 'opReturn',
+    className: 'col_lg',
+    type: 'input',
+    onChange: 'handleChange',
+    helpText: 'Custom message that will be sent with the transaction',
+    advanced: true
+  },
+  {
+    name: 'Disable Payment ID',
+    key: 'disablePaymentId',
+    className: 'col_sm_center',
+    type: 'boolean',
+    default: false,
+    helpText: 'Removes the random ID generated for the payment that is used to prevent the onSuccess callback to be triggered by a person who has the payment screen open at the same time as another',
+    advanced: true
+  },
 ]

--- a/components/ButtonGenerator/index.tsx
+++ b/components/ButtonGenerator/index.tsx
@@ -35,6 +35,8 @@ interface ButtonState {
   disabled: boolean
   editable: boolean
   widget: boolean
+  disablePaymentId: boolean
+  opReturn: string
   [key: string]: any
 }
 
@@ -70,7 +72,9 @@ export const initialButtonState: ButtonState = {
   disableEnforceFocus: true,
   disabled: false,
   editable: false,
-  widget: false
+  widget: false,
+  disablePaymentId: false,
+  opReturn: ''
 }
 
 export default function ButtonGenerator (): JSX.Element {

--- a/components/Paybutton/paybutton.module.css
+++ b/components/Paybutton/paybutton.module.css
@@ -144,6 +144,8 @@
   padding: 25px;
   border-radius: 10px;
   border: 1px solid var(--secondary-text-color);
+  overflow-y: auto;
+  max-height: 90vh;
 }
 
 .form_ctn p {


### PR DESCRIPTION
Related to #794 & #804

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Adding op return and disable payment id to the button generator
Also sneaking in a CSS tweak to prevent the wallet dialog from running off the page


Test plan
---
Check the button generator and check the create or edit wallet dialog in an account with lots of buttons 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
