### PR TITLE
Feat/export csv payments

### DIFF
--- a/pages/api/payments/download/index.ts
+++ b/pages/api/payments/download/index.ts
@@ -24,7 +24,7 @@ export interface PaymentFileData {
   rate: number
   transactionId: string
   currency: string
-  address: string
+  address?: string
 }
 
 export interface FormattedPaymentFileData {
@@ -33,7 +33,7 @@ export interface FormattedPaymentFileData {
   value: string
   rate: string
   transactionId: string
-  address: string
+  address?: string
 }
 
 export function isCurrencyValid (currency: SupportedQuotesType): boolean {

--- a/pages/api/payments/download/index.ts
+++ b/pages/api/payments/download/index.ts
@@ -1,0 +1,160 @@
+import moment from 'moment-timezone'
+import {
+  PRICE_API_DATE_FORMAT,
+  RESPONSE_MESSAGES,
+  DEFAULT_PAYBUTTON_CSV_FILE_DELIMITER,
+  SUPPORTED_QUOTES,
+  SupportedQuotesType,
+  SUPPORTED_QUOTES_FROM_ID,
+  PAYBUTTON_TRANSACTIONS_FILE_HEADERS,
+  DECIMALS
+} from 'constants/index'
+import { fetchAllPaymentsByUserId } from 'services/transactionService'
+import { streamToCSV } from 'utils/files'
+import { setSession } from 'utils/setSession'
+import { NextApiResponse } from 'next'
+import { fetchUserProfileFromId } from 'services/userService'
+import { Prisma } from '@prisma/client'
+import { Payment } from 'redis/types'
+
+export interface PaymentFileData {
+  amount: Prisma.Decimal
+  date: moment.Moment
+  value: number
+  rate: number
+  transactionId: string
+  currency: string
+  address: string
+}
+
+export interface FormattedPaymentFileData {
+  amount: string
+  date: string
+  value: string
+  rate: string
+  transactionId: string
+  address: string
+}
+
+export function isCurrencyValid (currency: SupportedQuotesType): boolean {
+  return SUPPORTED_QUOTES.includes(currency)
+}
+
+const getPaymentsFileData = (payment: Payment, currency: SupportedQuotesType, timezone: string): PaymentFileData => {
+  const { values, hash, timestamp, address } = payment
+  const amount = values.amount
+  const value = Number(values.values[currency])
+  const date = moment.tz(timestamp * 1000, timezone)
+  const rate = value / Number(amount)
+
+  return {
+    amount,
+    date,
+    transactionId: hash,
+    value,
+    rate,
+    currency,
+    address
+  }
+}
+
+const formatPaymentsFileData = (data: PaymentFileData): FormattedPaymentFileData => {
+  const {
+    amount,
+    date,
+    value,
+    rate,
+    currency
+  } = data
+
+  return {
+    ...data,
+    amount: amount.toFixed(DECIMALS[currency]),
+    date: date.format(PRICE_API_DATE_FORMAT),
+    value: value.toFixed(2),
+    rate: rate.toFixed(14)
+  }
+}
+
+const formatNumberHeaders = (headers: string[], currency: string): string[] => {
+  return headers.map(h => h === PAYBUTTON_TRANSACTIONS_FILE_HEADERS.value ? h + ` (${currency.toUpperCase()})` : h)
+}
+
+const sortPaymentsByNetworkId = (payments: Payment[]): Payment[] => {
+  const groupedByNetworkIdPayments = payments.reduce<Record<number, Payment[]>>((acc, payment) => {
+    const networkId = payment.networkId
+    if (acc[networkId] === undefined || acc[networkId] === null) {
+      acc[networkId] = []
+    }
+    acc[networkId].push(payment)
+    return acc
+  }, {})
+
+  return Object.values(groupedByNetworkIdPayments).reduce(
+    (acc, curr) => acc.concat(curr),
+    []
+  )
+}
+
+const downloadPaymentsFileByUserId = async (
+  userId: string,
+  res: NextApiResponse,
+  currency: SupportedQuotesType,
+  timezone: string): Promise<void> => {
+  const payments = await fetchAllPaymentsByUserId(userId)
+  const sortedPayments = await sortPaymentsByNetworkId(payments)
+  const mappedPaymentsData = sortedPayments.map(payment => {
+    const data = getPaymentsFileData(payment, currency, timezone)
+    return formatPaymentsFileData(data)
+  })
+  const headers = Object.keys(PAYBUTTON_TRANSACTIONS_FILE_HEADERS)
+  const humanReadableHeaders = formatNumberHeaders(Object.values(PAYBUTTON_TRANSACTIONS_FILE_HEADERS), currency)
+
+  streamToCSV(
+    mappedPaymentsData,
+    headers,
+    DEFAULT_PAYBUTTON_CSV_FILE_DELIMITER,
+    res,
+    humanReadableHeaders
+  )
+}
+
+export default async (req: any, res: any): Promise<void> => {
+  try {
+    if (req.method !== 'GET') {
+      throw new Error(RESPONSE_MESSAGES.METHOD_NOT_ALLOWED.message)
+    }
+
+    await setSession(req, res)
+
+    const userId = req.session.userId
+    const user = await fetchUserProfileFromId(userId)
+
+    let quoteId: number
+    if (req.query.currency === undefined || req.query.currency === '' || Number.isNaN(req.query.currency)) {
+      quoteId = user.preferredCurrencyId
+    } else {
+      quoteId = req.query.currency as number
+    }
+    const quoteSlug = SUPPORTED_QUOTES_FROM_ID[quoteId]
+    const userReqTimezone = req.headers.timezone as string
+    const userPreferredTimezone = user?.preferredTimezone
+    const timezone = userPreferredTimezone !== '' ? userPreferredTimezone : userReqTimezone
+
+    res.setHeader('Content-Type', 'text/csv')
+    await downloadPaymentsFileByUserId(userId, res, quoteSlug, timezone)
+  } catch (error: any) {
+    switch (error.message) {
+      case RESPONSE_MESSAGES.METHOD_NOT_ALLOWED.message:
+        res.status(RESPONSE_MESSAGES.METHOD_NOT_ALLOWED.statusCode)
+          .json(RESPONSE_MESSAGES.METHOD_NOT_ALLOWED)
+        break
+      case RESPONSE_MESSAGES.MISSING_PRICE_FOR_TRANSACTION_400.message:
+        res.status(RESPONSE_MESSAGES.MISSING_PRICE_FOR_TRANSACTION_400.statusCode)
+          .json(RESPONSE_MESSAGES.MISSING_PRICE_FOR_TRANSACTION_400)
+        break
+      default:
+        res.status(500).json({ message: error.message })
+    }
+  }
+}

--- a/pages/payments/index.tsx
+++ b/pages/payments/index.tsx
@@ -183,8 +183,7 @@ export default function Payments ({ user, userId }: PaybuttonsProps): React.Reac
         throw new Error('Failed to download CSV')
       }
 
-      const fileName = `${userId}-all-payments`
-
+      const fileName = `${isCurrencyEmptyOrUndefined(currency) ? 'all' : `${currency.toLowerCase()}`}-transactions`
       const blob = await response.blob()
       const downloadUrl = window.URL.createObjectURL(blob)
       const link = document.createElement('a')

--- a/pages/payments/index.tsx
+++ b/pages/payments/index.tsx
@@ -54,7 +54,7 @@ interface PaybuttonsProps {
 export default function Payments ({ user, userId }: PaybuttonsProps): React.ReactElement {
   const timezone = user?.userProfile.preferredTimezone === '' ? moment.tz.guess() : user?.userProfile?.preferredTimezone
   const [selectedCurrencyCSV, setSelectedCurrencyCSV] = useState<string>('')
-  const [paybuttonNetworks, setPaybuttonNetworks] = useState<number[]>([])
+  const [paybuttonNetworks, setPaybuttonNetworks] = useState<Set<number>>(new Set())
 
   const fetchPaybuttons = async (): Promise<any> => {
     const res = await fetch(`/api/paybuttons?userId=${user?.userProfile.id}`, {
@@ -66,9 +66,10 @@ export default function Payments ({ user, userId }: PaybuttonsProps): React.Reac
   }
   const getDataAndSetUpCurrencyCSV = async (): Promise<void> => {
     const paybuttons = await fetchPaybuttons()
-    const networkIds: number[] = []
+    const networkIds: Set<number> = new Set()
+
     paybuttons.forEach((p: { addresses: any[] }) => {
-      return p.addresses.forEach((c: { address: { networkId: number } }) => networkIds.push(c.address.networkId))
+      return p.addresses.forEach((c: { address: { networkId: number } }) => networkIds.add(c.address.networkId))
     })
 
     setPaybuttonNetworks(networkIds)
@@ -210,7 +211,7 @@ export default function Payments ({ user, userId }: PaybuttonsProps): React.Reac
     <>
       <TopBar title="Payments" user={user?.stUser?.email} />
       <div style={{ display: 'flex', alignItems: 'center', gap: '10px', justifyContent: 'right' }}>
-      {new Set(paybuttonNetworks).size > 1
+      {paybuttonNetworks.size > 1
         ? (
               <select
                 id='export-btn'
@@ -224,7 +225,7 @@ export default function Payments ({ user, userId }: PaybuttonsProps): React.Reac
                   All Currencies
                 </option>
                 {Object.entries(NETWORK_TICKERS_FROM_ID)
-                  .filter(([id]) => paybuttonNetworks.includes(Number(id)))
+                  .filter(([id]) => paybuttonNetworks.has(Number(id)))
                   .map(([id, ticker]) => (
                     <option key={id} value={ticker}>
                       {ticker.toUpperCase()}

--- a/redis/paymentCache.ts
+++ b/redis/paymentCache.ts
@@ -87,7 +87,8 @@ export const generatePaymentFromTx = async (tx: TransactionsWithPaybuttonsAndPri
     },
     networkId: tx.address.networkId,
     hash: tx.hash,
-    buttonDisplayDataList
+    buttonDisplayDataList,
+    address: tx.address.address
   }
 }
 

--- a/redis/types.ts
+++ b/redis/types.ts
@@ -56,6 +56,7 @@ export interface Payment {
   networkId: number
   hash: string
   buttonDisplayDataList: ButtonDisplayData[]
+  address: string
 }
 
 export interface ButtonData {

--- a/redis/types.ts
+++ b/redis/types.ts
@@ -56,7 +56,7 @@ export interface Payment {
   networkId: number
   hash: string
   buttonDisplayDataList: ButtonDisplayData[]
-  address: string
+  address?: string
 }
 
 export interface ButtonData {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -801,3 +801,33 @@ export async function fetchAllPaymentsByUserIdWithPagination (
   }
   return transformedData
 }
+
+export async function fetchAllPaymentsByUserId (
+  userId: string
+): Promise<Payment[]> {
+  const transactions = await prisma.transaction.findMany({
+    where: {
+      address: {
+        userProfiles: {
+          some: {
+            userId
+          }
+        }
+      },
+      amount: {
+        gt: 0
+      }
+    },
+    include: includePaybuttonsAndPrices
+  })
+
+  const transformedData: Payment[] = []
+  for (let index = 0; index < transactions.length; index++) {
+    const tx = transactions[index]
+    if (Number(tx.amount) > 0) {
+      const payment = await generatePaymentFromTx(tx)
+      transformedData.push(payment)
+    }
+  }
+  return transformedData
+}

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -803,7 +803,8 @@ export async function fetchAllPaymentsByUserIdWithPagination (
 }
 
 export async function fetchAllPaymentsByUserId (
-  userId: string
+  userId: string,
+  networkIds?: number[]
 ): Promise<Payment[]> {
   const transactions = await prisma.transaction.findMany({
     where: {
@@ -812,6 +813,9 @@ export async function fetchAllPaymentsByUserId (
           some: {
             userId
           }
+        },
+        networkId: {
+          in: networkIds ?? Object.values(NETWORK_IDS)
         }
       },
       amount: {


### PR DESCRIPTION
Related to #740 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---

Added export csv functionality to payments page 


Test plan
---
Run the server with `docker compose up`
Go to payments page click `Export as CSV` button it should download the payments in a csv
<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
