### PR TITLE
[#940] big queries fix

### DIFF
--- a/.env.from-dump
+++ b/.env.from-dump
@@ -1,0 +1,1 @@
+IGNORE_SEEDING=true

--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Run unit tests
         run: make github-test-unit
       - name: Spin up required database containers
-        run: docker-compose up -d db users-service
+        run: docker compose up -d db users-service
       - name: Run integration tests
         run: make github-test-integration

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,15 @@ stop-dev:
 reset-dev:
 	make stop-dev && make dev
 
+reset-dev-keep-db:
+	docker container restart paybutton-dev
+
+dev-from-dump:
+	make stop-dev
+	$(git_hook_setup)
+	$(touch_local_env)
+	docker compose -f docker-compose-from-dump.yml --env-file .env --env-file .env.local --env-file .env.from-dump up --build -d
+
 logs-dev:
 	docker logs -f paybutton-dev
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ reset-prod:
 	make stop-prod && make prod
 
 deploy:
-	git pull && make reset-prod
+	git pull && make reset-prod && make logs-dev
 
 dev:
 	$(git_hook_setup)

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -261,3 +261,5 @@ export const MAX_DAILY_EMAILS = 100 // If changed, update the DB default accordi
 
 export const XEC_TX_EXPLORER_URL = 'https://explorer.e.cash/tx/'
 export const BCH_TX_EXPLORER_URL = 'https://blockchair.com/bitcoin-cash/transaction/'
+
+export const MAX_MESSAGES_TO_PROCESS_AT_A_TIME = 5

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -262,4 +262,4 @@ export const MAX_DAILY_EMAILS = 100 // If changed, update the DB default accordi
 export const XEC_TX_EXPLORER_URL = 'https://explorer.e.cash/tx/'
 export const BCH_TX_EXPLORER_URL = 'https://blockchair.com/bitcoin-cash/transaction/'
 
-export const MAX_MESSAGES_TO_PROCESS_AT_A_TIME = 5
+export const MAX_MESSAGES_TO_PROCESS_AT_A_TIME = 2

--- a/docker-compose-from-dump.yml
+++ b/docker-compose-from-dump.yml
@@ -1,0 +1,71 @@
+services:
+  paybutton:
+    container_name: paybutton-dev
+    restart: always
+    depends_on:
+      - db
+      - users-service
+      - cache
+    build: .
+    env_file:
+      - .env.from-dump
+    ports:
+      - "3000:3000"
+      - "5000:5000"
+    volumes:
+      - .:/home/node/src
+    command: bash ./scripts/paybutton-server-start.sh
+  db:
+    container_name: paybutton-db
+    image: mariadb
+    user: root
+    build:
+      context: .
+      dockerfile: './scripts/db/Dockerfile'
+    restart: always
+    env_file:
+      - .env
+      - .env.local
+      - .env.from-dump
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MAIN_DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MAIN_DB_NAME}
+      MYSQL_USER: ${MAIN_DB_USER}
+      MYSQL_PASSWORD: ${MAIN_DB_PASSWORD}
+    command: --default-authentication-plugin=mysql_native_password
+    ports:
+      - 3306:3306
+    volumes:
+      - ./scripts/db/mysql-config.cnf:/etc/mysql/conf.d/mysql-config.cnf
+      - ./scripts/db-entrypoint.sh:/docker-entrypoint-initdb.d/1-db-entrypoint.sh
+      - ./scripts/db/init-test-db.sql:/home/mysql/raw_entrypoint/2-init-test-db.sql
+      - ./scripts/db/init-supertokens-db.sql:/home/mysql/raw_entrypoint/3-init-supertokens-db.sql
+      - ./scripts/db/prisma-shadow-db-fix.sql:/home/mysql/raw_entrypoint/4-prisma-shadow-db-fix.sql
+      - ./dump.sql:/home/mysql/raw_entrypoint/5-dump.sql
+
+  users-service:
+    container_name: paybutton-users-service
+    depends_on:
+      - db
+      - cache
+    image: registry.supertokens.io/supertokens/supertokens-mysql
+    restart: always
+    ports:
+      - 3567:3567
+    environment:
+      MYSQL_DATABASE_NAME: supertokens
+      MYSQL_USER: ${SUPERTOKENS_DB_USER}
+      MYSQL_PASSWORD: ${SUPERTOKENS_DB_PASSWORD}
+      MYSQL_HOST: ${MAIN_DB_HOST}
+      MYSQL_PORT: ${MAIN_DB_PORT}
+
+  cache:
+    container_name: paybutton-cache
+    image: redis:6.2-alpine
+    restart: always
+    ports:
+      - 6379:6379
+    volumes:
+      - ./redis:/data/redis:z
+      - ./scripts:/data/scripts
+    command: sh -c "sed -i 's/\\r//g' ./scripts/redis-start.sh && sh ./scripts/redis-start.sh"

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -27,6 +27,8 @@ export async function ignoreConflicts (callback: Function): Promise<void> {
 async function main (): Promise<void> {
   // don't seed in prod
   if (process.env.NODE_ENV === 'production' || process.env.ENVIRONMENT === 'production') return
+  // don't seed if skipped on env var
+  if (process.env.IGNORE_SEEDING === 'true') return
 
   // create networks
   if (await prisma.network.count() === 0) {

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -384,6 +384,9 @@ export class ChronikBlockchainClient {
   private async processWsMessage (msg: WsMsgClient): Promise<void> {
     // delete unconfirmed transaction from our database
     // if they were cancelled and not confirmed
+    while (this.initializing) {
+      await new Promise(resolve => setTimeout(resolve, 1000)) // wait for 1 second
+    }
     if (msg.type === 'Tx') {
       if (msg.msgType === 'TX_REMOVED_FROM_MEMPOOL') {
         console.log(`${this.CHRONIK_MSG_PREFIX}: [${msg.msgType}] ${msg.txid}`)
@@ -402,9 +405,6 @@ export class ChronikBlockchainClient {
       } else if (msg.msgType === 'TX_ADDED_TO_MEMPOOL') {
         if (this.isAlreadyBeingProcessed(msg.txid, false)) {
           return
-        }
-        while (this.initializing) {
-          await new Promise(resolve => setTimeout(resolve, 1000)) // wait for 1 second
         }
         console.log(`${this.CHRONIK_MSG_PREFIX}: [${msg.msgType}] ${msg.txid}`)
         const transaction = await this.chronik.tx(msg.txid)

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -387,10 +387,10 @@ export class ChronikBlockchainClient {
     // delete unconfirmed transaction from our database
     // if they were cancelled and not confirmed
     while (this.initializing) {
-      await new Promise(resolve => setTimeout(resolve, 1000)) // wait for 1 second
+      await new Promise(resolve => setTimeout(resolve, 1000))
     }
     while (this.messagesBeingProcessed > MAX_MESSAGES_TO_PROCESS_AT_A_TIME) {
-      await new Promise(resolve => setTimeout(resolve, 1000)) // wait for 1 second
+      await new Promise(resolve => setTimeout(resolve, 1000))
     }
     this.messagesBeingProcessed += 1
     try {

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -668,8 +668,11 @@ class MultiBlockchainClient {
         ecash: this.instantiateChronikClient('ecash', asyncOperations),
         bitcoincash: this.instantiateChronikClient('bitcoincash', asyncOperations)
       }
+      console.log('WIP instantiating clients')
       await Promise.all(asyncOperations)
+      console.log('WIP instantiated clients')
       if (this.isRunningApp()) {
+        console.log('WIP will connect')
         await connectAllTransactionsToPrices()
       }
     })()

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -662,16 +662,14 @@ class MultiBlockchainClient {
     void (async () => {
       if (this.isRunningApp()) {
         await syncPastDaysNewerPrices()
-      }
-      const asyncOperations: Array<Promise<void>> = []
-      this.clients = {
-        ecash: this.instantiateChronikClient('ecash', asyncOperations),
-        bitcoincash: this.instantiateChronikClient('bitcoincash', asyncOperations)
-      }
-      console.log('WIP instantiating clients')
-      await Promise.all(asyncOperations)
-      console.log('WIP instantiated clients')
-      if (this.isRunningApp()) {
+        const asyncOperations: Array<Promise<void>> = []
+        this.clients = {
+          ecash: this.instantiateChronikClient('ecash', asyncOperations),
+          bitcoincash: this.instantiateChronikClient('bitcoincash', asyncOperations)
+        }
+        console.log('WIP instantiating clients')
+        await Promise.all(asyncOperations)
+        console.log('WIP instantiated clients')
         console.log('WIP will connect')
         await connectAllTransactionsToPrices()
       }

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -687,6 +687,7 @@ class MultiBlockchainClient {
           ecash: this.instantiateChronikClient('ecash', asyncOperations),
           bitcoincash: this.instantiateChronikClient('bitcoincash', asyncOperations)
         }
+        await Promise.all(asyncOperations)
         await connectAllTransactionsToPrices()
         this.clients.ecash.setInitialized()
         this.clients.bitcoincash.setInitialized()

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -691,6 +691,13 @@ class MultiBlockchainClient {
         await connectAllTransactionsToPrices()
         this.clients.ecash.setInitialized()
         this.clients.bitcoincash.setInitialized()
+      } else if (process.env.NODE_ENV === 'test') {
+        const asyncOperations: Array<Promise<void>> = []
+        this.clients = {
+          ecash: this.instantiateChronikClient('ecash', asyncOperations),
+          bitcoincash: this.instantiateChronikClient('bitcoincash', asyncOperations)
+        }
+        await Promise.all(asyncOperations)
       }
     })()
   }

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -681,16 +681,11 @@ class MultiBlockchainClient {
     void (async () => {
       if (this.isRunningApp()) {
         await syncPastDaysNewerPrices()
-        console.log('connecting before')
         await connectAllTransactionsToPrices()
-        console.log('connecting after')
-        console.log('WIP instantiating clients')
         this.clients = {
           ecash: await this.instantiateChronikClient('ecash'),
           bitcoincash: await this.instantiateChronikClient('bitcoincash')
         }
-        console.log('WIP instantiated clients')
-        console.log('WIP will connect')
         await connectAllTransactionsToPrices()
         this.clients.ecash.setInitialized()
         this.clients.bitcoincash.setInitialized()

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -697,6 +697,7 @@ class MultiBlockchainClient {
       console.log(`[CHRONIK — ${networkSlug}] Syncing missed transactions...`)
       asyncOperations.push(newClient.syncMissedTransactions())
     }
+    console.log(`[CHRONIK — ${networkSlug}] Finished instantiating client.`)
 
     return newClient
   }

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -681,6 +681,9 @@ class MultiBlockchainClient {
     void (async () => {
       if (this.isRunningApp()) {
         await syncPastDaysNewerPrices()
+        console.log('connecting before')
+        await connectAllTransactionsToPrices()
+        console.log('connecting after')
         console.log('WIP instantiating clients')
         this.clients = {
           ecash: await this.instantiateChronikClient('ecash'),

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -689,6 +689,8 @@ class MultiBlockchainClient {
         console.log('WIP instantiated clients')
         console.log('WIP will connect')
         await connectAllTransactionsToPrices()
+        this.clients.ecash.setInitialized()
+        this.clients.bitcoincash.setInitialized()
       }
     })()
   }
@@ -715,7 +717,6 @@ class MultiBlockchainClient {
       console.log(`[CHRONIK — ${networkSlug}] Syncing missed transactions...`)
       await newClient.syncMissedTransactions()
     }
-    newClient.setInitialized()
     console.log(`[CHRONIK — ${networkSlug}] Finished instantiating client.`)
 
     return newClient

--- a/services/chronikService.ts
+++ b/services/chronikService.ts
@@ -662,13 +662,11 @@ class MultiBlockchainClient {
     void (async () => {
       if (this.isRunningApp()) {
         await syncPastDaysNewerPrices()
-        const asyncOperations: Array<Promise<void>> = []
-        this.clients = {
-          ecash: this.instantiateChronikClient('ecash', asyncOperations),
-          bitcoincash: this.instantiateChronikClient('bitcoincash', asyncOperations)
-        }
         console.log('WIP instantiating clients')
-        await Promise.all(asyncOperations)
+        this.clients = {
+          ecash: await this.instantiateChronikClient('ecash'),
+          bitcoincash: await this.instantiateChronikClient('bitcoincash')
+        }
         console.log('WIP instantiated clients')
         console.log('WIP will connect')
         await connectAllTransactionsToPrices()
@@ -687,16 +685,16 @@ class MultiBlockchainClient {
     return false
   }
 
-  private instantiateChronikClient (networkSlug: string, asyncOperations: Array<Promise<void>>): ChronikBlockchainClient {
+  private async instantiateChronikClient (networkSlug: string): Promise<ChronikBlockchainClient> {
     console.log(`[CHRONIK — ${networkSlug}] Instantiating client...`)
     const newClient = new ChronikBlockchainClient(networkSlug)
 
     // Subscribe addresses & Sync lost transactions on DB upon client initialization
     if (this.isRunningApp()) {
       console.log(`[CHRONIK — ${networkSlug}] Subscribing addresses in database...`)
-      asyncOperations.push(newClient.subscribeInitialAddresses())
+      await newClient.subscribeInitialAddresses()
       console.log(`[CHRONIK — ${networkSlug}] Syncing missed transactions...`)
-      asyncOperations.push(newClient.syncMissedTransactions())
+      await newClient.syncMissedTransactions()
     }
     console.log(`[CHRONIK — ${networkSlug}] Finished instantiating client.`)
 

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -403,12 +403,12 @@ export async function connectTransactionsListToPrices (txList: Transaction[]): P
 
 export async function connectAllTransactionsToPrices (): Promise<void> {
   const noPricesTxs = await fetchAllTransactionsWithNoPrices()
-  // const wrongNumberOfPricesTxs = await fetchAllTransactionsWithIrregularPrices()
+  const wrongNumberOfPricesTxs = await fetchAllTransactionsWithIrregularPrices()
   const txs = [
-    ...noPricesTxs
-    // ...wrongNumberOfPricesTxs
+    ...noPricesTxs,
+    ...wrongNumberOfPricesTxs
   ]
-  console.log(`[PRICES] Connecting ${noPricesTxs.length} txs with no prices and  with irregular prices...`)
+  console.log(`[PRICES] Connecting ${noPricesTxs.length} txs with no prices and ${wrongNumberOfPricesTxs.length} with irregular prices...`)
   void await connectTransactionsListToPrices(txs)
   console.log('[PRICES] Finished connecting txs to prices.')
 }

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -174,13 +174,25 @@ export async function fetchTransactionsWithPaybuttonsAndPricesForIdList (txIdLis
   })
 }
 
-export async function fetchTransactionsWithPaybuttonsAndPricesForAddress (addressId: string): Promise<TransactionsWithPaybuttonsAndPrices[]> {
-  return await prisma.transaction.findMany({
-    where: {
-      addressId
-    },
-    include: includePaybuttonsAndPrices
-  })
+export async function * generateTransactionsWithPaybuttonsAndPricesForAddress (addressId: string, pageSize = 5000): AsyncGenerator<TransactionsWithPaybuttonsAndPrices[]> {
+  let page = 0
+
+  while (true) {
+    const txs = await prisma.transaction.findMany({
+      where: {
+        addressId
+      },
+      include: includePaybuttonsAndPrices,
+      orderBy: {
+        timestamp: 'asc'
+      },
+      skip: page * pageSize,
+      take: pageSize
+    })
+    if (txs.length === 0) break
+    yield txs
+    page++
+  }
 }
 
 export async function fetchPaginatedAddressTransactions (addressString: string, page: number, pageSize: number, orderBy?: string, orderDesc = true): Promise<TransactionWithAddressAndPrices[]> {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -490,17 +490,15 @@ export async function fetchAllTransactionsWithNoPrices (): Promise<Transaction[]
 }
 
 export async function fetchAllTransactionsWithIrregularPrices (): Promise<Transaction[]> {
-  const txs = await prisma.transaction.findMany({
-    where: {
-      prices: {
-        some: {}
-      }
-    },
-    include: {
-      prices: true
-    }
-  })
-  return txs.filter(t => t.prices.length !== 2)
+  return await prisma.$queryRaw<Transaction[]>`
+  SELECT t.*
+  FROM Transaction t
+  WHERE (
+    SELECT COUNT(*)
+    FROM PricesOnTransactions pot
+    WHERE pot.transactionId = t.id
+  ) = 1;
+`
 }
 
 export async function fetchTransactionsByPaybuttonId (paybuttonId: string, networkIds?: number[]): Promise<TransactionWithAddressAndPrices[]> {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -391,12 +391,12 @@ export async function connectTransactionsListToPrices (txList: Transaction[]): P
 
 export async function connectAllTransactionsToPrices (): Promise<void> {
   const noPricesTxs = await fetchAllTransactionsWithNoPrices()
-  const wrongNumberOfPricesTxs = await fetchAllTransactionsWithIrregularPrices()
+  // const wrongNumberOfPricesTxs = await fetchAllTransactionsWithIrregularPrices()
   const txs = [
-    ...noPricesTxs,
-    ...wrongNumberOfPricesTxs
+    ...noPricesTxs
+    // ...wrongNumberOfPricesTxs
   ]
-  console.log(`[PRICES] Connecting ${noPricesTxs.length} txs with no prices and ${wrongNumberOfPricesTxs.length} with irregular prices...`)
+  console.log(`[PRICES] Connecting ${noPricesTxs.length} txs with no prices and  with irregular prices...`)
   void await connectTransactionsListToPrices(txs)
   console.log('[PRICES] Finished connecting txs to prices.')
 }


### PR DESCRIPTION
Related to #940 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Mainly, this PR fixes some big prisma queries that were throwing errors in production.
Additionally:

- Adds a new make command `make reset-dev-keep-db` to reset only the dev container and keep the db intact
- Adds a new make commands `make dev-from-dump` to create a dev environment but instead of seeding, using a `dump.sql` file in the repo's root directory.
- Fixes failing test on master that was failing because github updated their docker and no longer supports `docker-compose`, only `docker compose`
- Adds `logs-dev` to `make deploy`
- Freezes new messages that come during the initial sync. Then process them all `MAX_MESSAGES_TO_PROCESS_AT_A_TIME` at a time after the initial sync is done.

Test plan
---
Already running in prod.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
