### PR TITLE
Feat/paginate payments endpoint

### DIFF
--- a/components/TableContainer/TableContainerGetter.tsx
+++ b/components/TableContainer/TableContainerGetter.tsx
@@ -17,8 +17,17 @@ interface IProps {
   emptyMessage?: string
 }
 
+const getLocalStorageItem = (itemName: string): string | null => {
+  try {
+    return localStorage.getItem(itemName)
+  } catch (error: any) {
+    console.error(error.message)
+    return null
+  }
+}
+
 const TableContainer = ({ columns, dataGetter, opts, ssr, tableRefreshCount, emptyMessage }: IProps): JSX.Element => {
-  const localPageSize = localStorage.getItem('pageSize')
+  const localPageSize = getLocalStorageItem('pageSize')
   const localStoragePageSize = ssr ? 10 : localPageSize !== null ? +localPageSize : 10
   const [data, setData] = useState<any[]>([])
   const [sortColumn, setSortColumn] = useState(opts?.sortColumn ?? 'timestamp')

--- a/pages/api/payments/index.ts
+++ b/pages/api/payments/index.ts
@@ -1,4 +1,4 @@
-import { fetchAllPaymentsByUserId } from 'services/transactionService'
+import { fetchAllPaymentsByUserIdWithPagination } from 'services/transactionService'
 import { setSession } from 'utils/setSession'
 
 export default async (req: any, res: any): Promise<void> => {
@@ -10,7 +10,7 @@ export default async (req: any, res: any): Promise<void> => {
     const orderDesc: boolean = !!(req.query.orderDesc === '' || req.query.orderDesc === undefined || req.query.orderDesc === 'true')
     const orderBy = (req.query.orderBy === '' || req.query.orderBy === undefined) ? undefined : req.query.orderBy as string
 
-    const resJSON = await fetchAllPaymentsByUserId(userId, page, pageSize, orderBy, orderDesc)
+    const resJSON = await fetchAllPaymentsByUserIdWithPagination(userId, page, pageSize, orderBy, orderDesc)
     res.status(200).json(resJSON)
   }
 }

--- a/pages/api/payments/index.ts
+++ b/pages/api/payments/index.ts
@@ -5,7 +5,10 @@ export default async (req: any, res: any): Promise<void> => {
   if (req.method === 'GET') {
     await setSession(req, res)
     const userId = req.session.userId
-    const resJSON = await CacheGet.paymentList(userId)
+    const page = req.query.page as number
+    const pageSize = req.query.pageSize as number
+
+    const resJSON = await CacheGet.paymentListPaginated(userId, page, pageSize)
     res.status(200).json(resJSON)
   }
 }

--- a/pages/api/payments/index.ts
+++ b/pages/api/payments/index.ts
@@ -7,8 +7,9 @@ export default async (req: any, res: any): Promise<void> => {
     const userId = req.session.userId
     const page = req.query.page as number
     const pageSize = req.query.pageSize as number
+    const orderDesc: boolean = !!(req.query.orderDesc === '' || req.query.orderDesc === undefined || req.query.orderDesc === 'true')
 
-    const resJSON = await CacheGet.paymentListPaginated(userId, page, pageSize)
+    const resJSON = await CacheGet.paymentListPaginated(userId, page, pageSize, orderDesc)
     res.status(200).json(resJSON)
   }
 }

--- a/pages/api/payments/index.ts
+++ b/pages/api/payments/index.ts
@@ -1,4 +1,4 @@
-import { CacheGet } from 'redis/index'
+import { fetchAllPaymentsByUserId } from 'services/transactionService'
 import { setSession } from 'utils/setSession'
 
 export default async (req: any, res: any): Promise<void> => {
@@ -8,8 +8,9 @@ export default async (req: any, res: any): Promise<void> => {
     const page = req.query.page as number
     const pageSize = req.query.pageSize as number
     const orderDesc: boolean = !!(req.query.orderDesc === '' || req.query.orderDesc === undefined || req.query.orderDesc === 'true')
+    const orderBy = (req.query.orderBy === '' || req.query.orderBy === undefined) ? undefined : req.query.orderBy as string
 
-    const resJSON = await CacheGet.paymentListPaginated(userId, page, pageSize, orderDesc)
+    const resJSON = await fetchAllPaymentsByUserId(userId, page, pageSize, orderBy, orderDesc)
     res.status(200).json(resJSON)
   }
 }

