### PR TITLE
feat: get payments count

### DIFF
--- a/pages/api/payments/count/index.ts
+++ b/pages/api/payments/count/index.ts
@@ -6,7 +6,7 @@ export default async (req: any, res: any): Promise<void> => {
     await setSession(req, res)
     const userId = req.session.userId
 
-    const resJSON = await CacheGet.paymentListCount(userId)
+    const resJSON = await CacheGet.paymentsCount(userId)
     res.status(200).json(resJSON)
   }
 }

--- a/pages/api/payments/count/index.ts
+++ b/pages/api/payments/count/index.ts
@@ -1,0 +1,12 @@
+import { CacheGet } from 'redis/index'
+import { setSession } from 'utils/setSession'
+
+export default async (req: any, res: any): Promise<void> => {
+  if (req.method === 'GET') {
+    await setSession(req, res)
+    const userId = req.session.userId
+
+    const resJSON = await CacheGet.paymentListCount(userId)
+    res.status(200).json(resJSON)
+  }
+}

--- a/redis/index.ts
+++ b/redis/index.ts
@@ -4,7 +4,7 @@ import { TransactionWithAddressAndPrices } from 'services/transactionService'
 import { fetchUsersForAddress } from 'services/userService'
 import { cacheBalanceForAddress, clearBalanceCache, getBalanceForAddress, updateBalanceCacheFromTx } from './balanceCache'
 import { clearDashboardCache, getUserDashboardData } from './dashboardCache'
-import { appendPaybuttonToAddressesCache, cacheGroupedPayments, cacheManyTxs, generateGroupedPaymentsForAddress, getPaymentList, initPaymentCache, removePaybuttonToAddressesCache } from './paymentCache'
+import { appendPaybuttonToAddressesCache, cacheGroupedPayments, cacheManyTxs, generateGroupedPaymentsForAddress, getCachedPaymentsCountForUser, getPaymentList, initPaymentCache, removePaybuttonToAddressesCache } from './paymentCache'
 import { DashboardData, Payment } from './types'
 
 interface PaybuttonCreationParams {
@@ -84,5 +84,8 @@ export const CacheGet = {
   },
   addressBalance: async (addressString: string): Promise<AddressPaymentInfo> => {
     return await getBalanceForAddress(addressString)
+  },
+  paymentListCount: async (userId: string) => {
+    return await getCachedPaymentsCountForUser(userId)
   }
 }

--- a/redis/index.ts
+++ b/redis/index.ts
@@ -85,7 +85,7 @@ export const CacheGet = {
   addressBalance: async (addressString: string): Promise<AddressPaymentInfo> => {
     return await getBalanceForAddress(addressString)
   },
-  paymentListCount: async (userId: string) => {
+  paymentsCount: async (userId: string) => {
     return await getCachedPaymentsCountForUser(userId)
   }
 }

--- a/redis/paymentCache.ts
+++ b/redis/paymentCache.ts
@@ -8,6 +8,7 @@ import { RESPONSE_MESSAGES, PAYMENT_WEEK_KEY_FORMAT, KeyValueT } from 'constants
 import moment from 'moment'
 import { CacheSet } from 'redis/index'
 import { ButtonDisplayData, Payment } from './types'
+import { getUserDashboardData } from './dashboardCache'
 // ADDRESS:payments:YYYY:MM
 const getPaymentsWeekKey = (addressString: string, timestamp: number): string => {
   return `${addressString}:payments:${moment.unix(timestamp).format(PAYMENT_WEEK_KEY_FORMAT)}`
@@ -110,6 +111,12 @@ export const getCachedPaymentsForUser = async (userId: string): Promise<Payment[
     allPayments = allPayments.concat(weekPayments)
   }
   return allPayments
+}
+
+export const getCachedPaymentsCountForUser = async (userId: string): Promise<number> => {
+  const dashboardData = await getUserDashboardData(userId)
+
+  return dashboardData.total.payments
 }
 
 export const cacheGroupedPayments = async (paymentsGroupedByKey: KeyValueT<Payment[]>): Promise<void> => {


### PR DESCRIPTION
Related to #741 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Created a new endpoint to fetch the total amount of payments, it will be used in the paginate payments logic


Test plan
Run server, Log in the dashboard and try accessing this url : 
 'http://localhost:3000/api/payments/count' 
It should retrieve the same amount of payments that is showing up in the dashboard

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
