### PR TITLE
feat: show revenue selected time

### DIFF
--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -128,8 +128,8 @@ export default function Dashboard ({ user }: PaybuttonsProps): React.ReactElemen
     <>
       <TopBar title="Dashboard" user={user.stUser?.email} />
       <div className={style.number_ctn}>
-        <NumberBlock value={'$'.concat(formatQuoteValue(dashboardData.total.revenue, user.userProfile.preferredCurrencyId)) } text='Revenue (lifetime)' />
-        <NumberBlock value={formatQuoteValue(dashboardData.total.payments)} text='Payments (lifetime)' />
+        <NumberBlock value={'$'.concat(formatQuoteValue(activePeriod.totalRevenue, user.userProfile.preferredCurrencyId)) } text='Revenue' />
+        <NumberBlock value={activePeriod.totalPayments} text='Payments' />
         <NumberBlock value={dashboardData.total.buttons} text='Buttons' />
       </div>
       <div className={style.btn_ctn}>

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -141,8 +141,9 @@ export default function Dashboard ({ user }: PaybuttonsProps): React.ReactElemen
       <div className={style.chart_outer_ctn}>
         <div className={style.chart_inner_ctn}>
           <div className={style.chart_title_ctn}>
-            <h5>Revenue</h5>
-            <h5>{totalString}: ${formatQuoteValue(activePeriod.totalRevenue, user.userProfile.preferredCurrencyId)}</h5>
+            <div>
+              <h5>Revenue</h5>
+            </div>
           </div>
           <div className={style.chart_ctn}>
             <Chart chartData={activePeriod.revenue} currencyId={user.userProfile.preferredCurrencyId} />
@@ -150,8 +151,9 @@ export default function Dashboard ({ user }: PaybuttonsProps): React.ReactElemen
         </div>
         <div className={style.chart_inner_ctn}>
           <div className={style.chart_title_ctn}>
-            <h5>Payments</h5>
-            <h5>{totalString}: {formatQuoteValue(activePeriod.totalPayments)}</h5>
+            <div>
+              <h5>Payments</h5>
+            </div>
           </div>
           <div className={style.chart_ctn}>
             <Chart chartData={activePeriod.payments} />


### PR DESCRIPTION
Related to #936 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Change dashboard Revenue and Payments indicators to show only the results from selected range of time.


Test plan
---
Check dashboard revenue and payments indicator

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
