### PR TITLE
feat: wrap mailer on global

### DIFF
--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -6,7 +6,7 @@ import { EMPTY_OP_RETURN, OpReturnData, parseTriggerPostData } from 'utils/valid
 import { BroadcastTxData } from 'ws-service/types'
 import { fetchPaybuttonById, fetchPaybuttonWithTriggers } from './paybuttonService'
 import config from 'config'
-import { MAIL_FROM, MAIL_HTML_REPLACER, MAIL_SUBJECT, MAIL_TRANSPORTER, SendEmailParameters } from 'constants/mail'
+import { MAIL_FROM, MAIL_HTML_REPLACER, MAIL_SUBJECT, getMailerTransporter, SendEmailParameters } from 'constants/mail'
 
 const triggerWithPaybutton = Prisma.validator<Prisma.PaybuttonTriggerArgs>()({
   include: { paybutton: true }
@@ -339,7 +339,7 @@ async function sendEmailForTrigger (trigger: TriggerWithPaybutton, sendEmailPara
   try {
     const user = await fetchUserFromTriggerId(trigger.id)
     if (user.emailCredits > 0) {
-      const response = await MAIL_TRANSPORTER.sendMail(mailOptions)
+      const response = await getMailerTransporter().sendMail(mailOptions)
       logData = {
         email: trigger.emails,
         responseData: response.response


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Wraps up the mail transporter in the global var in order to avoid reconnecting to our mail host many times (during development).

Test plan
---
When running the dev environment in **master**, we would get many logs related to the mailer authenticating. Updating a file or refreshing a page would trigger all again.

In this branch, this should not be the case: refreshing a page or changing a file shouldn't result in these logs being shown again. Nonetheless, email triggers should work normally.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
