### PR TITLE
Don't show "Loading..." in the payment page when there is nothing to …

### DIFF
--- a/pages/payments/index.tsx
+++ b/pages/payments/index.tsx
@@ -252,6 +252,7 @@ export default function Payments ({ user, userId, organization }: PaybuttonsProp
       throw error
     } finally {
       setLoading(false)
+      setTableLoading(false)
     }
   }
 


### PR DESCRIPTION
…show

This fixes a bug that prevents the "No Payments to show yet" message from being displayed when there is no payment. Instead it would always show "Loading..."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where table loading indicators didn't properly clear after data fetching completed, ensuring the UI state remains accurate during the data loading process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->