### PR TITLE
Feat/set row collapsing threshold

### DIFF
--- a/components/Account/ChangeCsvCollapseThreshold.tsx
+++ b/components/Account/ChangeCsvCollapseThreshold.tsx
@@ -1,0 +1,90 @@
+import React, { ReactElement, useState } from 'react'
+import style from './account.module.css'
+import { DEFAULT_CSV_COLLAPSE_THRESHOLD } from 'constants/index'
+
+interface IProps {
+  csvCollapseThreshold: number
+}
+
+export default function ChangeCsvCollapseThreshold ({ csvCollapseThreshold }: IProps): ReactElement {
+  const [threshold, setThreshold] = useState(csvCollapseThreshold ?? DEFAULT_CSV_COLLAPSE_THRESHOLD)
+  const [inputValue, setInputValue] = useState(String(csvCollapseThreshold ?? DEFAULT_CSV_COLLAPSE_THRESHOLD))
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const [disabled, setDisabled] = useState(true)
+
+  const onSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault()
+    const newThreshold = parseInt(inputValue, 10)
+    if (isNaN(newThreshold) || newThreshold < 0) {
+      setError('Please enter a valid non-negative number')
+      return
+    }
+
+    const oldThreshold = threshold
+    setThreshold(newThreshold)
+    setDisabled(true)
+
+    try {
+      const res = await fetch('/api/user/csvCollapseThreshold', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ csvCollapseThreshold: newThreshold })
+      })
+      if (res.status === 200) {
+        setError('')
+        setSuccess('Updated successfully.')
+        setTimeout(() => {
+          setSuccess('')
+        }, 3000)
+      } else {
+        throw new Error('Failed to update threshold')
+      }
+    } catch (err: any) {
+      setSuccess('')
+      setError(err.message ?? 'Failed to update threshold')
+      setThreshold(oldThreshold)
+      setInputValue(String(oldThreshold))
+    }
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const value = e.target.value
+    setInputValue(value)
+    const numValue = parseInt(value, 10)
+    if (!isNaN(numValue) && numValue >= 0 && numValue !== threshold) {
+      setDisabled(false)
+      setError('')
+    } else if (numValue === threshold) {
+      setDisabled(true)
+    } else {
+      setDisabled(true)
+      if (value !== '') {
+        setError('Please enter a valid non-negative number')
+      }
+    }
+  }
+
+  return (
+    <div className={style.threshold_ctn}>
+      <form onSubmit={(e) => { void onSubmit(e) }}>
+        <div className={style.threshold_row}>
+          <input
+            id="csvCollapseThreshold"
+            type="text"
+            min="0"
+            required
+            value={inputValue}
+            onChange={handleInputChange}
+            className={style.threshold_input}
+          />
+          <button disabled={disabled} className='button_main' type='submit'>Update</button>
+        </div>
+        {error !== '' && <div className={style.error_message}>{error}</div>}
+        {success !== '' && <div className={style.success_message}>{success}</div>}
+      </form>
+    </div>
+  )
+}

--- a/components/Account/account.module.css
+++ b/components/Account/account.module.css
@@ -78,3 +78,34 @@ body[data-theme="dark"] .pro_ctn input {
   margin: 0 0 10px 0;
   font-weight: 600;
 }
+
+.threshold_ctn {
+  width: 100%;
+  margin-top: 10px;
+}
+
+.threshold_row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.threshold_input {
+  width: 80px;
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  font-size: 14px;
+}
+
+body[data-theme='dark'] .threshold_input {
+  border-color: #a5a5a5;
+  background-color: var(--primary-bg-color);
+  color: var(--primary-text-color);
+}
+
+.threshold_ctn button {
+  padding: 5px 15px;
+  border-radius: 5px;
+  font-size: 14px;
+}

--- a/components/Account/account.module.css
+++ b/components/Account/account.module.css
@@ -151,3 +151,35 @@ body[data-theme="dark"] .pro_ctn input {
   font-size: 14px;
   color: #666;
 }
+
+
+.threshold_ctn {
+  width: 100%;
+  margin-top: 10px;
+}
+
+.threshold_row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.threshold_input {
+  width: 80px;
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  font-size: 14px;
+}
+
+body[data-theme='dark'] .threshold_input {
+  border-color: #a5a5a5;
+  background-color: var(--primary-bg-color);
+  color: var(--primary-text-color);
+}
+
+.threshold_ctn button {
+  padding: 5px 15px;
+  border-radius: 5px;
+  font-size: 14px;
+}

