### PR TITLE
Added vertical scrollbar to addresses list

### DIFF
--- a/components/Paybutton/PaybuttonDetail.tsx
+++ b/components/Paybutton/PaybuttonDetail.tsx
@@ -56,30 +56,32 @@ export default ({ paybutton, refreshPaybutton, listView }: IProps): JSX.Element 
         <label className={style.label_margin}>
           Address{paybutton.addresses.length > 1 ? 'es' : ''}
         </label>
-        {paybutton.addresses.map((item) => (
-          <div className={style.address_ctn} key={item.address.address}>
-            <div className={style.address}>
-              {isCopied === item.address.address && (
-                <div className={style.copied}>Copied!</div>
-              )}
-              {item.address.address.slice(
-                0,
-                item.address.address.startsWith('bitcoin') ? 16 : 10
-              )}
-              ...{item.address.address.slice(-5)}
+        <div className={style.paybutton_detail_address}>
+          {paybutton.addresses.map((item) => (
+            <div className={style.address_ctn} key={item.address.address}>
+              <div className={style.address}>
+                {isCopied === item.address.address && (
+                  <div className={style.copied}>Copied!</div>
+                )}
+                {item.address.address.slice(
+                  0,
+                  item.address.address.startsWith('bitcoin') ? 16 : 10
+                )}
+                ...{item.address.address.slice(-5)}
+              </div>
+              <div
+                className={style.copy_btn}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  e.preventDefault()
+                  void handleCopyClick(item.address.address)
+                }}
+              >
+                <Image src={CopyIcon} alt="copy" width={15} height={15} />
+              </div>
             </div>
-            <div
-              className={style.copy_btn}
-              onClick={(e) => {
-                e.stopPropagation()
-                e.preventDefault()
-                void handleCopyClick(item.address.address)
-              }}
-            >
-              <Image src={CopyIcon} alt="copy" width={15} height={15} />
-            </div>
-          </div>
-        ))}
+          ))}
+        </div>
 
         {paybutton.url !== '' && (
           <>

--- a/components/Paybutton/paybutton-detail.module.css
+++ b/components/Paybutton/paybutton-detail.module.css
@@ -84,6 +84,11 @@ body[data-theme='dark'] .arrow {
   margin-right: 5px;
 }
 
+.paybutton_detail_address {
+  max-height: 500px;
+  overflow-y: auto;
+}
+
 .address_ctn {
   display: flex;
   margin-bottom: 4px;


### PR DESCRIPTION
Related to #1074

<!-- Non-technical -->
Description
---
Adds scrollbar on /button/xxx page for buttons that have a lot of addresses


Test plan
---
Visit a /button/xxx page for a button with lots of addresses and see the scrollbar in action. The page is a bit more manageable with this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Copy button now appears inline within each address for quicker access
  * Address list now scrolls when displaying multiple addresses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->