### PR TITLE
fix: add timezone to csv

### DIFF
--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -124,7 +124,11 @@ export default function Button (props: PaybuttonProps): React.ReactElement {
       if (!isCurrencyEmptyOrUndefined(currency)) {
         url += `&network=${currency}`
       }
-      const response = await fetch(url)
+      const response = await fetch(url, {
+        headers: {
+          Timezone: moment.tz.guess()
+        }
+      })
 
       if (!response.ok) {
         throw new Error('Failed to download CSV')


### PR DESCRIPTION
Related to #911 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Added timezone logic to CSV creation


Test plan
---
Run the server with `docker compose up`
download CSV it should display the date according to the timezone set.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
