### PR TITLE
feat: added secondary alphabetical sort on timezone selector

### DIFF
--- a/components/Timezone Selector/index.tsx
+++ b/components/Timezone Selector/index.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react'
-import Select from 'react-timezone-select'
+import React, { useState, useMemo } from 'react'
+import { useTimezoneSelect, allTimezones } from 'react-timezone-select'
+import Select from 'react-select'
 import style from './timezone-selector.module.css'
 
 interface TimezoneSelectorProps {
@@ -13,6 +14,16 @@ const TimezoneSelector: React.FC<TimezoneSelectorProps> = ({ value }) => {
   const [selectedTimezone, setSelectedTimezone] = useState(value !== '' ? value : '')
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
+
+  const { options, parseTimezone } = useTimezoneSelect({ timezones: allTimezones, displayValue: 'UTC' })
+
+  const sortedOptions = useMemo(() => {
+    return [...options].sort((a, b) => {
+      if (a.offset !== b.offset) return (a.offset ?? 0) - (b.offset ?? 0)
+      // secondary sort by timezone name
+      return a.value.localeCompare(b.value)
+    })
+  }, [options])
 
   const handleChange = (selectedOption: any): void => {
     const updateTimezone = async (): Promise<void> => {
@@ -62,12 +73,12 @@ const TimezoneSelector: React.FC<TimezoneSelectorProps> = ({ value }) => {
   return (
     <>
       <Select
-        value={selectedTimezone}
+        value={parseTimezone(selectedTimezone)}
         onChange={handleChange}
-        disabled={false}
+        isDisabled={false}
         className={style.select_timezone}
-        displayValue="UTC"
         styles={customStyles}
+        options={sortedOptions}
       />
       {error !== '' && <span className={style.error_message}>{error}</span>}
       {success !== '' && <span className={style.success_message}>{success}</span>}


### PR DESCRIPTION
<!-- Non-technical -->
Description
---
The secondary sort is seemingly random after the UTC hour on the timezone selector (/account page) so this fixes that.


Test plan
---
Go to /account and see that we're sorting alphabetically on timezones with the same UTC hour offset.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the timezone selector component's internal implementation to improve performance and maintainability while preserving the same user experience and functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->