### PR TITLE
fix: fetch user from trigger fix

### DIFF
--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -300,32 +300,24 @@ export async function executeAddressTriggers (broadcastTxData: BroadcastTxData, 
 }
 
 async function fetchUserFromTriggerId (triggerId: string): Promise<UserProfile> {
-  const result = await prisma.paybuttonTrigger.findUniqueOrThrow({
-    where: { id: triggerId },
-    select: {
-      paybutton: {
-        select: {
-          addresses: {
-            select: {
-              address: {
-                select: {
-                  userProfiles: {
-                    select: {
-                      userProfile: true
-                    }
-                  }
-                }
-              }
-            }
-          }
+  const pb = await prisma.paybutton.findFirstOrThrow({
+    where: {
+      triggers: {
+        some: {
+          id: triggerId
         }
       }
+    },
+    select: {
+      providerUserId: true
     }
   })
 
-  // Since there may be multiple user profiles linked, extract the first one if needed
-  const userProfile = result.paybutton.addresses[0].address.userProfiles[0].userProfile
-  return userProfile
+  return await prisma.userProfile.findUniqueOrThrow({
+    where: {
+      id: pb.providerUserId
+    }
+  })
 }
 
 async function decrementUserCreditCount (userId: string): Promise<void> {


### PR DESCRIPTION

<!-- Non-technical -->
Description
---
Fix logic for getting user from button trigger, that could lead to fetching the wrong user for a trigger.


Test plan
---
 I couldn't reproduce getting another user's info in master, by having two users have buttons with the same address and different triggers, but it would still theoretically be possible.

In any case, triggers should still work normally.

<!-- Uncomment below to add any remarks, technical or 


not -->
<!-- 
Remarks
---
-->
