### PR TITLE
fix: Attempted fix for dashboard not loading sometimes

### DIFF
--- a/redis/index.ts
+++ b/redis/index.ts
@@ -96,7 +96,7 @@ export class CacheGet {
 
     const existingCall = this.pendingCalls[userId][methodName]
     if (existingCall !== undefined) {
-      return await (await existingCall as Promise<T>)
+      return await (existingCall as Promise<T>)
     }
 
     const pendingCall = fn()


### PR DESCRIPTION
Related to #1098

<!-- Non-technical -->
Description
---
Sometimes (especially after a re-deploy) the dashboard doesn't load without doing an extra refresh.


Test plan
---
I'm not 100% how to reproduce it without trying this for real in prod but perhaps there is a good way? We can also give it a quick deploy in prod together.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Concurrent requests now return the existing in-flight result instead of raising an error, improving reliability for identical simultaneous requests.
  * Per-user request tracking and cleanup corrected to avoid stale state after calls complete.

* **Refactor**
  * Internal request-tracking updated to store and manage in-flight results per method for more predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->