### PR TITLE
fix: negative indexes

### DIFF
--- a/redis/dashboardCache.ts
+++ b/redis/dashboardCache.ts
@@ -142,13 +142,13 @@ const generateDashboardDataFromStream = async function (
         let index = -1
 
         if (period === 'sevenDays') {
-          index = (today.day() - paymentWeekDay) % 7
+          index = ((today.day() - paymentWeekDay) + 7) % 7
         } else if (period === 'thirtyDays') {
-          index = (today.dayOfYear() - paymentYearDay) % yearModBase
+          index = ((today.dayOfYear() - paymentYearDay) + yearModBase) % yearModBase
         } else if (period === 'year') {
-          index = (today.month() - paymentMonth) % 12
+          index = ((today.month() - paymentMonth) + 12) % 12
         } else if (period === 'all') {
-          index = (thisYear - paymentYear) * 12 + (today.month() - paymentMonth) % 12
+          index = ((thisYear - paymentYear) * 12 + (today.month() - paymentMonth) + 12) % 12
         }
 
         if (index >= 0 && index < revenueAccumulators[period].length) {


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes bug where many payments from last year wouldn't appear in the dashboard.


Test plan
---
Make sure that now the dashboard plots show # of payments & their revenue as expected.


Remarks
---
**Technical explanation:**
I assumed that the remainder operator in JS worked just like in Python, where the sign of the result is always the same as the sign of the divisor. In truth, the sign of the remainder division result in JS is equal to the dividend's, not the divisor's. To clarify:

![image](https://github.com/user-attachments/assets/6f1d8ef1-615d-4c43-b9b0-6981fb5fa855)


... so this solves the issue by adding the divisor to the dividend, which will make it positive if it's negative (since it's never less than minus the divisor) or will have no effect if it is already positive.