### PR TITLE
Bug: Fix button generator anchor link

### DIFF
--- a/components/LandingPage/Navbar.tsx
+++ b/components/LandingPage/Navbar.tsx
@@ -43,7 +43,7 @@ export default function Navbar ({ userId }: IProps): JSX.Element {
           style={mobileMenu ? { left: '0' } : { left: '-200px' }}
         >
           <ThemeToggle landingpage />
-          <Link href="#button-generator" onClick={() => setMobileMenu(false)}>Button Generator</Link>
+          <a href="#button-generator" onClick={() => setMobileMenu(false)}>Button Generator</a>
           <Link
             href="https://github.com/paybutton"
             target="_blank"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ import { GetServerSideProps } from 'next'
 const DynamicButtonGenerator = dynamic(
   async () => await import('components/ButtonGenerator/index'),
   {
-    ssr: false
+    ssr: true
   }
 )
 


### PR DESCRIPTION
Related to #935 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
The button generator anchor link doesn't work if you navigate directly to /#button-generator. 
This change should fix it


Test plan
---
Preview the site and try loading http://localhost:3000/#button-generator
The page should scroll down to the button generator section 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
