### PR TITLE
fix: use websocket, not polling, on button detail view

### DIFF
--- a/pages/button/[id].tsx
+++ b/pages/button/[id].tsx
@@ -96,7 +96,8 @@ export default function PayButton (props: PaybuttonProps): React.ReactElement {
 
   const setUpSocket = async (addresses: string[]): Promise<void> => {
     const socket = io(`${config.wsBaseURL}/addresses`, {
-      query: { addresses }
+      query: { addresses },
+      transports: ['websocket']
     })
 
     socket.on(SOCKET_MESSAGES.INCOMING_TXS, (broadcastedData: BroadcastTxData) => {


### PR DESCRIPTION

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes CORS issues in the button detail view by enforcing `websocket` as the connection, instead of `polling`.


Test plan
---
In master, acessing the button detail view should show CORS errors in the console, and therefore not allow for a real-time refresh of incoming txs. This PR should fix that.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
