### PR TITLE
[fix] Don't re-enable sign in button

### DIFF
--- a/components/Auth/SignIn.tsx
+++ b/components/Auth/SignIn.tsx
@@ -26,10 +26,12 @@ export default function SignIn (): ReactElement {
       if (response.status === 'FIELD_ERROR') {
         response.formFields.forEach(formField => {
           setError(formField.error)
+          setDisabled(false)
         })
       } else if (response.status === 'WRONG_CREDENTIALS_ERROR') {
         setError('Incorrect email or password.')
         reset({ password: '' })
+        setDisabled(false)
       } else {
         // sign in successful. The session tokens are automatically handled by
         // the frontend SDK.
@@ -44,8 +46,8 @@ export default function SignIn (): ReactElement {
         setError('Something went wrong.')
         reset({ password: '' })
       }
+      setDisabled(false)
     }
-    setDisabled(false)
   }
   return (
     <>


### PR DESCRIPTION
Related to #990

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fix the loading state of the submit button so it does not change state before changing pages when signing in



Test plan
---
Logout and then go to /sign-in. Signin and check the submit button behaves as expected. Try some incorrect credentials as well to test error behavior   

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
