### PR TITLE
fix: updated loading spinner colour to use the standard blue

### DIFF
--- a/components/Loading/index.tsx
+++ b/components/Loading/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { DotLoader } from 'react-spinners'
 import style from './loading.module.css'
 
@@ -8,21 +8,10 @@ interface LoadingProps {
 }
 
 export default function Loading ({ size = 60, color }: LoadingProps): React.ReactElement {
-  const [accentColor, setAccentColor] = useState(color ?? '#0ac18e')
-
-  useEffect(() => {
-    if (color === undefined) {
-      const computedColor = getComputedStyle(document.documentElement).getPropertyValue('--accent-color').trim()
-      if (computedColor !== '') {
-        setAccentColor(computedColor)
-      }
-    }
-  }, [color])
-
   return (
     <div className={style.loading_container}>
       <DotLoader
-        color={accentColor}
+        color={color ?? 'var(--accent-color)'}
         size={size}
         speedMultiplier={2}
       />


### PR DESCRIPTION
Test plan
---
Open any of the pages and see the spinner loading animation is the standard blue instead of green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the Loading component's color handling by removing unnecessary state management, improving performance and code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->