--- a/pages/payments/index.tsx
+++ b/pages/payments/index.tsx
@@ -51,11 +51,12 @@ interface PaybuttonsProps {
 export default function Payments ({ user }: PaybuttonsProps): React.ReactElement {
   function fetchData (): Function {
     return async (page: number, pageSize: number, orderBy: string, orderDesc: boolean) => {
-      const data = await fetch(`/api/payments?page=${page}&pageSize=${pageSize}`)
-      const response = await fetch('/api/payments/count')
-      const totalCount = await response.json()
+      const paymentsResponse = await fetch(`/api/payments?page=${page}&pageSize=${pageSize}`)
+      const paymentsCountResponse = await fetch('/api/payments/count')
+      const totalCount = await paymentsCountResponse.json()
+      const payments = await paymentsResponse.json()
       return {
-        data: await data.json(),
+        data: payments,
         totalCount
       }
     }

--- a/pages/payments/index.tsx
+++ b/pages/payments/index.tsx
@@ -51,7 +51,7 @@ interface PaybuttonsProps {
 export default function Payments ({ user }: PaybuttonsProps): React.ReactElement {
   function fetchData (): Function {
     return async (page: number, pageSize: number, orderBy: string, orderDesc: boolean) => {
-      const paymentsResponse = await fetch(`/api/payments?page=${page}&pageSize=${pageSize}`)
+      const paymentsResponse = await fetch(`/api/payments?page=${page}&pageSize=${pageSize}&orderDesc=${String(orderDesc)}`)
       const paymentsCountResponse = await fetch('/api/payments/count')
       const totalCount = await paymentsCountResponse.json()
       const payments = await paymentsResponse.json()

--- a/pages/payments/index.tsx
+++ b/pages/payments/index.tsx
@@ -83,7 +83,7 @@ export default function Payments ({ user, userId }: PaybuttonsProps): React.Reac
       },
       {
         Header: () => (<div style={{ textAlign: 'center' }}>Network</div>),
-        accessor: 'address.networkId',
+        accessor: 'networkId',
         Cell: (cellProps) => {
           return (
             <div className='table-icon-ctn'>

--- a/pages/payments/index.tsx
+++ b/pages/payments/index.tsx
@@ -39,19 +39,21 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   return {
     props: {
-      user
+      user,
+      userId
     }
   }
 }
 
 interface PaybuttonsProps {
   user: UserWithSupertokens
+  userId: string
 }
 
-export default function Payments ({ user }: PaybuttonsProps): React.ReactElement {
+export default function Payments ({ user, userId }: PaybuttonsProps): React.ReactElement {
   function fetchData (): Function {
     return async (page: number, pageSize: number, orderBy: string, orderDesc: boolean) => {
-      const paymentsResponse = await fetch(`/api/payments?page=${page}&pageSize=${pageSize}&orderDesc=${String(orderDesc)}`)
+      const paymentsResponse = await fetch(`/api/payments?page=${page}&pageSize=${pageSize}&orderBy=${orderBy}&orderDesc=${String(orderDesc)}`)
       const paymentsCountResponse = await fetch('/api/payments/count')
       const totalCount = await paymentsCountResponse.json()
       const payments = await paymentsResponse.json()
@@ -81,7 +83,7 @@ export default function Payments ({ user }: PaybuttonsProps): React.ReactElement
       },
       {
         Header: () => (<div style={{ textAlign: 'center' }}>Network</div>),
-        accessor: 'networkId',
+        accessor: 'address.networkId',
         Cell: (cellProps) => {
           return (
             <div className='table-icon-ctn'>
@@ -97,12 +99,17 @@ export default function Payments ({ user }: PaybuttonsProps): React.ReactElement
         accessor: 'buttonDisplayDataList',
         Cell: (cellProps) => {
           return (
-            <div className='payments-btn-cell'> {cellProps.cell.value.map((buttonDisplayData: ButtonDisplayData) =>
-              <div style={{ textAlign: 'center' }} className="table-button" key={buttonDisplayData.id}>
-              <Link href={`/button/${buttonDisplayData.id}`}>{buttonDisplayData.name}</Link>
-              </div>
-            )}
-             </div>
+            <div className='payments-btn-cell'>
+              {cellProps.cell.value.map((buttonDisplayData: ButtonDisplayData) =>
+                buttonDisplayData.providerUserId === userId
+                  ? (
+                  <div style={{ textAlign: 'center' }} className="table-button" key={buttonDisplayData.id}>
+                    <Link href={`/button/${buttonDisplayData.id}`}>{buttonDisplayData.name}</Link>
+                  </div>
+                    )
+                  : null
+              )}
+            </div>
           )
         }
       },

--- a/pages/payments/index.tsx
+++ b/pages/payments/index.tsx
@@ -78,7 +78,7 @@ export default function Payments ({ user, userId }: PaybuttonsProps): React.Reac
         accessor: 'values',
         sortType: compareNumericString,
         Cell: (cellProps) => {
-          return <div style={{ textAlign: 'right', fontWeight: '600' }}>${formatQuoteValue(cellProps.cell.value, user.userProfile.preferredCurrencyId)}</div>
+          return <div style={{ textAlign: 'right', fontWeight: '600' }}> {cellProps.cell.value.amount} (${formatQuoteValue(cellProps.cell.value.values, user.userProfile.preferredCurrencyId)})</div>
         }
       },
       {

--- a/redis/dashboardCache.ts
+++ b/redis/dashboardCache.ts
@@ -69,14 +69,14 @@ export const getButtonPaymentData = (n: number, periodString: string, paymentLis
           },
           total: {
             payments: 1,
-            revenue: p.values
+            revenue: p.values.values
           }
         }
         buttonPaymentData[b.id] = newEntry
         return
       }
       prevObj.total.payments += 1
-      prevObj.total.revenue = sumQuoteValues(prevObj.total.revenue, p.values)
+      prevObj.total.revenue = sumQuoteValues(prevObj.total.revenue, p.values.values)
       prevObj.displayData.isXec = prevObj.displayData.isXec === true || (p.networkId === XEC_NETWORK_ID)
       prevObj.displayData.isBch = prevObj.displayData.isBch === true || (p.networkId === BCH_NETWORK_ID)
       const lastPayment = prevObj.displayData.lastPayment as number
@@ -99,8 +99,8 @@ export const sumPaymentsValue = function (paymentList: Payment[]): QuoteValues {
   }
 
   for (const p of paymentList) {
-    ret.usd = ret.usd.plus(p.values.usd)
-    ret.cad = ret.cad.plus(p.values.cad)
+    ret.usd = ret.usd.plus(p.values.values.usd)
+    ret.cad = ret.cad.plus(p.values.values.cad)
   }
   return ret
 }
@@ -150,7 +150,7 @@ const generateDashboardDataFromStream = async function (
         }
 
         if (index >= 0 && index < revenueAccumulators[period].length) {
-          revenueAccumulators[period][index] = sumQuoteValues(revenueAccumulators[period][index], payment.values)
+          revenueAccumulators[period][index] = sumQuoteValues(revenueAccumulators[period][index], payment.values.values)
           paymentCounters[period][index] += 1
         }
       }
@@ -298,13 +298,13 @@ function processButtonData (
             lastPayment: payment.timestamp
           },
           total: {
-            revenue: payment.values,
+            revenue: payment.values.values,
             payments: 1
           }
         }
       } else {
         const buttonData = buttonDataAccumulators[period][button.id]
-        buttonData.total.revenue = sumQuoteValues(buttonData.total.revenue, payment.values)
+        buttonData.total.revenue = sumQuoteValues(buttonData.total.revenue, payment.values.values)
         buttonData.total.payments += 1
         buttonData.displayData.lastPayment = Math.max(
           buttonData.displayData.lastPayment ?? 0,

--- a/redis/index.ts
+++ b/redis/index.ts
@@ -4,7 +4,7 @@ import { TransactionsWithPaybuttonsAndPrices } from 'services/transactionService
 import { fetchUsersForAddress } from 'services/userService'
 import { cacheBalanceForAddress, clearBalanceCache, getBalanceForAddress, updateBalanceCacheFromTx } from './balanceCache'
 import { clearDashboardCache, getUserDashboardData } from './dashboardCache'
-import { appendPaybuttonToAddressesCache, cacheGroupedPayments, cacheManyTxs, generateAndCacheGroupedPaymentsAndInfoForAddress, getCachedPaymentsCountForUser, getPaymentList, initPaymentCache, removePaybuttonToAddressesCache } from './paymentCache'
+import { appendPaybuttonToAddressesCache, cacheGroupedPayments, cacheManyTxs, generateAndCacheGroupedPaymentsAndInfoForAddress, getCachedPaymentsCountForUser, getCachedPaymentsForUserWithPagination, getPaymentList, initPaymentCache, removePaybuttonToAddressesCache } from './paymentCache'
 import { DashboardData, Payment } from './types'
 import { Address } from '@prisma/client'
 
@@ -130,5 +130,9 @@ export class CacheGet {
     return await this.executeCall(userId, 'paymentsCount', async () => {
       return await getCachedPaymentsCountForUser(userId)
     })
+  }
+  
+  static async paymentListPaginated (userId: string, page: number, pageSize: number): Promise<Payment[]> {
+    return await getCachedPaymentsForUserWithPagination(userId, page, pageSize)
   }
 }

--- a/redis/index.ts
+++ b/redis/index.ts
@@ -4,7 +4,7 @@ import { TransactionsWithPaybuttonsAndPrices } from 'services/transactionService
 import { fetchUsersForAddress } from 'services/userService'
 import { cacheBalanceForAddress, clearBalanceCache, getBalanceForAddress, updateBalanceCacheFromTx } from './balanceCache'
 import { clearDashboardCache, getUserDashboardData } from './dashboardCache'
-import { appendPaybuttonToAddressesCache, cacheGroupedPayments, cacheManyTxs, generateAndCacheGroupedPaymentsAndInfoForAddress, getCachedPaymentsCountForUser, getCachedPaymentsForUserWithPagination, getPaymentList, initPaymentCache, removePaybuttonToAddressesCache } from './paymentCache'
+import { appendPaybuttonToAddressesCache, cacheGroupedPayments, cacheManyTxs, generateAndCacheGroupedPaymentsAndInfoForAddress, getCachedPaymentsCountForUser, getPaymentList, initPaymentCache, removePaybuttonToAddressesCache } from './paymentCache'
 import { DashboardData, Payment } from './types'
 import { Address } from '@prisma/client'
 
@@ -130,9 +130,5 @@ export class CacheGet {
     return await this.executeCall(userId, 'paymentsCount', async () => {
       return await getCachedPaymentsCountForUser(userId)
     })
-  }
-
-  static async paymentListPaginated (userId: string, page: number, pageSize: number, orderDesc: boolean): Promise<Payment[]> {
-    return await getCachedPaymentsForUserWithPagination(userId, page, pageSize, orderDesc)
   }
 }

--- a/redis/index.ts
+++ b/redis/index.ts
@@ -131,8 +131,8 @@ export class CacheGet {
       return await getCachedPaymentsCountForUser(userId)
     })
   }
-  
-  static async paymentListPaginated (userId: string, page: number, pageSize: number): Promise<Payment[]> {
-    return await getCachedPaymentsForUserWithPagination(userId, page, pageSize)
+
+  static async paymentListPaginated (userId: string, page: number, pageSize: number, orderDesc: boolean): Promise<Payment[]> {
+    return await getCachedPaymentsForUserWithPagination(userId, page, pageSize, orderDesc)
   }
 }

--- a/redis/paymentCache.ts
+++ b/redis/paymentCache.ts
@@ -140,7 +140,10 @@ export const generatePaymentFromTx = async (tx: TransactionsWithPaybuttonsAndPri
   }
   return {
     timestamp: tx.timestamp,
-    values,
+    values: {
+      values,
+      amount: tx.amount
+    },
     networkId: tx.address.networkId,
     hash: tx.hash,
     buttonDisplayDataList
@@ -165,7 +168,7 @@ export const generateAndCacheGroupedPaymentsAndInfoForAddress = async (address: 
     paymentCount
   }
 
-  paymentList = paymentList.filter((p) => p.values.usd > new Prisma.Decimal(0))
+  paymentList = paymentList.filter((p) => p.values.values.usd > new Prisma.Decimal(0))
   const groupedPayments = getPaymentsByWeek(address.address, paymentList)
   return {
     groupedPayments,
@@ -249,7 +252,7 @@ export const cacheManyTxs = async (txs: TransactionsWithPaybuttonsAndPrices[]): 
   const zero = new Prisma.Decimal(0)
   for (const tx of txs.filter(tx => tx.amount > zero)) {
     const payment = await generatePaymentFromTx(tx)
-    if (payment.values.usd !== new Prisma.Decimal(0)) {
+    if (payment.values.values.usd !== new Prisma.Decimal(0)) {
       const paymentsGroupedByKey = getPaymentsByWeek(tx.address.address, [payment])
       void await cacheGroupedPaymentsAppend(paymentsGroupedByKey)
     }

--- a/redis/paymentCache.ts
+++ b/redis/paymentCache.ts
@@ -67,7 +67,6 @@ export const getCachedPaymentsForUserWithPagination = async (
       currentIndex++
 
       if (currentIndex >= endIndex) {
-        console.log('break')
         break
       }
     }

--- a/redis/paymentCache.ts
+++ b/redis/paymentCache.ts
@@ -131,7 +131,8 @@ export const generatePaymentFromTx = async (tx: TransactionsWithPaybuttonsAndPri
       (conn) => {
         return {
           name: conn.paybutton.name,
-          id: conn.paybutton.id
+          id: conn.paybutton.id,
+          providerUserId: conn.paybutton.providerUserId
         }
       }
     )

--- a/redis/paymentCache.ts
+++ b/redis/paymentCache.ts
@@ -32,65 +32,6 @@ export const getPaymentList = async (userId: string): Promise<Payment[]> => {
   return await getCachedPaymentsForUser(userId)
 }
 
-export const getCachedPaymentsForUserWithPagination = async (
-  userId: string,
-  page: number,
-  pageSize: number,
-  orderDesc: boolean
-): Promise<Payment[]> => {
-  const weekKeys = await getCachedWeekKeysForUser(userId)
-
-  const userButtonIds: string[] = (await fetchPaybuttonArrayByUserId(userId))
-    .map(p => p.id)
-
-  const allPayments: Payment[] = []
-  const startIndex = page * pageSize
-  const endIndex = Number(startIndex) + Number(pageSize)
-  let currentIndex = 0
-  const sortedWeekKeys = sortByDate(weekKeys, (orderDesc ? 'descending' : 'ascending'))
-  for (const weekKey of sortedWeekKeys) {
-    const paymentsString = await redis.get(weekKey)
-
-    if (paymentsString === null) {
-      throw new Error(RESPONSE_MESSAGES.CACHED_PAYMENT_NOT_FOUND_404.message)
-    }
-
-    const weekPayments: Payment[] = JSON.parse(paymentsString)
-
-    for (const payment of weekPayments) {
-      if (currentIndex >= startIndex && currentIndex < endIndex) {
-        payment.buttonDisplayDataList = payment.buttonDisplayDataList.filter(d =>
-          userButtonIds.includes(d.id)
-        )
-        allPayments.push(payment)
-      }
-      currentIndex++
-
-      if (currentIndex >= endIndex) {
-        break
-      }
-    }
-    if (currentIndex >= endIndex) {
-      break
-    }
-  }
-  return allPayments
-}
-
-function sortByDate (keys: string[], order: 'ascending' | 'descending'): string[] {
-  const getDateValue = (str: string): number => {
-    const parts = str.split(':')
-    const year = parseInt(parts[parts.length - 2], 10)
-    const week = parseInt(parts[parts.length - 1], 10)
-    return year * 100 + week
-  }
-
-  return keys.sort((a, b) => {
-    const comparison = getDateValue(a) - getDateValue(b)
-    return order === 'ascending' ? comparison : -comparison
-  })
-}
-
 const getCachedWeekKeysForAddress = async (addressString: string): Promise<string[]> => {
   return await redis.keys(`${addressString}:payments:*`)
 }

--- a/redis/types.ts
+++ b/redis/types.ts
@@ -1,3 +1,4 @@
+import { Decimal } from '@prisma/client/runtime/library'
 import { QuoteValues } from 'services/priceService'
 
 export interface ChartColor {
@@ -44,10 +45,14 @@ export interface ButtonDisplayData {
   lastPayment?: number
   providerUserId?: string
 }
+export interface AmountData {
+  values: QuoteValues
+  amount: Decimal
+}
 
 export interface Payment {
   timestamp: number
-  values: QuoteValues
+  values: AmountData
   networkId: number
   hash: string
   buttonDisplayDataList: ButtonDisplayData[]

--- a/redis/types.ts
+++ b/redis/types.ts
@@ -42,6 +42,7 @@ export interface ButtonDisplayData {
   isXec?: boolean
   isBch?: boolean
   lastPayment?: number
+  providerUserId?: string
 }
 
 export interface Payment {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -11,7 +11,7 @@ import { CacheSet } from 'redis/index'
 import { SimplifiedTransaction } from 'ws-service/types'
 import { OpReturnData, parseAddress } from 'utils/validators'
 import { generatePaymentFromTx } from 'redis/paymentCache'
-import { Payment } from 'redis/types'
+import { ButtonDisplayData, Payment } from 'redis/types'
 
 export async function getTransactionValue (transaction: TransactionWithPrices | TransactionsWithPaybuttonsAndPrices): Promise<QuoteValues> {
   const ret: QuoteValues = {
@@ -707,7 +707,7 @@ export async function getPaymentsByUserIdOrderedByButtonName (
         ret.cad = ret.cad.plus(p.priceValue * tx.amount)
       }
     }
-    const buttonDisplayDataList: Array<{ name: string, id: string, providerUserId: string}> = []
+    const buttonDisplayDataList: ButtonDisplayData[] = []
     buttonDisplayDataList.push({
       name: tx.paybuttonName,
       id: tx.paybuttonId,
@@ -716,7 +716,10 @@ export async function getPaymentsByUserIdOrderedByButtonName (
     if (tx.amount > 0) {
       payments.push({
         timestamp: tx.timestamp,
-        values: ret,
+        values: {
+          values: ret,
+          amount: tx.amount
+        },
         networkId: tx.networkId,
         hash: tx.hash,
         buttonDisplayDataList

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -710,16 +710,18 @@ export async function getPaymentsByUserIdOrderedByButtonName (
     const buttonDisplayDataList: Array<{ name: string, id: string, providerUserId: string}> = []
     buttonDisplayDataList.push({
       name: tx.paybuttonName,
-      id: tx.paybuttonName,
+      id: tx.paybuttonId,
       providerUserId: tx.paybuttonProviderUserId
     })
-    payments.push({
-      timestamp: tx.timestamp,
-      values: ret,
-      networkId: tx.networkId,
-      hash: tx.hash,
-      buttonDisplayDataList
-    })
+    if (tx.amount > 0) {
+      payments.push({
+        timestamp: tx.timestamp,
+        values: ret,
+        networkId: tx.networkId,
+        hash: tx.hash,
+        buttonDisplayDataList
+      })
+    }
   })
 
   return payments
@@ -736,22 +738,19 @@ export async function fetchAllPaymentsByUserIdWithPagination (
 
   let orderByQuery
   if (orderBy !== undefined && orderBy !== '') {
-    if (orderBy.includes('.')) {
-      const [relation, property] = orderBy.split('.')
+    if (orderBy === 'values') {
       orderByQuery = {
-        [relation]: {
-          [property]: orderDescString
+        amount: orderDescString
+      }
+    } else if (orderBy === 'networkId') {
+      orderByQuery = {
+        address: {
+          networkId: orderDescString
         }
       }
     } else {
-      if (orderBy === 'values') {
-        orderByQuery = {
-          amount: orderDescString
-        }
-      } else {
-        orderByQuery = {
-          [orderBy]: orderDescString
-        }
+      orderByQuery = {
+        [orderBy]: orderDescString
       }
     }
   } else {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -124,23 +124,6 @@ const transactionsWithPaybuttonsAndPrices = Prisma.validator<Prisma.TransactionD
 
 export type TransactionsWithPaybuttonsAndPrices = Prisma.TransactionGetPayload<typeof transactionsWithPaybuttonsAndPrices>
 
-export const transactionWithAddressAndPricesAndButtons = Prisma.validator<Prisma.TransactionDefaultArgs>()({
-  include: {
-    address: {
-      include: {
-        paybuttons: {
-          include: {
-            paybutton: true // Include full Paybutton data
-          }
-        }
-      }
-    },
-    prices: true // Include related price data
-  }
-})
-
-export type TransactionWithAddressAndPricesAndButtons = Prisma.TransactionGetPayload<typeof transactionWithAddressAndPricesAndButtons>
-
 export async function fetchTransactionsByAddressList (
   addressIdList: string[],
   networkIdsListFilter?: number[]
@@ -738,7 +721,11 @@ export async function fetchAllPaymentsByUserIdWithPagination (
   orderDesc = true
 ): Promise<Payment[]> {
   const orderDescString: Prisma.SortOrder = orderDesc ? 'desc' : 'asc'
-
+  if (orderBy === 'buttonDisplayDataList') {
+    return await getPaymentsByUserIdOrderedByButtonName(
+      userId, page, pageSize, orderDesc
+    )
+  }
   let orderByQuery
   if (orderBy !== undefined && orderBy !== '') {
     if (orderBy === 'values') {
@@ -791,26 +778,4 @@ export async function fetchAllPaymentsByUserIdWithPagination (
     }
   }
   return transformedData
-}
-
-export async function fetchAllPaymentsByUserId (
-  userId: string,
-  page: number,
-  pageSize: number,
-  orderBy?: string,
-  orderDesc = true
-): Promise<Payment[]> {
-  if (orderBy === 'buttonDisplayDataList') {
-    return await getPaymentsByUserIdOrderedByButtonName(
-      userId, page, pageSize, orderDesc
-    )
-  } else {
-    return await fetchAllPaymentsByUserIdWithPagination(
-      userId,
-      page,
-      pageSize,
-      orderBy,
-      orderDesc
-    )
-  }
 }

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -613,7 +613,7 @@ export async function getPaymentsByUserIdOrderedByButtonName (
         p.id AS paybuttonId, 
         p.name AS paybuttonName, 
         p.providerUserId AS paybuttonProviderUserId,
-        a.networkId as newtworkId,
+        a.networkId as networkId,
         JSON_ARRAYAGG(
           JSON_OBJECT(
             'priceId', pb.id,
@@ -646,7 +646,7 @@ export async function getPaymentsByUserIdOrderedByButtonName (
         p.id AS paybuttonId, 
         p.name AS paybuttonName, 
         p.providerUserId AS paybuttonProviderUserId,
-        a.networkId as newtworkId,
+        a.networkId as networkId,
         JSON_ARRAYAGG(
           JSON_OBJECT(
             'priceId', pb.id,

--- a/tests/integration-tests/api.test.ts
+++ b/tests/integration-tests/api.test.ts
@@ -1312,7 +1312,12 @@ describe('GET /api/payments', () => {
     headers: {
       'Content-Type': 'application/json'
     },
-    query: {}
+    query: {
+      page: 0,
+      pageSize: 10,
+      orderBy: 'timestamp',
+      orderDesc: false
+    }
   }
 
   it('Should return HTTP 200', async () => {


### PR DESCRIPTION
Related to #741 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Added server side pagination to payments page, before the payments where fetched all at once in a single api call and the pagination was made in the client, now the client will fetch payments using page and pageSize parameters. 
Changed Pagination to fetch tx data from database instead of cache, because it was too complex to paginate and order getting data from cache.

Test plan
---
Run server and check payments page pagination, try to change pageSize and pass between the pages 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
