### PR TITLE
Added v1 Terms of Use & Privacy Policy.

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,30 @@
+## Privacy Policy
+
+**Effective Date:** 2025-05-03
+
+At PayButton.org, your privacy matters. Here’s what we collect and how we use it:
+
+1. **What We Collect**
+   - Basic info associated with your account (eg. email, organization)
+   - Technical data (eg. IP address, browser info) for security and analytics
+   - Payment metadata (eg. amount, recipient address) for transaction records
+
+2. **What We Don’t Collect**
+   - Credit card information
+   - Private keys
+
+3. **Cookies & Analytics**
+   - We use cookies and tracking tools (like Google Analytics) to improve site performance.
+
+4. **Third Parties**
+   - We may use third-party services (e.g., CDN, analytics providers), but we don’t share your personal data for marketing.
+
+5. **Your Control**
+   - You can update your account settings anytime.
+   - Contact us to request data deletion or access.
+
+6. **Security**
+   - We take reasonable steps to protect your data, but no system is 100% secure.
+
+7. **Changes**
+   - We may revise this policy. Continued use means you accept the new terms.

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,12 @@
+## Terms of Use
+
+**Effective Date:** 2025-05-03
+
+Welcome to PayButton.org. By using this site, you agree to the following terms:
+
+1. **Eligibility**: This service is available worldwide and may be used by individuals of any age.
+2. **Account**: You may create an account to manage your settings. You are responsible for keeping your login information secure.
+3. **Usage**: PayButton.org does not store or control funds. Any payment activity you associate with your PayButton account is read-only and on-chain.
+4. **Conduct**: You agree not to abuse the platform or use it for illegal activity. We may suspend accounts for violations.
+5. **Changes**: We may update these terms at any time. Continued use of the site means you accept the changes.
+6. **Disclaimer**: PayButton.org is provided “as is” without warranty. We are not responsible for losses resulting from site use or payment activity.


### PR DESCRIPTION
Related to https://github.com/PayButton/wordpress-plugin/pull/60

<!-- Non-technical -->
Description
---
Introduces a simple privacy policy and terms of use. For now, we'll just limit it to `paybutton-server`.


Test plan
---
Think about what we're maybe missing, could use tweaking.