### PR TITLE
#896 fix/dashboard issues

### DIFF
--- a/redis/dashboardCache.ts
+++ b/redis/dashboardCache.ts
@@ -5,7 +5,7 @@ import { Prisma } from '@prisma/client'
 import moment, { DurationInputArg2 } from 'moment'
 import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 import { QuoteValues } from 'services/priceService'
-import { getOldestTxForUser } from 'services/transactionService'
+import { getOldestPositiveTxForUser } from 'services/transactionService'
 
 // USERID:dashboard
 const getDashboardSummaryKey = (userId: string): string => {
@@ -41,7 +41,7 @@ const getChartData = function (n: number, periodString: string, dataArray: numbe
 }
 
 const getNumberOfMonths = async function (userId: string): Promise<number> {
-  const oldestTx = await getOldestTxForUser(userId)
+  const oldestTx = await getOldestPositiveTxForUser(userId)
   if (oldestTx === null) return 0
   const oldestDate = moment(oldestTx.timestamp * 1000)
   const today = moment()

--- a/redis/dashboardCache.ts
+++ b/redis/dashboardCache.ts
@@ -45,7 +45,7 @@ const getNumberOfMonths = async function (userId: string): Promise<number> {
   if (oldestTx === null) return 0
   const oldestDate = moment(oldestTx.timestamp * 1000)
   const today = moment()
-  const floatDiff = today.diff(oldestDate, 'months', true)
+  const floatDiff = today.diff(oldestDate.startOf('month'), 'months', true)
   return Math.ceil(floatDiff)
 }
 

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -576,7 +576,7 @@ export const getTransactionValueInCurrency = (transaction: TransactionWithAddres
 
   return result[currency]
 }
-export async function getOldestTxForUser (userId: string): Promise<Transaction | null> {
+export async function getOldestPositiveTxForUser (userId: string): Promise<Transaction | null> {
   return await prisma.transaction.findFirst({
     where: {
       address: {
@@ -585,6 +585,9 @@ export async function getOldestTxForUser (userId: string): Promise<Transaction |
             userId
           }
         }
+      },
+      amount: {
+        gt: 0
       }
     },
     orderBy: { timestamp: 'asc' }


### PR DESCRIPTION
Related to #896

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Dashboard on master was back to showing data, but it was all wrong. Payments would appear one month after they real date, and the view for **ALL** payments would include months with no payments in the beginning. This PR fixes these issues.


Test plan
---
On **master**:
1. Take any address with some payments, and check how on the dashboard they would be displaced: shifted one to the right, i.e, a payment from september would appear in october, for example.
2. Check how the **ALL** view in the dev user would include the months Dec2020 and Jan2021, with no payments. That is useless info that shouldn't be there, **ALL** should start from the first payment.

Then checkout this branch, run `yarn docker cr` to reset the cache and try it again — all the above should be fixed.



Remarks
---
I left a WIP comment to do the accounting for timezone — after we have that in the DB, labeling the payments in a tz-aware manner should be as simple as including the timezone info there.
