### PR TITLE
Document the connection limit bump

### DIFF
--- a/.env
+++ b/.env
@@ -4,12 +4,13 @@ MAIN_DB_ROOT_PASSWORD='paybutton-root-password'
 MAIN_DB_USER='paybutton-user'
 MAIN_DB_HOST='db'
 MAIN_DB_PORT='3306'
+MAIN_DB_CONNECTION_LIMIT='50'
 
 SUPERTOKENS_DB_USER='st-user'
 SUPERTOKENS_DB_PASSWORD='st-password'
 
-DATABASE_URL="mysql://$MAIN_DB_USER:$MAIN_DB_PASSWORD@$MAIN_DB_HOST:$MAIN_DB_PORT/$MAIN_DB_NAME?charset=utf8mb4"
-SHADOW_DATABASE_URL="mysql://$MAIN_DB_USER:$MAIN_DB_PASSWORD@$MAIN_DB_HOST:$MAIN_DB_PORT/prisma-shadow-db?charset=utf8mb4"
+DATABASE_URL="mysql://$MAIN_DB_USER:$MAIN_DB_PASSWORD@$MAIN_DB_HOST:$MAIN_DB_PORT/$MAIN_DB_NAME?charset=utf8mb4&connection_limit=$MAIN_DB_CONNECTION_LIMIT"
+SHADOW_DATABASE_URL="mysql://$MAIN_DB_USER:$MAIN_DB_PASSWORD@$MAIN_DB_HOST:$MAIN_DB_PORT/prisma-shadow-db?charset=utf8mb4&connection_limit=$MAIN_DB_CONNECTION_LIMIT"
 
 
 ### These must be set in .env.local:


### PR DESCRIPTION
And hint at an appropriated production value.
This is self-documenting that the default value from Prisma might not be enough for a production server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration to enforce a maximum connection limit of 50 across primary and replica database instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->