### PR TITLE
Make the paybutton server run on ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  --platform=linux/amd64 node:lts-alpine
+FROM node:lts-alpine
 RUN apk add --no-cache python3 make g++  bash openssl
 SHELL ["/bin/bash", "-c"]
 USER node


### PR DESCRIPTION
There is no point hardcoding the platform, it only prevents the app from working on ARM64 which is not desirable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container base image to use the default Node LTS Alpine image instead of a platform-pinned variant.
  * Simplified the build setup with no other configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->