### PR TITLE
Fix payment triggers with <outputaddresses> set

### DIFF
--- a/services/triggerService.ts
+++ b/services/triggerService.ts
@@ -305,6 +305,7 @@ function buildPostParams (
       ? { paymentId: tx.paymentId, message: tx.message, rawMessage: tx.rawMessage }
       : EMPTY_OP_RETURN,
     inputAddresses: tx.inputAddresses,
+    outputAddresses: tx.outputAddresses,
     value: valueStr
   }
 }


### PR DESCRIPTION
Depends on
---
- [ ] #1050


<!-- Non-technical -->
Description
---
Prod fix for including outputAddresses in payment trigger messages.


Test plan
---
1. Create a payment trigger post data request w/ `<outputAddresses>` set.
2. Make a payment to see if it works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trigger/webhook POST payloads now include output addresses alongside input addresses, providing richer transaction context for reconciliation and analytics.
  * Backwards compatible: existing integrations continue to work without changes. No action required unless you want to consume the new field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->