### PR TITLE
fix: tables sorting

### DIFF
--- a/components/Dashboard/Leaderboard.tsx
+++ b/components/Dashboard/Leaderboard.tsx
@@ -5,6 +5,7 @@ import style from '../Transaction/transaction.module.css'
 import moment from 'moment'
 import { compareNumericString } from 'utils/index'
 import { formatQuoteValue } from 'utils'
+import { SUPPORTED_QUOTES_FROM_ID } from 'constants/index'
 
 interface IProps {
   buttons: PaymentDataByButton
@@ -13,6 +14,7 @@ interface IProps {
 }
 
 export default ({ buttons, totalString, currencyId }: IProps): JSX.Element => {
+  const totalRevenueAcessor = 'total.revenue.' + SUPPORTED_QUOTES_FROM_ID[currencyId]
   const columns = useMemo(
     () => [
       {
@@ -34,7 +36,7 @@ export default ({ buttons, totalString, currencyId }: IProps): JSX.Element => {
       },
       {
         Header: () => (<div style={{ textAlign: 'right' }}>{totalString} Revenue</div>),
-        accessor: 'total.revenue',
+        accessor: totalRevenueAcessor,
         id: 'revenue',
         sortType: compareNumericString,
         Cell: (cellProps) => {

--- a/components/TableContainer/TableContainer.tsx
+++ b/components/TableContainer/TableContainer.tsx
@@ -23,7 +23,8 @@ const TableContainer = ({ columns, data, opts, ssr }: IProps): JSX.Element => {
     nextPage,
     previousPage,
     setPageSize,
-    state: { pageIndex, pageSize }
+    state: { pageIndex, pageSize, sortBy },
+    setSortBy
   } = useTable(
     {
       columns,
@@ -52,10 +53,16 @@ const TableContainer = ({ columns, data, opts, ssr }: IProps): JSX.Element => {
           {headerGroups.map((headerGroup: any) => (
             <tr {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map((column: any) => (
-                <th {...column.getHeaderProps(column.getSortByToggleProps())}>
-                  {column.render('Header')}
-                  {generateSortingIndicator(column)}
-                </th>
+                <th {...column.getHeaderProps({
+                  onClick: () => {
+                    const isDesc = sortBy[0]?.id === column.id ? !sortBy[0]?.desc : true;
+                    setSortBy([{ id: column.id, desc: isDesc }]);
+                  }
+                })}
+              >
+                {column.render('Header')}
+                {generateSortingIndicator(column)}
+              </th>
               ))}
             </tr>
           ))}


### PR DESCRIPTION
Related to #950 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fix Leaderboard Total revenue sorting, also fixed the behavior of sorting tables, before if we click twice the third click would remove sorting, now it will work just `asc` and `desc`, it wont remove the sorting in the third click


Test plan
---
Run server with `docker compose up` check Leaderboard total revenue table sorting. 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
