### PR TITLE
feat: copy address buttons

### DIFF
--- a/components/Paybutton/PaybuttonList.tsx
+++ b/components/Paybutton/PaybuttonList.tsx
@@ -5,6 +5,7 @@ import style from './paybutton.module.css'
 import Arrow from 'assets/right-arrow.png'
 import XECIcon from 'assets/xec-logo.png'
 import BCHIcon from 'assets/bch-logo.png'
+import CopyIcon from 'assets/copy.png'
 import { XEC_NETWORK_ID, BCH_NETWORK_ID } from 'constants/index'
 
 export const checkNetwork = (paybutton: any, ID: number): boolean => {
@@ -15,6 +16,9 @@ export const checkNetwork = (paybutton: any, ID: number): boolean => {
 
 interface IProps { paybuttons: PaybuttonWithAddresses[] }
 export default ({ paybuttons }: IProps): FunctionComponent<IProps> => {
+  const copyToClipboard = (text: string): void => {
+    void navigator.clipboard.writeText(text)
+  }
   return (
   <div className={style.paybutton_list_ctn}>
     {paybuttons.length === 0 && <div className={style.paybutton_nocard}>No buttons yet! Use the button below to create one</div>}
@@ -30,7 +34,31 @@ export default ({ paybuttons }: IProps): FunctionComponent<IProps> => {
         <div>
           {paybutton.addresses.map(item => (
             <div className={style.address} key={item.address.address}>
-              {item.address.address}
+              <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px'
+              }}
+              >
+                <span>{item.address.address}</span>
+                <Image
+                  src={CopyIcon}
+                  alt="copy"
+                  width={16}
+                  height={16}
+                  style={{
+                    cursor: 'pointer',
+                    transition: 'transform 0.2s ease'
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.2)')}
+                  onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    copyToClipboard(item.address.address)
+                  }}
+                />
+            </div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
Related to #781 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Added a copy icon close to the address in the buttons page


Test plan
---
Run server with docker compose up
go to buttons page and test the copy icon close to the address

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