--- a/pages/account/index.tsx
+++ b/pages/account/index.tsx
@@ -7,6 +7,7 @@ import { GetServerSideProps } from 'next'
 import Page from 'components/Page'
 import ChangePassword from 'components/Account/ChangePassword'
 import ChangeFiatCurrency from 'components/Account/ChangeFiatCurrency'
+import ChangeCsvCollapseThreshold from 'components/Account/ChangeCsvCollapseThreshold'
 import style from './account.module.css'
 import { fetchUserProfileFromId, fetchUserWithSupertokens, getUserPublicKeyHex, UserWithSupertokens } from 'services/userService'
 import CopyIcon from '../../assets/copy-black.png'
@@ -145,6 +146,15 @@ export default function Account ({ user, userPublicKey, organization, orgMembers
               value={timezone}
               onChange={handleTimezoneChange}
             />
+          </div>
+
+          <div className={style.account_row}>
+            <div className={style.label}>CSV Collapse Threshold</div>
+            <div className={style.value}>
+              <ChangeCsvCollapseThreshold
+                csvCollapseThreshold={userProfile.csvCollapseThreshold}
+              />
+            </div>
           </div>
 
           <div className={style.account_row}>

--- a/pages/account/index.tsx
+++ b/pages/account/index.tsx
@@ -8,6 +8,7 @@ import Page from 'components/Page'
 import ChangePassword from 'components/Account/ChangePassword'
 import ChangeFiatCurrency from 'components/Account/ChangeFiatCurrency'
 import CsvRowCollapsing from 'components/Account/CsvRowCollapsing'
+import ChangeCsvCollapseThreshold from 'components/Account/ChangeCsvCollapseThreshold'
 import style from './account.module.css'
 import { fetchUserProfileFromId, fetchUserWithSupertokens, getUserPublicKeyHex, UserWithSupertokens } from 'services/userService'
 import CopyIcon from '../../assets/copy-black.png'
@@ -153,6 +154,14 @@ export default function Account ({ user, userPublicKey, organization, orgMembers
             <div className={style.value}>
               <CsvRowCollapsing
                 initialValue={userProfile.csvRowCollapsing}
+              />
+            </div>
+          </div>
+                    <div className={style.account_row}>
+            <div className={style.label}>CSV Collapse Threshold</div>
+            <div className={style.value}>
+              <ChangeCsvCollapseThreshold
+                csvCollapseThreshold={userProfile.csvCollapseThreshold}
               />
             </div>
           </div>

--- a/pages/api/paybutton/download/transactions/[paybuttonId].ts
+++ b/pages/api/paybutton/download/transactions/[paybuttonId].ts
@@ -52,7 +52,7 @@ export default async (req: any, res: any): Promise<void> => {
     };
     const transactions = await fetchTransactionsByPaybuttonId(paybutton.id, networkIdArray)
     res.setHeader('Content-Type', 'text/csv')
-    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, paybuttonId)
+    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, paybuttonId, true, user.csvCollapseThreshold)
   } catch (error: any) {
     switch (error.message) {
       case RESPONSE_MESSAGES.PAYBUTTON_ID_NOT_PROVIDED_400.message:

--- a/pages/api/paybutton/download/transactions/[paybuttonId].ts
+++ b/pages/api/paybutton/download/transactions/[paybuttonId].ts
@@ -52,8 +52,7 @@ export default async (req: any, res: any): Promise<void> => {
     };
     const transactions = await fetchTransactionsByPaybuttonId(paybutton.id, networkIdArray)
     res.setHeader('Content-Type', 'text/csv')
-
-    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, paybuttonId, true, user.csvCollapseThreshold, user.csvRowCollapsing)
+    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, paybuttonId, user.csvRowCollapsing, user.csvCollapseThreshold)
   } catch (error: any) {
     switch (error.message) {
       case RESPONSE_MESSAGES.PAYBUTTON_ID_NOT_PROVIDED_400.message:

--- a/pages/api/paybutton/download/transactions/[paybuttonId].ts
+++ b/pages/api/paybutton/download/transactions/[paybuttonId].ts
@@ -52,7 +52,8 @@ export default async (req: any, res: any): Promise<void> => {
     };
     const transactions = await fetchTransactionsByPaybuttonId(paybutton.id, networkIdArray)
     res.setHeader('Content-Type', 'text/csv')
-    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, paybuttonId, user.csvRowCollapsing)
+
+    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, paybuttonId, true, user.csvCollapseThreshold, user.csvRowCollapsing)
   } catch (error: any) {
     switch (error.message) {
       case RESPONSE_MESSAGES.PAYBUTTON_ID_NOT_PROVIDED_400.message:

--- a/pages/api/payments/download/index.ts
+++ b/pages/api/payments/download/index.ts
@@ -62,7 +62,7 @@ export default async (req: any, res: any): Promise<void> => {
 
     const transactions = await fetchAllPaymentsByUserId(userId, networkIdArray, buttonIds, years, startDate, endDate, timezone)
 
-    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId)
+    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, undefined, true, user.csvCollapseThreshold)
   } catch (error: any) {
     switch (error.message) {
       case RESPONSE_MESSAGES.METHOD_NOT_ALLOWED_405.message:

--- a/pages/api/payments/download/index.ts
+++ b/pages/api/payments/download/index.ts
@@ -62,7 +62,7 @@ export default async (req: any, res: any): Promise<void> => {
 
     const transactions = await fetchAllPaymentsByUserId(userId, networkIdArray, buttonIds, years, startDate, endDate, timezone)
 
-    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, undefined, user.csvRowCollapsing)
+    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, undefined, true, user.csvCollapseThreshold, user.csvRowCollapsing)
   } catch (error: any) {
     switch (error.message) {
       case RESPONSE_MESSAGES.METHOD_NOT_ALLOWED_405.message:

--- a/pages/api/payments/download/index.ts
+++ b/pages/api/payments/download/index.ts
@@ -62,7 +62,7 @@ export default async (req: any, res: any): Promise<void> => {
 
     const transactions = await fetchAllPaymentsByUserId(userId, networkIdArray, buttonIds, years, startDate, endDate, timezone)
 
-    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, undefined, true, user.csvCollapseThreshold, user.csvRowCollapsing)
+    await downloadTxsFile(res, quoteSlug, timezone, transactions, userId, undefined, user.csvRowCollapsing, user.csvCollapseThreshold)
   } catch (error: any) {
     switch (error.message) {
       case RESPONSE_MESSAGES.METHOD_NOT_ALLOWED_405.message:

--- a/pages/api/user/csvCollapseThreshold/index.ts
+++ b/pages/api/user/csvCollapseThreshold/index.ts
@@ -1,0 +1,32 @@
+import { setSession } from 'utils/setSession'
+import * as userService from 'services/userService'
+import { RESPONSE_MESSAGES } from 'constants/index'
+
+export default async (
+  req: any,
+  res: any
+): Promise<void> => {
+  await setSession(req, res, true)
+
+  if (req.method === 'PUT') {
+    const session = req.session
+    const { csvCollapseThreshold } = req.body
+
+    if (csvCollapseThreshold === undefined || csvCollapseThreshold === null) {
+      res.status(400).json({ message: 'csvCollapseThreshold is required' })
+      return
+    }
+
+    const threshold = Number(csvCollapseThreshold)
+    if (isNaN(threshold) || threshold < 0) {
+      res.status(400).json({ message: 'csvCollapseThreshold must be a non-negative number' })
+      return
+    }
+
+    await userService.updateCsvCollapseThreshold(session.userId, threshold)
+    res.status(200).json({ success: true })
+  } else {
+    res.status(RESPONSE_MESSAGES.METHOD_NOT_ALLOWED_405.statusCode)
+      .json(RESPONSE_MESSAGES.METHOD_NOT_ALLOWED_405)
+  }
+}

--- a/prisma-local/migrations/20260317024924_csv_collapse_threshold/migration.sql
+++ b/prisma-local/migrations/20260317024924_csv_collapse_threshold/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `UserProfile` ADD COLUMN `csvCollapseThreshold` INTEGER NOT NULL DEFAULT 1;

--- a/prisma-local/schema.prisma
+++ b/prisma-local/schema.prisma
@@ -189,6 +189,7 @@ model UserProfile {
   invoices Invoice[]
   preferredCurrencyId Int @default(1)
   preferredTimezone String    @db.VarChar(255)@default("")
+  csvCollapseThreshold Int @default(1)
   proUntil DateTime?
   paybuttons   Paybutton[]
 

--- a/prisma-local/schema.prisma
+++ b/prisma-local/schema.prisma
@@ -190,6 +190,7 @@ model UserProfile {
   preferredCurrencyId Int @default(1)
   preferredTimezone String    @db.VarChar(255)@default("")
   csvRowCollapsing Boolean @default(true)
+  csvCollapseThreshold Int @default(1)
   proUntil DateTime?
   paybuttons   Paybutton[]
 

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -156,6 +156,15 @@ export async function updatePreferredTimezone (id: string, preferredTimezone: st
   })
 }
 
+export async function updateCsvCollapseThreshold (id: string, csvCollapseThreshold: number): Promise<void> {
+  await prisma.userProfile.update({
+    where: { id },
+    data: {
+      csvCollapseThreshold
+    }
+  })
+}
+
 export async function userRemainingProTime (id: string): Promise<number | null> {
   const today = new Date()
   const proUntil = (await prisma.userProfile.findUniqueOrThrow({

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -165,6 +165,15 @@ export async function updateCsvRowCollapsing (id: string, csvRowCollapsing: bool
   })
 }
 
+export async function updateCsvCollapseThreshold (id: string, csvCollapseThreshold: number): Promise<void> {
+  await prisma.userProfile.update({
+    where: { id },
+    data: {
+      csvCollapseThreshold
+    }
+  })
+}
+
 export async function userRemainingProTime (id: string): Promise<number | null> {
   const today = new Date()
   const proUntil = (await prisma.userProfile.findUniqueOrThrow({

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -528,7 +528,8 @@ export const mockedUserProfile: UserProfile = {
   preferredTimezone: '',
   emailCredits: 15,
   postCredits: 15,
-  proUntil: null
+  proUntil: null,
+  csvCollapseThreshold: 0
 }
 
 export const mockedUserProfileWithPublicKey: UserProfile = {
@@ -543,7 +544,8 @@ export const mockedUserProfileWithPublicKey: UserProfile = {
   preferredTimezone: '',
   emailCredits: 15,
   postCredits: 15,
-  proUntil: null
+  proUntil: null,
+  csvCollapseThreshold: 0
 }
 
 export const mockedAddressesOnButtons: AddressesOnButtons[] = [

--- a/tests/mockedObjects.ts
+++ b/tests/mockedObjects.ts
@@ -529,7 +529,8 @@ export const mockedUserProfile: UserProfile = {
   emailCredits: 15,
   postCredits: 15,
   proUntil: null,
-  csvRowCollapsing: false
+  csvRowCollapsing: false,
+  csvCollapseThreshold: 0
 }
 
 export const mockedUserProfileWithPublicKey: UserProfile = {
@@ -545,7 +546,8 @@ export const mockedUserProfileWithPublicKey: UserProfile = {
   emailCredits: 15,
   postCredits: 15,
   proUntil: null,
-  csvRowCollapsing: false
+  csvRowCollapsing: false,
+  csvCollapseThreshold: 0
 }
 
 export const mockedAddressesOnButtons: AddressesOnButtons[] = [


### PR DESCRIPTION
Related to #953 

<!--
Depends on
---
- [ ] #
-->

<!-- Non-technical -->
Description
---
Allow users to adjust the CSV collapse threshold directly from account settings.

- Added a `csvCollapseThreshold` parameter to the `UserProfile`

- Added an input field in account settings to configure `csvCollapseThreshold`

- Updated CSV generation logic to use the `csvCollapseThreshold` value from `UserProfile`

Test plan
---

1. Go to Payments and generate a CSV file
2. Navigate to Account Settings and update the CSV Collapse Threshold value
3. Return to Payments and generate a new CSV 
4. Verify that the collapsing behavior reflects the updated threshold value

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **CSV Collapse Threshold** setting to the Account page, letting you control how transaction CSVs are collapsed during download.
* **Improvements**
  * Added input validation with success/error feedback when saving the threshold, including quick UI updates.
* **UI Updates**
  * Added dedicated styling for the new threshold control, with dark-theme support.
* **Maintenance**
  * Added backend support and persistence for the setting, and updated related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->