### PR TITLE
Fix: 'yarn docker test' on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "dotenv -e .env.test -- ts-node -O '{\"module\":\"commonjs\"}' node_modules/jest/bin/jest.js",
     "pretest": "dotenv -e .env.test -- prisma migrate reset --force",
     "prisma": "dotenv -e .env -c -- prisma",
-    "docker": "./scripts/docker-exec-shortcuts.sh",
+    "docker": "bash ./scripts/docker-exec-shortcuts.sh",
     "ci:integration:test": "yarn pretest && dotenv -e .env.test -- ts-node -O '{\"module\":\"commonjs\"}' node_modules/jest/bin/jest.js tests/integration-tests --forceExit",
     "tarDebug": "tar cf debug.tar logs/ paybutton-config.json .env*",
     "updateAllPrices": "./scripts/update-all-prices.sh",


### PR DESCRIPTION
<!-- Non-technical -->
Description
---
Stops the test command from simply opening the docker-exec-shortcuts.sh file instead of actually running the tests.


Test plan
---
Run `yarn docker test` and make sure it still works as expected in your environment.
