### PR TITLE
feat: broadcast input addresses

### DIFF
--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -356,7 +356,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
     }
   }
 
-  private getInputAddresses (transaction: Tx_InNode): string[] {
+  private getSortedInputAddresses (transaction: Tx_InNode): string[] {
     const addressValueMap = new Map<string, number>()
 
     transaction.inputs.forEach((inp) => {
@@ -399,7 +399,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
         console.log(`${this.CHRONIK_MSG_PREFIX}: [${msg.msgType}] ${msg.txid}`)
         const transaction = await this.chronik.tx(msg.txid)
         const addressesWithTransactions = await this.getAddressesForTransaction(transaction)
-        const inputAddresses = this.getInputAddresses(transaction)
+        const inputAddresses = this.getSortedInputAddresses(transaction)
         for (const addressWithTransaction of addressesWithTransactions) {
           const { created, tx } = await createTransaction(addressWithTransaction.transaction)
           if (tx !== undefined) {
@@ -421,7 +421,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
     }
   }
 
-  private broadcastIncomingTx (addressString: string, createdTx: TransactionWithAddressAndPrices, inputAddresses: Array<string | undefined>): BroadcastTxData {
+  private broadcastIncomingTx (addressString: string, createdTx: TransactionWithAddressAndPrices, inputAddresses: string[]): BroadcastTxData {
     const broadcastTxData: BroadcastTxData = {} as BroadcastTxData
     broadcastTxData.address = addressString
     broadcastTxData.messageType = 'NewTx'
@@ -449,7 +449,7 @@ export class ChronikBlockchainClient implements BlockchainClient {
     }
     for (const transaction of blockTxsToSync) {
       const addressesWithTransactions = await this.getAddressesForTransaction(transaction)
-      const inputAddresses = transaction.inputs.map(inp => outputScriptToAddress(this.networkSlug, inp.outputScript))
+      const inputAddresses = this.getSortedInputAddresses(transaction)
 
       for (const addressWithTransaction of addressesWithTransactions) {
         const { created, tx } = await createTransaction(addressWithTransaction.transaction)

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -44,7 +44,7 @@ export function getSimplifiedTransactions (transactionsToPersist: TransactionWit
   return simplifiedTransactions
 }
 
-export function getSimplifiedTrasaction (tx: TransactionWithAddressAndPrices): SimplifiedTransaction {
+export function getSimplifiedTrasaction (tx: TransactionWithAddressAndPrices, inputAddresses?: Array<string | undefined>): SimplifiedTransaction {
   const {
     hash,
     amount,
@@ -64,7 +64,8 @@ export function getSimplifiedTrasaction (tx: TransactionWithAddressAndPrices): S
     address: address.address,
     timestamp,
     message: parsedOpReturn?.message ?? '',
-    rawMessage: parsedOpReturn?.rawMessage ?? ''
+    rawMessage: parsedOpReturn?.rawMessage ?? '',
+    inputAddresses
   }
 
   return simplifiedTransaction

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -44,7 +44,7 @@ export function getSimplifiedTransactions (transactionsToPersist: TransactionWit
   return simplifiedTransactions
 }
 
-export function getSimplifiedTrasaction (tx: TransactionWithAddressAndPrices, inputAddresses?: Array<string | undefined>): SimplifiedTransaction {
+export function getSimplifiedTrasaction (tx: TransactionWithAddressAndPrices, inputAddresses?: string[]): SimplifiedTransaction {
   const {
     hash,
     amount,
@@ -65,7 +65,7 @@ export function getSimplifiedTrasaction (tx: TransactionWithAddressAndPrices, in
     timestamp,
     message: parsedOpReturn?.message ?? '',
     rawMessage: parsedOpReturn?.rawMessage ?? '',
-    inputAddresses
+    inputAddresses: inputAddresses ?? []
   }
 
   return simplifiedTransaction

--- a/ws-service/types.ts
+++ b/ws-service/types.ts
@@ -17,6 +17,7 @@ export interface SimplifiedTransaction {
   timestamp: number
   address: string
   rawMessage: string
+  inputAddresses?: Array<string | undefined>
 }
 
 export interface CreateQuoteAndShiftData {

--- a/ws-service/types.ts
+++ b/ws-service/types.ts
@@ -17,7 +17,7 @@ export interface SimplifiedTransaction {
   timestamp: number
   address: string
   rawMessage: string
-  inputAddresses?: Array<string | undefined>
+  inputAddresses: string[]
 }
 
 export interface CreateQuoteAndShiftData {


### PR DESCRIPTION
Related to [#916]([https://github.com/PayButton/paybutton-server/issues/916])

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Send input addresses in broadcast incoming tx data, this will be used in paybutton client, this will make input addresses available on client callbacks 


Test plan
---
- Run server with docker compose up
- Run client in this PR https://github.com/PayButton/paybutton/pull/445
- Test if inputs are being returned as a param (inputAddresses) of tx object in onSuccess/OnTransaction callbacks

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
