### PR TITLE
fix: Clicking on the PayButton in Button Generator

### DIFF
--- a/components/ButtonGenerator/index.tsx
+++ b/components/ButtonGenerator/index.tsx
@@ -363,7 +363,7 @@ export default function ButtonGenerator (): JSX.Element {
                 <PayButtonWidget
                   key={`widget-${JSON.stringify(button)}`}
                   to={button.to}
-                  amount={parseFloat(button.amount)}
+                  amount={button.amount === '' ? undefined : parseFloat(button.amount)}
                   currency={button.currency}
                   text={button.text === '' ? undefined : button.text}
                   hoverText={
@@ -385,7 +385,7 @@ export default function ButtonGenerator (): JSX.Element {
                       ? undefined
                       : button.onTransaction
                   }
-                  randomSatoshis={button.randomSatoshis}
+                  randomSatoshis={button.amount !== '' ? button.randomSatoshis : undefined}
                   hideToasts={button.hideToasts}
                   disableEnforceFocus={button.disableEnforceFocus}
                   contributionOffset={button.contributionOffset}
@@ -398,7 +398,7 @@ export default function ButtonGenerator (): JSX.Element {
                 <PayButton
                   key={`button-${JSON.stringify(button)}`}
                   to={button.to}
-                  amount={button.amount}
+                  amount={button.amount === '' ? undefined : button.amount}
                   currency={button.currency}
                   text={button.text === '' ? undefined : button.text}
                   hoverText={
@@ -420,7 +420,7 @@ export default function ButtonGenerator (): JSX.Element {
                       ? undefined
                       : button.onTransaction
                   }
-                  randomSatoshis={button.randomSatoshis}
+                  randomSatoshis={button.amount !== '' ? button.randomSatoshis : undefined}
                   hideToasts={button.hideToasts}
                   disableEnforceFocus={button.disableEnforceFocus}
                   contributionOffset={button.contributionOffset}
@@ -428,8 +428,8 @@ export default function ButtonGenerator (): JSX.Element {
                   disabled={button.disabled}
                   editable={button.editable}
                   autoClose={button.autoClose}
-                  onOpen={button.onOpen}
-                  onClose={button.onClose}
+                  onOpen={button.onOpen === '' ? undefined : button.onOpen}
+                  onClose={button.onClose === '' ? undefined : button.onClose}
                   wsBaseURL={button.wsBaseURL}
                   apiBaseURL={button.apiBaseURL}
                 />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,7 +2294,7 @@ chronik-client-cashtokens@^3.1.1-rc0:
   dependencies:
     "@types/ws" "^8.2.1"
     axios "^1.6.3"
-    ecashaddrjs "file:../../../.cache/yarn/v6/npm-chronik-client-cashtokens-3.1.1-rc0-e5e4a3538e8010b70623974a731bf2712506c5e3-integrity/node_modules/ecashaddrjs"
+    ecashaddrjs "file:../.cache/yarn/v6/npm-chronik-client-cashtokens-3.1.1-rc0-e5e4a3538e8010b70623974a731bf2712506c5e3-integrity/node_modules/ecashaddrjs"
     isomorphic-ws "^4.0.1"
     protobufjs "^6.8.8"
     ws "^8.3.0"
@@ -2830,7 +2830,7 @@ ecashaddrjs@^1.0.7:
     big-integer "1.6.36"
     bs58check "^3.0.1"
 
-ecashaddrjs@^2.0.0, "ecashaddrjs@file:../.cache/yarn/v6/npm-chronik-client-cashtokens-3.1.1-rc0-e5e4a3538e8010b70623974a731bf2712506c5e3-integrity/node_modules/ecashaddrjs":
+ecashaddrjs@^2.0.0, "ecashaddrjs@file:../../../.cache/yarn/v6/npm-chronik-client-cashtokens-3.1.1-rc0-e5e4a3538e8010b70623974a731bf2712506c5e3-integrity/node_modules/ecashaddrjs":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ecashaddrjs/-/ecashaddrjs-2.0.0.tgz#d45ede7fb6168815dbcf664b8e0a6872e485d874"
   integrity sha512-EvK1V4D3+nIEoD0ggy/b0F4lW39/72R9aOs/scm6kxMVuXu16btc+H74eQv7okNfXaQWKgolEekZkQ6wfcMMLw==


### PR DESCRIPTION
Related to #1080

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
PayButton generator not working unless USD value is set.


Test plan
---
Open the landing page, setup a button using the Button Generator. Click it to open the dialog. Try a bunch of combinations of things. Also make sure dialog closing works as that was broken regardless of if USD was set or not.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed payment button component prop handling for empty input fields. Amount, randomSatoshis, and event callback props now properly reset to undefined when corresponding fields are empty, ensuring cleaner component behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->