### PR TITLE
[#937] fix: sideshift user ip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ stop-prod:
 reset-prod:
 	make stop-prod && make prod
 
+deploy:
+	git pull && make reset-prod
+
 dev:
 	$(git_hook_setup)
 	$(touch_local_env)

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -285,16 +285,18 @@ export class ChronikBlockchainClient {
         [...confirmedTransactions, ...unconfirmedTransactions].map(async tx => await this.getTransactionFromChronikTransaction(tx, address))
       )
       const persistedTransactions = await createManyTransactions(transactionsToPersist)
-      const simplifiedTransactions = getSimplifiedTransactions(persistedTransactions)
+      if (persistedTransactions.length > 0) {
+        const simplifiedTransactions = getSimplifiedTransactions(persistedTransactions)
 
-      console.log(`${this.CHRONIK_MSG_PREFIX}: added ${simplifiedTransactions.length} txs to ${addressString}`)
+        console.log(`${this.CHRONIK_MSG_PREFIX}: added ${simplifiedTransactions.length} txs to ${addressString}`)
 
-      const broadcastTxData: BroadcastTxData = {} as BroadcastTxData
-      broadcastTxData.messageType = 'OldTx'
-      broadcastTxData.address = addressString
-      broadcastTxData.txs = simplifiedTransactions
+        const broadcastTxData: BroadcastTxData = {} as BroadcastTxData
+        broadcastTxData.messageType = 'OldTx'
+        broadcastTxData.address = addressString
+        broadcastTxData.txs = simplifiedTransactions
 
-      this.wsEndpoint.emit(SOCKET_MESSAGES.TXS_BROADCAST, broadcastTxData)
+        this.wsEndpoint.emit(SOCKET_MESSAGES.TXS_BROADCAST, broadcastTxData)
+      }
 
       yield persistedTransactions
 

--- a/ws-service/route.ts
+++ b/ws-service/route.ts
@@ -77,13 +77,8 @@ const broadcastRouteConnection = (socket: Socket): void => {
 
 const altpaymentNs = io.of('/altpayment')
 const altpaymentRouteConnection = async (socket: Socket): Promise<void> => {
-  const headersAddress = socket.handshake.headers['X-FORWARDED-FOR']
-  const headersAddressLC = socket.handshake.headers['x-forwarded-for']
-  const remoteAddress = socket.request.connection.remoteAddress ?? ''
-  const handshakeAddress = socket.handshake.address
-  const origin = socket.handshake.headers.origin ?? ''
-  const userIp = (headersAddressLC as string).split(',')[0]
-  console.log('wip', { userIp, origin, handshakeAddress, remoteAddress, headersAddress, headersAddressLC })
+  const headersForwardedAddresses = socket.handshake.headers['x-forwarded-for']
+  const userIp = (headersForwardedAddresses as string).split(',')[0]
   const coins = await getSideshiftCoinsInfo(userIp)
   void socket.emit(SOCKET_MESSAGES.SEND_ALTPAYMENT_COINS_INFO, coins)
   void socket.on(SOCKET_MESSAGES.GET_ALTPAYMENT_RATE, async (getPairRateData: GetPairRateData) => {

--- a/ws-service/route.ts
+++ b/ws-service/route.ts
@@ -77,7 +77,13 @@ const broadcastRouteConnection = (socket: Socket): void => {
 
 const altpaymentNs = io.of('/altpayment')
 const altpaymentRouteConnection = async (socket: Socket): Promise<void> => {
-  const userIp = socket.handshake.address
+  const headersAddress = socket.handshake.headers['X-FORWARDED-FOR']
+  const headersAddressLC = socket.handshake.headers['x-forwarded-for']
+  const remoteAddress = socket.request.connection.remoteAddress ?? ''
+  const handshakeAddress = socket.handshake.address
+  const origin = socket.handshake.headers.origin ?? ''
+  const userIp = (headersAddressLC as string).split(',')[0]
+  console.log('wip', { userIp, origin, handshakeAddress, remoteAddress, headersAddress, headersAddressLC })
   const coins = await getSideshiftCoinsInfo(userIp)
   void socket.emit(SOCKET_MESSAGES.SEND_ALTPAYMENT_COINS_INFO, coins)
   void socket.on(SOCKET_MESSAGES.GET_ALTPAYMENT_RATE, async (getPairRateData: GetPairRateData) => {

--- a/ws-service/route.ts
+++ b/ws-service/route.ts
@@ -77,21 +77,22 @@ const broadcastRouteConnection = (socket: Socket): void => {
 
 const altpaymentNs = io.of('/altpayment')
 const altpaymentRouteConnection = async (socket: Socket): Promise<void> => {
-  const coins = await getSideshiftCoinsInfo()
+  const userIp = socket.handshake.address
+  const coins = await getSideshiftCoinsInfo(userIp)
   void socket.emit(SOCKET_MESSAGES.SEND_ALTPAYMENT_COINS_INFO, coins)
   void socket.on(SOCKET_MESSAGES.GET_ALTPAYMENT_RATE, async (getPairRateData: GetPairRateData) => {
-    const pairRate = await getSideshiftPairRate(getPairRateData)
+    const pairRate = await getSideshiftPairRate(getPairRateData, userIp)
     socket.emit(SOCKET_MESSAGES.SEND_ALTPAYMENT_RATE, pairRate)
   })
   void socket.on(SOCKET_MESSAGES.CREATE_ALTPAYMENT_QUOTE, async (createQuoteData: CreateQuoteAndShiftData) => {
-    const createdQuoteRes = await postSideshiftQuote(createQuoteData)
+    const createdQuoteRes = await postSideshiftQuote(createQuoteData, userIp)
     if ('errorType' in createdQuoteRes) {
       socket.emit(SOCKET_MESSAGES.ERROR_WHEN_CREATING_QUOTE, createdQuoteRes)
     } else {
       const createdShiftRes = await postSideshiftShift({
         quoteId: createdQuoteRes.id,
         settleAddress: createQuoteData.settleAddress
-      })
+      }, userIp)
       if ('errorType' in createdShiftRes) {
         socket.emit(SOCKET_MESSAGES.ERROR_WHEN_CREATING_SHIFT, createdShiftRes)
       } else {

--- a/ws-service/sideshift.ts
+++ b/ws-service/sideshift.ts
@@ -3,13 +3,18 @@ import config from 'config/index'
 
 export const SIDESHIFT_BASE_URL = 'https://sideshift.ai/api/v2/'
 
-export const getSideshiftPairRate = async (getPairRateData: GetPairRateData): Promise<SideshiftPairRes> => {
-  const res = await fetch(SIDESHIFT_BASE_URL + `pair/${getPairRateData.from}/${getPairRateData.to}`)
+export const getSideshiftPairRate = async (getPairRateData: GetPairRateData, userIp: string): Promise<SideshiftPairRes> => {
+  const res = await fetch(SIDESHIFT_BASE_URL + `pair/${getPairRateData.from}/${getPairRateData.to}`, {
+    method: 'GET',
+    headers: {
+      'x-user-ip': userIp
+    }
+  })
   const data = await res.json()
   return data as SideshiftPairRes
 }
 
-export const postSideshiftQuote = async (createQuoteData: CreateQuoteAndShiftData): Promise<SideshiftQuoteRes | SideshiftError> => {
+export const postSideshiftQuote = async (createQuoteData: CreateQuoteAndShiftData, userIp: string): Promise<SideshiftQuoteRes | SideshiftError> => {
   const requestBody = JSON.stringify({
     ...createQuoteData,
     affiliateId: config.sideshiftAffiliateId
@@ -19,7 +24,8 @@ export const postSideshiftQuote = async (createQuoteData: CreateQuoteAndShiftDat
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'x-sideshift-secret': process.env.SIDESHIFT_SECRET_KEY as string
+      'x-sideshift-secret': process.env.SIDESHIFT_SECRET_KEY as string,
+      'x-user-ip': userIp
     },
     body: requestBody
   })
@@ -44,7 +50,7 @@ interface CreateShiftData {
   settleAddress: string
 }
 
-export const postSideshiftShift = async (createShiftData: CreateShiftData): Promise<SideshiftShiftRes | SideshiftError> => {
+export const postSideshiftShift = async (createShiftData: CreateShiftData, userIp: string): Promise<SideshiftShiftRes | SideshiftError> => {
   const { quoteId, settleAddress } = createShiftData
   const requestBody = JSON.stringify({
     affiliateId: config.sideshiftAffiliateId,
@@ -56,7 +62,8 @@ export const postSideshiftShift = async (createShiftData: CreateShiftData): Prom
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'x-sideshift-secret': process.env.SIDESHIFT_SECRET_KEY as string
+      'x-sideshift-secret': process.env.SIDESHIFT_SECRET_KEY as string,
+      'x-user-ip': userIp
     },
     body: requestBody
   })
@@ -76,8 +83,13 @@ export const postSideshiftShift = async (createShiftData: CreateShiftData): Prom
   return shiftResponse
 }
 
-export const getSideshiftCoinsInfo = async (): Promise<SideShiftCoinRes[]> => {
-  const res = await fetch(SIDESHIFT_BASE_URL + 'coins')
+export const getSideshiftCoinsInfo = async (userIp: string): Promise<SideShiftCoinRes[]> => {
+  const res = await fetch(SIDESHIFT_BASE_URL + 'coins', {
+    method: 'GET',
+    headers: {
+      'x-user-ip': userIp
+    }
+  })
   const data = await res.json()
 
   const coins = data as SideShiftCoinRes[]


### PR DESCRIPTION
Related to #937

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes issue with sideshift where client requests were being proxied without their IP being properly passed in the headers.


Test plan
---
Already running in prod, should solve the blocked sideshift issue.


 
Remarks
---
- Add command `make deploy` to deploy production more easily.
- Removed empty tx broadcasting.
