### PR TITLE
feat: merge stdout and stderr on logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - "5000:5000"
     volumes:
       - .:/home/node/src
-      - ./logs:/home/node/.pm2/logs
     command: bash ./scripts/paybutton-server-start.sh
   db:
     container_name: paybutton-db

--- a/scripts/paybutton-server-start.sh
+++ b/scripts/paybutton-server-start.sh
@@ -13,14 +13,14 @@ yarn || exit 1
 rm logs/*
 if [ "$ENVIRONMENT" = "production" ]; then
     yarn prisma migrate deploy || exit 1
-    pm2 start yarn --time --interpreter ash --name jobs -- initJobs || exit 1
-    pm2 start yarn --time --interpreter ash --name WSServer -- initWSServer || exit 1
-    pm2 start yarn --time --interpreter ash --name next -- prod || exit 1
+    pm2 start yarn --time --interpreter ash --name jobs --output logs/jobs.log --error logs/jobs.log -- initJobs || exit 1
+    pm2 start yarn --time --interpreter ash --name WSServer --output logs/ws-server.log --error logs/ws-server.log -- initWSServer || exit 1
+    pm2 start yarn --time --interpreter ash --name next --output logs/next.log --error logs/next.log -- prod || exit 1
 else
     yarn prisma migrate dev || exit 1
     yarn prisma db seed || exit 1
-    pm2 start yarn --time --interpreter ash --name jobs -- initJobs || exit 1
-    pm2 start yarn --time --interpreter ash --name WSServer -- initWSServer || exit 1
-    pm2 start yarn --time --interpreter ash --name next -- dev || exit 1
+    pm2 start yarn --time --interpreter ash --name jobs --output logs/jobs.log --error logs/jobs.log -- initJobs || exit 1
+    pm2 start yarn --time --interpreter ash --name WSServer --output logs/ws-server.log --error logs/ws-server.log -- initWSServer || exit 1
+    pm2 start yarn --time --interpreter ash --name next --output logs/next.log --error logs/next.log -- dev || exit 1
 fi
 pm2 logs next


### PR DESCRIPTION

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Makes so that logs are not stored with errors separate from everything else (as is the default in `pm2`), which IMO has always made debugging a little more complex than it should be.


Test plan
---
Reset the containers, make sure everything starts normally and that the `logs/` don't contain two logs of each service anymore (e.g. `logs/jobs-out.log` and `logs/jobs-error.log`, but only one `logs/jobs.log`)

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
