### PR TITLE
Fix wallet balance + decimal formatting

### DIFF
--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -56,16 +56,17 @@ const component: FunctionComponent<IProps> = ({ wallet, paymentInfo, userAddress
         {
           isSyncing
             ? <p>Syncing transactions...</p>
-            : paymentInfo.XECBalance > new Prisma.Decimal(0) &&
-            <>
+            : <>
+              { paymentInfo.XECBalance > new Prisma.Decimal(0) &&
               <div className={style.info_item}>
                 <h6>XEC Balance</h6>
-                <h5>{Number(paymentInfo.XECBalance).toLocaleString()} XEC</h5>
+                <h5>{Number(paymentInfo.XECBalance).toLocaleString(navigator.language, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} XEC</h5>
               </div>
+              }
               { paymentInfo.BCHBalance > new Prisma.Decimal(0) &&
               <div className={style.info_item}>
                 <h6>BCH Balance</h6>
-                <h5>{Number(paymentInfo.BCHBalance).toLocaleString()} BCH</h5>
+                <h5>{Number(paymentInfo.BCHBalance).toLocaleString(navigator.language, { minimumFractionDigits: 4, maximumFractionDigits: 4 })} BCH</h5>
               </div>
               }
             </>


### PR DESCRIPTION
Related to #492.

<!-- Non-technical -->
Description
---

Fixed wallet balance display formatting to show consistent decimal places across different cryptocurrencies:

- **XEC Balance**: Now displays exactly 2 decimal places (e.g., "1,234.56 XEC")
- **BCH Balance**: Now displays exactly 4 decimal places (e.g., "0.1234 BCH") - 8 felt too much but we could do that.
- **Locale Support**: Uses the user's browser locale for number formatting (respects international formatting preferences for thousands separators and decimal points)

This provides a more consistent and professional appearance for wallet balances while maintaining appropriate precision for each cryptocurrency type.

Test plan
---

1. Open /wallets.
2. **View wallet with XEC balance**: Verify XEC balance shows exactly 2 decimal places
3. **View wallet with BCH balance**: Verify BCH balance shows exactly 4 decimal places  
4. **Test different locales**: Change browser language/locale settings and verify number formatting adapts appropriately (e.g., comma vs period for decimal separator)
5. **Test edge cases**: 
   - Very small balances (should still show required decimal places)
   - Large balances (should show thousands separators according to locale)
   - Zero balances (should not display balance sections)
